### PR TITLE
Array tuple set syntax

### DIFF
--- a/rel/expr_tuple.go
+++ b/rel/expr_tuple.go
@@ -121,7 +121,7 @@ func (e *TupleExpr) Attrs() []AttrExpr {
 // String returns a string representation of the expression.
 func (e *TupleExpr) String() string {
 	var b bytes.Buffer
-	b.WriteByte('{')
+	b.WriteByte('(')
 	for i, attr := range e.attrs {
 		if i > 0 {
 			b.WriteString(", ")
@@ -137,7 +137,7 @@ func (e *TupleExpr) String() string {
 			b.WriteString(attr.expr.String())
 		}
 	}
-	b.WriteByte('}')
+	b.WriteByte(')')
 	return b.String()
 }
 

--- a/rel/set_test.go
+++ b/rel/set_test.go
@@ -168,10 +168,10 @@ func TestSetString(t *testing.T) {
 		}
 	}
 	scenario(`none`)
-	scenario(`{|42|}`, 42)
-	scenario(`{|5432|}`, 5432)
-	scenario(`{|321, 4321|}`, 4321, 321)
-	scenario(`{|321, 4321|}`, 321, 4321)
+	scenario(`{42}`, 42)
+	scenario(`{5432}`, 5432)
+	scenario(`{321, 4321}`, 4321, 321)
+	scenario(`{321, 4321}`, 321, 4321)
 }
 
 func TestSetCount(t *testing.T) {

--- a/rel/tuple_test.go
+++ b/rel/tuple_test.go
@@ -165,16 +165,15 @@ func TestTupleString(t *testing.T) {
 			assert.Equal(t, repr, tuple.String(), "%v", tuple)
 		}
 	}
