### PR TITLE
Add wasm workflow

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -27,6 +27,7 @@ jobs:
       run: GOOS=js GOARCH=wasm go build -o arrai.wasm ./cmd/arrai
 
     - name: get wasm_exec.js
+      # Get the tagged version of wasm_exec.js from the github repo for go
       run: curl -O https://raw.githubusercontent.com/golang/go/46f9aea80197bfdf4c024c3f5a71be51a2facf59/misc/wasm/wasm_exec.js
 
     - name: Set up Node
@@ -35,7 +36,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run tests
-      run: node wasm_exec.js arrai.wasm
+      run: node wasm_exec.js arrai.wasm eval 1 + 5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_AUTH_TOKEN: "SOME-RANDOM-KEY"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,41 @@
+name: Go wasm
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  build:
+    name: Build and Test Wasm
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: go get -v -t -d ./...
+
+    - name: Build
+      run: GOOS=js GOARCH=wasm go build -o arrai.wasm ./cmd/arrai
+
+    - name: get wasm_exec.js
+      run: curl -O https://raw.githubusercontent.com/golang/go/46f9aea80197bfdf4c024c3f5a71be51a2facf59/misc/wasm/wasm_exec.js
+
+    - name: Set up Node
+      uses: actions/setup-node@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Run tests
+      run: node wasm_exec.js arrai.wasm
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_AUTH_TOKEN: "SOME-RANDOM-KEY"


### PR DESCRIPTION
Fixes #49

Changes proposed in this pull request:
- Adds `wasm.yml` to github workflows that builds a wasm binary:
`GOOS=js GOARCH=wasm go build -o arrai.wasm ./cmd/arrai`
- Then the binary is executed with node:
 `node wasm_exec.js arrai.wasm`

This is quite preliminary in terms of testing, but any linking errors or compile errors will fail the ci
NOTE:
the line: 
`curl -O https://raw.githubusercontent.com/golang/go/46f9aea80197bfdf4c024c3f5a71be51a2facf59/misc/wasm/wasm_exec.js`
goes and gets the wasm_exec.js from the version of go that is 1.14; (couldn't fun out how to get it from the local go installation)

Checklist:
- [x] Added related tests
- [] Made corresponding changes to the documentation
