### PR TITLE
add basic os and file stdlib

### DIFF
--- a/docs/std-os.md
+++ b/docs/std-os.md
@@ -1,0 +1,23 @@
+# os library
+
+# args
+
+`//.os.args` returns the provided arguments when running an arrai program. It returns an array of strings.
+
+# path_separator
+
+`//.os.path_separator` returns the path separator of the current operating system.
+`/` for UNIX-like machine and `\` for Windows machine. It returns a string.
+
+# path_list_separator
+`//.os.path_list_separator` returns the path list separator of the current operating system.
+`:` for UNIX-like machine and `;` for Windows machine. It returns a string.
+
+# cwd
+`//.os.cwd` returns a string representing the current user directory.
+
+# file
+`//.os.file()` is a function that returns the content of a file represented by a filepath in the form of an array of bytes.
+
+# get_env
+`//.os.get_eng()` is a function that returns the environment variable that corresponds to the provided key in the form of a string.

--- a/syntax/std.go
+++ b/syntax/std.go
@@ -57,6 +57,7 @@ func stdScope() rel.Scope {
 				stdReflect(),
 				stdRel(),
 				stdStr(),
+				stdOs(),
 			))
 	})
 	return stdScopeVar

--- a/syntax/std.go
+++ b/syntax/std.go
@@ -7,9 +7,8 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/arr-ai/wbnf/ast"
-
 	"github.com/arr-ai/arrai/rel"
+	"github.com/arr-ai/wbnf/ast"
 	"github.com/arr-ai/wbnf/parser"
 	"github.com/arr-ai/wbnf/wbnf"
 )

--- a/syntax/std_os.go
+++ b/syntax/std_os.go
@@ -9,8 +9,8 @@ import (
 func stdOs() rel.Attr {
 	return rel.NewAttr("os", rel.NewTuple(
 		rel.NewAttr("args", getArgs()),
-		rel.NewAttr("pathSeparator", pathSeparator()),
-		rel.NewAttr("pathListSeparator", pathListSeparator()),
+		rel.NewAttr("path_separator", pathSeparator()),
+		rel.NewAttr("path_list_separator", pathListSeparator()),
 		rel.NewAttr("cwd", cwd()),
 		rel.NewNativeFunctionAttr("file", func(value rel.Value) rel.Value {
 			f, err := ioutil.ReadFile(value.(rel.String).String())
@@ -19,6 +19,6 @@ func stdOs() rel.Attr {
 			}
 			return rel.NewBytes(f)
 		}),
-		rel.NewNativeFunctionAttr("getenv", getEnv),
+		rel.NewNativeFunctionAttr("get_env", getEnv),
 	))
 }

--- a/syntax/std_os.go
+++ b/syntax/std_os.go
@@ -1,0 +1,24 @@
+package syntax
+
+import (
+	"io/ioutil"
+
+	"github.com/arr-ai/arrai/rel"
+)
+
+func stdOs() rel.Attr {
+	return rel.NewAttr("os", rel.NewTuple(
+		rel.NewAttr("args", getArgs()),
+		rel.NewAttr("pathSeparator", pathSeparator()),
+		rel.NewAttr("pathListSeparator", pathListSeparator()),
+		rel.NewAttr("cwd", cwd()),
+		rel.NewNativeFunctionAttr("file", func(value rel.Value) rel.Value {
+			f, err := ioutil.ReadFile(value.(rel.String).String())
+			if err != nil {
+				panic(err)
+			}
+			return rel.NewBytes(f)
+		}),
+		rel.NewNativeFunctionAttr("getenv", getEnv),
+	))
+}

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -1,0 +1,33 @@
+// +build !wasm
+
+package syntax
+
+import (
+	"os"
+
+	"github.com/arr-ai/arrai/rel"
+)
+
+func getArgs() rel.Value {
+	return strArrToRelArr(os.Args[2:])
+}
+
+func getEnv(value rel.Value) rel.Value {
+	return rel.NewString([]rune(os.Getenv(value.(rel.String).String())))
+}
+
+func pathSeparator() rel.Value {
+	return rel.NewString([]rune{os.PathSeparator})
+}
+
+func pathListSeparator() rel.Value {
+	return rel.NewString([]rune{os.PathListSeparator})
+}
+
+func cwd() rel.Value {
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	return rel.NewString([]rune(wd))
+}

--- a/syntax/std_os_wasm.go
+++ b/syntax/std_os_wasm.go
@@ -1,0 +1,27 @@
+// +build wasm
+
+package syntax
+
+import (
+	"github.com/arr-ai/arrai/rel"
+)
+
+func getArgs() rel.Value {
+	return rel.NewSet()
+}
+
+func getEnv(value rel.Value) rel.Value {
+	return rel.NewSet()
+}
+
+func pathSeparator() rel.Value {
+	return rel.NewSet()
+}
+
+func pathListSeparator() rel.Value {
+	return rel.NewSet()
+}
+
+func cwd() rel.Value {
+	return rel.NewSet()
+}

--- a/syntax/util.go
+++ b/syntax/util.go
@@ -1,0 +1,11 @@
+package syntax
+
+import "github.com/arr-ai/arrai/rel"
+
+func strArrToRelArr(s []string) rel.Value {
+	values := make([]rel.Value, 0, len(s))
+	for _, a := range s {
+		values = append(values, rel.NewString([]rune(a)))
+	}
+	return rel.NewArray(values...)
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Add basic `os` and `file` functions
    - `cwd`
    - `file`
    - `pathSeparator`
    - `pathListSeparator`
    - `args`
    - `getenv`
