### PR TITLE
Json translator

### DIFF
--- a/cmd/arrai/json.go
+++ b/cmd/arrai/json.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/arr-ai/arrai/rel"
+	"github.com/arr-ai/arrai/translate"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -28,52 +28,10 @@ func fromJSON(cli *cli.Context) error {
 	if err := json.Unmarshal(raw, &data); err != nil {
 		return err
 	}
-	val, err := jsonToArrai(data)
+	val, err := translate.JSONToArrai(data)
 	if err != nil {
 		logrus.Fatal(err)
 	}
 	fmt.Println(val)
 	return nil
-}
-
-func jsonToArrai(data interface{}) (rel.Value, error) {
-	switch v := data.(type) {
-	case map[string]interface{}:
-		return jsonObjToArrai(v)
-	case []interface{}:
-		return jsonArrToArrai(v)
-	case string: // rel.NewValue cannot produce strings
-		return rel.NewString([]rune(v)), nil
-	default:
-		return rel.NewValue(v)
-	}
-}
-
-func jsonObjToArrai(data map[string]interface{}) (rel.Value, error) {
-	tuples := make([]rel.Value, len(data))
-	i := 0
-	for key, val := range data {
-		item, err := jsonToArrai(val)
-		if err != nil {
-			return nil, err
-		}
-		tuples[i] = rel.NewTuple(
-			rel.Attr{"@", rel.NewString([]rune(key))},
-			rel.Attr{"@item", item},
-		)
-		i++
-	}
-	return rel.NewSet(tuples...), nil
-}
-
-func jsonArrToArrai(data []interface{}) (rel.Value, error) {
-	elts := make([]rel.Value, len(data))
-	for i, val := range data {
-		elt, err := jsonToArrai(val)
-		if err != nil {
-			return nil, err
-		}
-		elts[i] = elt
-	}
-	return rel.NewArray(elts...), nil
 }

--- a/cmd/arrai/json.go
+++ b/cmd/arrai/json.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/arr-ai/arrai/rel"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+var jsonCommand = cli.Command{
+	Name:      "json",
+	Aliases:   []string{"jx"},
+	Usage:     "Convert json to arrai",
+	UsageText: "Takes json as input from stdin, prints equivalent arrai to stdout",
+	Action:    fromJSON,
+}
+
+func fromJSON(cli *cli.Context) error {
+	raw, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return err
+	}
+	var data interface{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return err
+	}
+	val, err := jsonToArrai(data)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	fmt.Println(val)
+	return nil
+}
+
+func jsonToArrai(data interface{}) (rel.Value, error) {
+	switch v := data.(type) {
+	case map[string]interface{}:
+		return jsonObjToArrai(v)
+	case []interface{}:
+		return jsonArrToArrai(v)
+	case string: // rel.NewValue cannot produce strings
+		return rel.NewString([]rune(v)), nil
+	default:
+		return rel.NewValue(v)
+	}
+}
+
+func jsonObjToArrai(data map[string]interface{}) (rel.Value, error) {
+	tuples := make([]rel.Value, len(data))
+	i := 0
+	for key, val := range data {
+		item, err := jsonToArrai(val)
+		if err != nil {
+			return nil, err
+		}
+		tuples[i] = rel.NewTuple(
+			rel.Attr{"@", rel.NewString([]rune(key))},
+			rel.Attr{"@item", item},
+		)
+		i++
+	}
+	return rel.NewSet(tuples...), nil
+}
+
+func jsonArrToArrai(data []interface{}) (rel.Value, error) {
+	elts := make([]rel.Value, len(data))
+	for i, val := range data {
+		elt, err := jsonToArrai(val)
+		if err != nil {
+			return nil, err
+		}
+		elts[i] = elt
+	}
+	return rel.NewArray(elts...), nil
+}

--- a/cmd/arrai/main.go
+++ b/cmd/arrai/main.go
@@ -23,12 +23,13 @@ func main() {
 		app.Usage = "the ultimate data engine"
 
 		app.Commands = []cli.Command{
-			transformCommand,
 			evalCommand,
-			serveCommand,
+			jsonCommand,
 			observeCommand,
-			updateCommand,
+			serveCommand,
 			syncCommand,
+			transformCommand,
+			updateCommand,
 		}
 	}
 

--- a/translate/json.go
+++ b/translate/json.go
@@ -1,0 +1,59 @@
+package translate
+
+import "github.com/arr-ai/arrai/rel"
+
+// JSONToArrai translates an object unmarshalled from json into an array value
+//
+// translation follows the rules
+//
+//     object -> {|@,@item|, |key,val|, ...}
+//     array  -> array
+//     null   -> none
+//     other  -> value (bools, numerics, strings)
+func JSONToArrai(data interface{}) (rel.Value, error) {
+	switch v := data.(type) {
+	case map[string]interface{}:
+		return jsonObjToArrai(v)
+	case []interface{}:
+		return jsonArrToArrai(v)
+	case string: // rel.NewValue cannot produce strings
+		return rel.NewString([]rune(v)), nil
+	case nil:
+		return rel.None, nil
+	default:
+		return rel.NewValue(v)
+	}
+}
+
+// Converts a json object to a binary relation {|@,@item|, |key,val|, ...}
+func jsonObjToArrai(data map[string]interface{}) (rel.Value, error) {
+	tuples := make([]rel.Value, len(data))
+	i := 0
+	for key, val := range data {
+		// Recursively apply ToArrai to all values
+		item, err := JSONToArrai(val)
+		if err != nil {
+			return nil, err
+		}
+		tuples[i] = rel.NewTuple(
+			rel.Attr{"@", rel.NewString([]rune(key))},
+			rel.Attr{"@item", item},
+		)
+		i++
+	}
+	return rel.NewSet(tuples...), nil
+}
+
+// Converts a json array to an arrai array
+func jsonArrToArrai(data []interface{}) (rel.Value, error) {
+	elts := make([]rel.Value, len(data))
+	for i, val := range data {
+		// Recursively apply ToArrai to all elements
+		elt, err := JSONToArrai(val)
+		if err != nil {
+			return nil, err
+		}
+		elts[i] = elt
+	}
+	return rel.NewArray(elts...), nil
+}