-	scenario("{}")
-	scenario("{a: 42}", Attr{"a", NewNumber(42)})
-	scenario("{a: 42}", Attr{"a", NewNumber(42)})
-	scenario("{b: 42}", Attr{"b", NewNumber(42)})
-	scenario("{a: 5432}", Attr{"a", NewNumber(5432)})
-	scenario("{a: 4321, b: 321}",
+	scenario("()")
+	scenario("(a: 42)", Attr{"a", NewNumber(42)})
+	scenario("(b: 42)", Attr{"b", NewNumber(42)})
+	scenario("(a: 5432)", Attr{"a", NewNumber(5432)})
+	scenario("(a: 4321, b: 321)",
 		Attr{"a", NewNumber(4321)},
 		Attr{"b", NewNumber(321)},
 	)
-	scenario("{a: 4321, b: 321}",
+	scenario("(a: 4321, b: 321)",
 		Attr{"b", NewNumber(321)},
 		Attr{"a", NewNumber(4321)},
 	)

--- a/rel/value_set.go
+++ b/rel/value_set.go
@@ -117,14 +117,14 @@ func (s *genericSet) String() string {
 		}
 
 		var buf bytes.Buffer
-		buf.WriteString("{|")
+		buf.WriteString("{")
 		for i, value := range s.OrderedValues() {
 			if i != 0 {
 				buf.WriteString(", ")
 			}
 			buf.WriteString(value.String())
 		}
-		buf.WriteString("|}")
+		buf.WriteString("}")
 		return buf.String()
 
 	case setFlavorArray:

--- a/rel/value_tuple.go
+++ b/rel/value_tuple.go
@@ -127,7 +127,7 @@ var identRE = regexp.MustCompile(`\A` + LexerNamePat + `\z`)
 // String returns a string representation of a Tuple.
 func (t *GenericTuple) String() string {
 	var buf bytes.Buffer
-	buf.WriteRune('{')
+	buf.WriteRune('(')
 	for i, name := range tupleOrderedNames(t) {
 		if i != 0 {
 			buf.WriteString(", ")
@@ -149,7 +149,7 @@ func (t *GenericTuple) String() string {
 		}
 		buf.WriteString(value.String())
 	}
-	buf.WriteRune('}')
+	buf.WriteRune(')')
 	return buf.String()
 }
 

--- a/syntax/lex.go
+++ b/syntax/lex.go
@@ -187,12 +187,12 @@ func NewLexerWithPrefix(prefix *bytes.Buffer, reader io.Reader) *Lexer {
 
 func (l *Lexer) copy() *Lexer {
 	// Copy most fields
-	new := *l
+	newL := *l
 
 	if l.stack != nil {
-		new.stack = append([]lexerState{}, l.stack...)
+		newL.stack = append([]lexerState{}, l.stack...)
 	}
-	new.buffer = bytes.NewBuffer(l.buffer.Bytes())
+	newL.buffer = bytes.NewBuffer(l.buffer.Bytes())
 
 	// We need to duplicate the reader since reading from it is destructive
 	remBuf, err := ioutil.ReadAll(l.reader)
@@ -200,8 +200,8 @@ func (l *Lexer) copy() *Lexer {
 		panic(err)
 	}
 	l.reader = bytes.NewBuffer(remBuf)
-	new.reader = bytes.NewBuffer(remBuf)
-	return &new
+	newL.reader = bytes.NewBuffer(remBuf)
+	return &newL
 }
 
 // Reader returns the most recently recognized token.

--- a/syntax/lex.go
+++ b/syntax/lex.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"regexp"
 	"strconv"
 
@@ -164,7 +165,7 @@ type Lexer struct {
 	fresh  bool
 }
 
-// NewLexer returns a new Lexer for the given input.
+// NewStringLexer returns a new Lexer for the given input.
 func NewStringLexer(input string) *Lexer {
 	return NewLexer(bytes.NewBufferString(input))
 }
@@ -182,6 +183,25 @@ func NewLexerWithPrefix(prefix *bytes.Buffer, reader io.Reader) *Lexer {
 		state:  LexerInitState,
 		fr:     FileRange{FilePos{1, 1}, FilePos{1, 1}},
 	}
+}
+
+func (l *Lexer) copy() *Lexer {
+	// Copy most fields
+	new := *l
+
+	if l.stack != nil {
+		new.stack = append([]lexerState{}, l.stack...)
+	}
+	new.buffer = bytes.NewBuffer(l.buffer.Bytes())
+
+	// We need to duplicate the reader since reading from it is destructive
+	remBuf, err := ioutil.ReadAll(l.reader)
+	if err != nil {
+		panic(err)
+	}
+	l.reader = bytes.NewBuffer(remBuf)
+	new.reader = bytes.NewBuffer(remBuf)
+	return &new
 }
 
 // Reader returns the most recently recognized token.

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -399,15 +399,7 @@ func ParseAtom(l *Lexer) (rel.Expr, error) {
 		return rel.NewString([]rune(ParseArraiString(l.Lexeme()))), nil
 
 	case Token('('):
-		l.Scan()
-		expr, err := parseExpr(l)
-		if err != nil {
-			return nil, err
-		}
-		if !l.Scan(Token(')')) {
-			return nil, expecting(l, "after expr", "')'")
-		}
-		return expr, nil
+		return parseTuple(l)
 
 	case Token('<'):
 		return parseXML(l, newXMLContext())
@@ -445,89 +437,10 @@ func ParseAtom(l *Lexer) (rel.Expr, error) {
 		return rel.NewFunction(arg, body), nil
 
 	case Token('{'):
-		l.Scan()
-		attrs := []rel.AttrExpr{}
-	tokenLoop:
-		for {
-			var name string
-			switch l.Peek() {
-			case STRING:
-				l.Scan()
-				name = ParseArraiString(l.Lexeme())
-			case IDENT:
-				l.Scan()
-				name = string(l.Lexeme())
-			case Token('}'):
-				break tokenLoop
-			case Token('&'):
-				l.Scan()
-				if !l.Scan(IDENT) {
-					return nil, expecting(l, "after '&'-prefix", "ident")
-				}
-				name = "&" + string(l.Lexeme())
-			}
-			expr, err := parseAttrExpr(l, name)
-			if err != nil {
-				return nil, err
-			}
-			attr, err := rel.NewAttrExpr(name, expr)
-			if err != nil {
-				return nil, err
-			}
-			attrs = append(attrs, attr)
-			if !l.Scan(',') {
-				break
-			}
-		}
+		return parseSetOrRel(l)
 
-		if !l.Scan('}') {
-			return nil, expecting(l, "after tuple body", "'}'")
-		}
-		return rel.NewTupleExpr(attrs...), nil
-
-	case OSET, Token('['):
-		l.Scan()
-
-		var closer Token
-		if tok == OSET {
-			closer = CSET
-		} else {
-			closer = Token(']')
-		}
-
-		if closer == CSET {
-			names, err := parseNameList(l)
-			if err != nil {
-				return nil, err
-			}
-			if names != nil {
-				tuples := [][]rel.Expr{}
-				for l.Scan(Token('{')) {
-					exprs, err := parseExprCommaList(
-						l, Token('}'), "'}'", "after relation body")
-					if err != nil {
-						return nil, err
-					}
-					tuples = append(tuples, exprs)
-					if !l.Scan(Token(',')) {
-						break
-					}
-				}
-				if !l.Scan(CSET) {
-					return nil, expecting(l, "after set tuple", "'|}'")
-				}
-				return rel.NewRelationExpr(names, tuples...)
-			}
-		}
-
-		elts, err := parseExprCommaList(l, closer, "'|}'", "after set body")
-		if err != nil {
-			return nil, err
-		}
-		if closer == CSET {
-			return rel.NewSetExpr(elts...), nil
-		}
-		return rel.NewArrayExpr(elts...), nil
+	case Token('['):
+		return parseArray(l)
 
 	case ERROR:
 		l.Failf("syntax error")
@@ -536,6 +449,90 @@ func ParseAtom(l *Lexer) (rel.Expr, error) {
 	default:
 		return nil, noParse
 	}
+}
+
+func parseTuple(l *Lexer) (rel.Expr, error) {
+	if !l.Scan(Token('(')) {
+		return nil, expecting(l, "tuple start", "'('")
+	}
+	attrs := []rel.AttrExpr{}
+tupleLoop:
+	for {
+		var name string
+		switch l.Peek() {
+		case Token(')'):
+			break tupleLoop
+		case STRING:
+			l.Scan()
+			name = ParseArraiString(l.Lexeme())
+		case IDENT:
+			l.Scan()
+			name = string(l.Lexeme())
+		case Token('&'):
+			l.Scan()
+			if !l.Scan(IDENT) {
+				return nil, expecting(l, "after '&'-prefix", "ident")
+			}
+			name = "&" + string(l.Lexeme())
+		}
+		expr, err := parseAttrExpr(l, name)
+		if err != nil {
+			return nil, err
+		}
+		attr, err := rel.NewAttrExpr(name, expr)
+		if err != nil {
+			return nil, err
+		}
+		attrs = append(attrs, attr)
+		if !l.Scan(Token(',')) {
+			break
+		}
+	}
+	if !l.Scan(Token(')')) {
+		return nil, expecting(l, "after tuple body", "')'")
+	}
+	return rel.NewTupleExpr(attrs...), nil
+}
+
+func parseSetOrRel(l *Lexer) (rel.Expr, error) {
+	if !l.Scan(Token('{')) {
+		return nil, expecting(l, "set beginning", "'{'")
+	}
+	names, err := parseNameList(l)
+	if err != nil {
+		return nil, err
+	}
+	if names != nil {
+		tuples := [][]rel.Expr{}
+		for l.Scan(Token('(')) {
+			exprs, err := parseExprCommaList(l, Token(')'), "')'", "after relation body")
+			if err != nil {
+				return nil, err
+			}
+			tuples = append(tuples, exprs)
+			if !l.Scan(Token(',')) {
+				break
+			}
+		}
+		if !l.Scan(Token('}')) {
+			return nil, expecting(l, "after set tuple", "'}'")
+		}
+		return rel.NewRelationExpr(names, tuples...)
+	}
+	elts, err := parseExprCommaList(l, Token('}'), "'}'", "after set body")
+	if err != nil {
+		return nil, err
+	}
+	return rel.NewSetExpr(elts...), nil
+}
+
+func parseArray(l *Lexer) (rel.Expr, error) {
+	l.Scan()
+	elts, err := parseExprCommaList(l, Token(']'), "']'", "after array body")
+	if err != nil {
+		return nil, err
+	}
+	return rel.NewArrayExpr(elts...), nil
 }
 
 func parseAttrExpr(l *Lexer, name string) (rel.Expr, error) {
@@ -568,7 +565,7 @@ func parseNameList(l *Lexer) ([]string, error) {
 	if !l.Scan(Token('|')) {
 		return nil, nil
 	}
-	// relation shorthand, e.g.: {| |a,b| {1,2}, {3,4} |}
+	// relation shorthand, e.g.: { |a,b| (1,2), (3,4) }
 	names := []string{}
 	for l.Scan(IDENT) {
 		names = append(names, string(l.Lexeme()))

--- a/tests/expr_binary_test.go
+++ b/tests/expr_binary_test.go
@@ -6,6 +6,6 @@ import (
 
 func TestWhereExpr(t *testing.T) {
 	t.Parallel()
-	s := `{||a,b| {3,41}, {2,42}, {1,43}|}`
-	AssertCodesEvalToSameValue(t, `{|{a:3,b:41}|}`, s+` where .a=3`)
+	s := `{ |a,b| (3,41), (2,42), (1,43) }`
+	AssertCodesEvalToSameValue(t, `{(a:3,b:41)}`, s+` where .a=3`)
 }

--- a/tests/expr_reduce_test.go
+++ b/tests/expr_reduce_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 )
 
-var s = `{||a,b| {3,41}, {2,42}, {1,43}|}`
-var u = `{||a,b| {3,41}, {2,42}, {1,43}, {0, 46}|}`
+var s = `{ |a,b| (3,41), (2,42), (1,43)}`
+var u = `{ |a,b| (3,41), (2,42), (1,43), (0, 46)}`
 
 func TestSumExpr(t *testing.T) {
 	t.Parallel()

--- a/tests/expr_unary_test.go
+++ b/tests/expr_unary_test.go
@@ -6,15 +6,15 @@ import (
 
 func TestCountExpr(t *testing.T) {
 	t.Parallel()
-	AssertCodesEvalToSameValue(t, `3`, `{|41, 42, 43|} count`)
+	AssertCodesEvalToSameValue(t, `3`, `{41, 42, 43} count`)
 }
 
 func TestPowerSet(t *testing.T) {
 	t.Parallel()
-	AssertCodesEvalToSameValue(t, `{|none|}`, `^{||}`)
-	AssertCodesEvalToSameValue(t, `{|{||}, {|1|}|}`, `^{|1|}`)
-	AssertCodesEvalToSameValue(t, `{|{||}, {|1|}, {|2|}, {|1, 2|}|}`, `^{|1, 2|}`)
+	AssertCodesEvalToSameValue(t, `{none}`, `^{}`)
+	AssertCodesEvalToSameValue(t, `{{}, {1}}`, `^{1}`)
+	AssertCodesEvalToSameValue(t, `{{}, {1}, {2}, {1, 2}}`, `^{1, 2}`)
 	AssertCodesEvalToSameValue(t,
-		`{|{||}, {|1|}, {|2|}, {|1, 2|}, {|3|}, {|1, 3|}, {|2, 3|}, {|1, 2, 3|}|}`,
-		`^{|1, 2, 3|}`)
+		`{{}, {1}, {2}, {1, 2}, {3}, {1, 3}, {2, 3}, {1, 2, 3}}`,
+		`^{1, 2, 3}`)
 }

--- a/tests/parse_expr_test.go
+++ b/tests/parse_expr_test.go
@@ -10,29 +10,30 @@ func TestParseIfElseExpr(t *testing.T) {
 
 func TestParseTupleShorthand(t *testing.T) {
 	t.Parallel()
-	AssertCodesEvalToSameValue(t, `{a:42}`, `(\a{a:a})42`)
+	// TODO: Fix
+	// AssertCodesEvalToSameValue(t, `(a:42)`, `(\a(a:a))42`)
 	// TODO: Fix
 	// AssertCodesEvalToSameValue(t, `{a:42}`, `(\a{a})42`)
 }
 
 func TestParseArrowStarExprAssignExisting(t *testing.T) {
 	t.Parallel()
-	AssertCodesEvalToSameValue(t, `{a:42}`, `{a:41}->*a: 42`)
-	AssertCodesEvalToSameValue(t, `{a:{b:42}}`, `{a:{b:41}}->*a->*b: 42`)
+	AssertCodesEvalToSameValue(t, `(a:42)`, `(a:41)->*a: 42`)
+	AssertCodesEvalToSameValue(t, `(a:(b:42))`, `(a:(b:41))->*a->*b: 42`)
 	AssertCodesEvalToSameValue(t,
-		`{a:{b:{c:42}}}`,
-		`{a:{b:{c:41}}}->*a->*b->*c: 42`)
+		`(a:(b:(c:42)))`,
+		`(a:(b:(c:41)))->*a->*b->*c: 42`)
 }
 
 func TestParseArrowStarExprAssignNew(t *testing.T) {
 	t.Parallel()
-	AssertCodesEvalToSameValue(t, `{a:41,b:42}`, `{a:41}->*b: 42`)
+	AssertCodesEvalToSameValue(t, `(a:41,b:42)`, `(a:41)->*b: 42`)
 	AssertCodesEvalToSameValue(t,
-		`{a:{b:41, c:42}}`,
-		`{a:{b:41}}->*a->*c: 42`)
+		`(a:(b:41, c:42))`,
+		`(a:(b:41))->*a->*c: 42`)
 	AssertCodesEvalToSameValue(t,
-		`{a:{b:{c:41,d:42}}}`,
-		`{a:{b:{c:41}}}->*a->*b->*d: 42`)
+		`(a:(b:(c:41,d:42)))`,
+		`(a:(b:(c:41)))->*a->*b->*d: 42`)
 }
 
 func TestParseArrowStarExprAlterExisting(t *testing.T) {

--- a/tests/parse_expr_test.go
+++ b/tests/parse_expr_test.go
@@ -10,8 +10,7 @@ func TestParseIfElseExpr(t *testing.T) {
 
 func TestParseTupleShorthand(t *testing.T) {
 	t.Parallel()
-	// TODO: Fix
-	// AssertCodesEvalToSameValue(t, `(a:42)`, `(\a(a:a))42`)
+	AssertCodesEvalToSameValue(t, `(a:42)`, `(\a(a:a))42`)
 	// TODO: Fix
 	// AssertCodesEvalToSameValue(t, `{a:42}`, `(\a{a})42`)
 }

--- a/tests/parse_value_test.go
+++ b/tests/parse_value_test.go
@@ -31,31 +31,31 @@ func TestParseNumber(t *testing.T) {
 
 func TestParseTuple(t *testing.T) {
 	t.Parallel()
-	assertParse(t, rel.EmptyTuple, `{}`)
+	assertParse(t, rel.EmptyTuple, `()`)
 	assertParse(t,
 		rel.NewTuple(rel.Attr{Name: "a", Value: rel.NewNumber(1)}),
-		`{"a":1}`)
+		`("a":1)`)
 	assertParse(t, rel.NewTuple(
 		rel.Attr{Name: "a", Value: rel.NewNumber(1)},
 		rel.Attr{Name: "b", Value: rel.NewNumber(2)},
-	), `{"a":1, "b": 2}`)
+	), `("a":1, "b": 2)`)
 	assertParse(t, rel.NewTuple(
 		rel.Attr{Name: "a", Value: rel.NewNumber(1)},
 		rel.Attr{Name: "b", Value: rel.NewNumber(2)},
-	), `{a :1, b : 2}`)
+	), `(a :1, b : 2)`)
 }
 
 func TestParseSet(t *testing.T) {
 	t.Parallel()
-	assertParse(t, rel.NewSet(), `{||}`)
+	assertParse(t, rel.NewSet(), `{}`)
 	assertParse(t, rel.NewSet(), `false`)
-	assertParse(t, rel.NewSet(rel.NewNumber(1)), `{|1|}`)
-	assertParse(t, rel.NewSet(rel.NewNumber(1), rel.NewNumber(2)), `{|1,2|}`)
+	assertParse(t, rel.NewSet(rel.NewNumber(1)), `{1}`)
+	assertParse(t, rel.NewSet(rel.NewNumber(1), rel.NewNumber(2)), `{1,2}`)
 	assertParse(t, rel.NewSet(
 		rel.NewNumber(1),
 		rel.NewSet(rel.NewNumber(3), rel.NewNumber(4)),
 		rel.NewNumber(2),
-	), `{|1, {|3, 4|}, 2|}`)
+	), `{1, {3, 4}, 2}`)
 }
 
 func TestParseMixed(t *testing.T) {
@@ -67,11 +67,19 @@ func TestParseMixed(t *testing.T) {
 			rel.NewNumber(4),
 		)},
 		rel.Attr{Name: "c", Value: rel.NewNumber(2)},
-	), `{a:1, b:{|{d:3}, 4,|}, c:2,}`)
+	), `(a:1, b:{(d:3), 4,}, c:2,)`)
 }
 
 func TestParseRelationShortcut(t *testing.T) {
 	t.Parallel()
-	value, err := syntax.Parse(syntax.NewStringLexer(`{|<a,b> {1, 2}, {3, 4}|}`))
-	assert.Error(t, err, "%s", value)
+	assertParse(t, rel.NewSet(
+		rel.NewTuple(
+			rel.Attr{Name: "a", Value: rel.NewNumber(1)},
+			rel.Attr{Name: "b", Value: rel.NewNumber(2)},
+		),
+		rel.NewTuple(
+			rel.Attr{Name: "a", Value: rel.NewNumber(3)},
+			rel.Attr{Name: "b", Value: rel.NewNumber(4)},
+		),
+	), `{ |a,b| (1, 2), (3, 4) }`)
 }


### PR DESCRIPTION
This PR changes the syntax for tuples and sets. These collection types now conforms to the intended spec.

* Sets: `{}`
* Tuples: `()`
* Arrays: `[]`

Use of `()` for tuples now clashes with the classical use of parens to wrap expressions. This PR includes a hack workaround to continue supporting `(<expr>)`.

Includes:
* Syntax parse changes
* `String()` methods for output
* Hopefully does not break `(<expr>)`.
* Updated tests related to the syntax changes and `String()` methods.

No new tests have been added