--- a/translate/json_test.go
+++ b/translate/json_test.go
@@ -1,0 +1,84 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/arr-ai/arrai/rel"
+	"github.com/arr-ai/arrai/syntax"
+	"github.com/arr-ai/arrai/translate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AssertExpectedTranslation asserts that the translated value is the same as the expected string
+func AssertExpectedTranslation(t *testing.T, expected string, value rel.Value) bool {
+	expectedExpr, err := syntax.Parse(syntax.NewStringLexer(expected))
+	if !assert.NoError(t, err, "parsing expected: %s", expected) {
+		return false
+	}
+	if !rel.AssertExprsEvalToSameValue(t, expectedExpr, value) {
+		return assert.Fail(
+			t, "Input should translate to same value", "%s == %s", expected, value)
+	}
+	return true
+}
+
+func AssertExpectedJSONTranslation(t *testing.T, expected, rawJSON string) {
+	var data interface{}
+	require.NoError(t, json.Unmarshal([]byte(rawJSON), &data))
+	trans, err := translate.JSONToArrai(data)
+	require.NoError(t, err)
+	AssertExpectedTranslation(t, expected, trans)
+}
+
+func TestJSONObjectToArrai(t *testing.T) {
+	t.Parallel()
+
+	// Empty
+	AssertExpectedJSONTranslation(t, `{}`, `{}`)
+
+	// different value types
+	AssertExpectedJSONTranslation(t, `{ |@,@item| ("key","val")}`, `{"key":"val"}`)
+	AssertExpectedJSONTranslation(t, `{ |@,@item| ("key",123)}`, `{"key":123}`)
+	AssertExpectedJSONTranslation(t, `{ |@,@item| ("key",{ |@,@item| ("foo","bar")})}`, `{"key":{"foo":"bar"}}`)
+	AssertExpectedJSONTranslation(t, `{ |@,@item| ("key",[1, 2, 3])}`, `{"key":[1, 2, 3]}`)
+	AssertExpectedJSONTranslation(t, `{ |@,@item| ("key",none)}`, `{"key":null}`)
+
+	// Multiple key-val pairs
+	AssertExpectedJSONTranslation(t, `{ |@,@item| ("key","val"), ("foo",123)}`, `{"key":"val", "foo":123}`)
+}
+
+func TestJSONArrayToArrai(t *testing.T) {
+	t.Parallel()
+
+	// Empty
+	AssertExpectedJSONTranslation(t, `[]`, `[]`)
+
+	// Different value types
+	AssertExpectedJSONTranslation(t, `[1]`, `[1]`)
+	AssertExpectedJSONTranslation(t, `["hello"]`, `["hello"]`)
+	AssertExpectedJSONTranslation(t, `[{ |@,@item| ("foo","bar")}]`, `[{"foo":"bar"}]`)
+	AssertExpectedJSONTranslation(t, `[[1, 2, 3]]`, `[[1, 2, 3]]`)
+	AssertExpectedJSONTranslation(t, `[none]`, `[null]`)
+
+	// Multiple values with different types
+	AssertExpectedJSONTranslation(t, `[1, "Hello", none]`, `[1, "Hello", null]`)
+}
+
+func TestJSONNullToNone(t *testing.T) {
+	t.Parallel()
+	AssertExpectedJSONTranslation(t, `none`, `null`)
+}
+
+func TestJSONStringToArrai(t *testing.T) {
+	t.Parallel()
+	AssertExpectedJSONTranslation(t, `""`, `""`)
+	AssertExpectedJSONTranslation(t, `"Hello World"`, `"Hello World"`)
+}
+
+func TestJSONNumericToArrai(t *testing.T) {
+	t.Parallel()
+	AssertExpectedJSONTranslation(t, `123`, `123`)
+	AssertExpectedJSONTranslation(t, `1.23`, `1.23`)
+}


### PR DESCRIPTION
This PR adds a json translation command to arrai.

Usage:
```bash
# json subcommand reads from stdin
$ echo '<json blob>' | arrai json
```

This functionality is also available in code through the `translate` package

```go
val, err := translate.JSONToArrai(data interface{})
```

Assumes raw json has already been marshalled into an interface. Will error out if `data` is a strongly typed struct (or anything that doesn't come out of `json.Unmarshal()` on a blank interface variable)
