### PR TITLE
Rename Value.Bool() to Value.IsTrue().

### DIFF
--- a/rel/expr_binary.go
+++ b/rel/expr_binary.go
@@ -170,7 +170,7 @@ func NewWhereExpr(a, pred Expr) Expr {
 						if err != nil {
 							panic(err)
 						}
-						return match.Bool()
+						return match.IsTrue()
 					}), nil
 				}
 				return nil, errors.Errorf("'where' rhs must be a Fn, not %T", a)
@@ -224,7 +224,7 @@ func NewOrderExpr(a, key Expr) Expr {
 							if err != nil {
 								panic(err)
 							}
-							return result.Bool()
+							return result.IsTrue()
 						})
 					if err != nil {
 						return nil, err

--- a/rel/expr_dot.go
+++ b/rel/expr_dot.go
@@ -60,7 +60,7 @@ func (x *DotExpr) Eval(local Scope) (Value, error) {
 	case Tuple:
 		return get(t)
 	case Set:
-		if !t.Bool() {
+		if !t.IsTrue() {
 			return nil, errors.Errorf("Cannot get attr %q from empty set", x.attr)
 		}
 		e := t.Enumerator()

--- a/rel/expr_if_else.go
+++ b/rel/expr_if_else.go
@@ -40,7 +40,7 @@ func (e *IfElseExpr) Eval(local Scope) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	if cond.Bool() {
+	if cond.IsTrue() {
 		return e.ifTrue.Eval(local)
 	}
 	return e.ifFalse.Eval(local)

--- a/rel/expr_logical.go
+++ b/rel/expr_logical.go
@@ -19,7 +19,7 @@ func (e AndExpr) Eval(local Scope) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !a.Bool() {
+	if !a.IsTrue() {
 		return a, nil
 	}
 
@@ -48,7 +48,7 @@ func (e OrExpr) Eval(local Scope) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	if a.Bool() {
+	if a.IsTrue() {
 		return a, nil
 	}
 

--- a/rel/expr_reduce.go
+++ b/rel/expr_reduce.go
@@ -53,7 +53,7 @@ func NewMaxExpr(a, b Expr) Expr {
 	return NewReduceExpr(
 		a, ExprAsFunction(b), "%s max ???",
 		func(s Set) (interface{}, error) {
-			if s.Bool() {
+			if s.IsTrue() {
 				return nil, nil
 			}
 			return nil, errors.Errorf("Empty set has no max")
@@ -109,7 +109,7 @@ func NewMinExpr(a, b Expr) Expr {
 	return NewReduceExpr(
 		a, ExprAsFunction(b), "%s min ???",
 		func(s Set) (interface{}, error) {
-			if s.Bool() {
+			if s.IsTrue() {
 				return nil, nil
 			}
 			return nil, errors.Errorf("Empty set has no min")

--- a/rel/expr_unary.go
+++ b/rel/expr_unary.go
@@ -49,7 +49,7 @@ func NewPowerSetExpr(a Expr) Expr {
 // NewNotExpr evaluates to !a.
 func NewNotExpr(a Expr) Expr {
 	return newUnaryExpr(a, "!", "(!%s)",
-		func(a Value, _ Scope) (Value, error) { return NewBool(!a.Bool()), nil })
+		func(a Value, _ Scope) (Value, error) { return NewBool(!a.IsTrue()), nil })
 }
 
 // NewEvalExpr evaluates to *a, given a set lhs.

--- a/rel/names.go
+++ b/rel/names.go
@@ -22,7 +22,7 @@ func NewNames(names ...string) Names {
 }
 
 // Bool returns true iff there are names in the set.
-func (n Names) Bool() bool {
+func (n Names) IsTrue() bool {
 	return n.Count() != 0
 }
 

--- a/rel/number_test.go
+++ b/rel/number_test.go
@@ -36,12 +36,12 @@ func TestNumberHash(t *testing.T) {
 
 func TestNumberBool(t *testing.T) {
 	t.Parallel()
-	assert.False(t, NewNumber(0).Bool())
-	assert.False(t, NewNumber(0.0).Bool())
-	assert.False(t, NewNumber(-0.0).Bool())
-	assert.True(t, NewNumber(-1).Bool())
-	assert.True(t, NewNumber(0.5).Bool())
-	assert.True(t, NewNumber(-0.05).Bool())
+	assert.False(t, NewNumber(0).IsTrue())
+	assert.False(t, NewNumber(0.0).IsTrue())
+	assert.False(t, NewNumber(-0.0).IsTrue())
+	assert.True(t, NewNumber(-1).IsTrue())
+	assert.True(t, NewNumber(0.5).IsTrue())
+	assert.True(t, NewNumber(-0.05).IsTrue())
 }
 
 func TestNumberLess(t *testing.T) {

--- a/rel/set_test.go
+++ b/rel/set_test.go
@@ -116,8 +116,8 @@ func (vl Float64InterfaceList) Swap(i, j int) {
 
 func TestSetBool(t *testing.T) {
 	t.Parallel()
-	assert.False(t, intSet().Bool())
-	assert.True(t, intSet(42).Bool())
+	assert.False(t, intSet().IsTrue())
+	assert.True(t, intSet(42).IsTrue())
 }
 
 func TestSetLess(t *testing.T) {

--- a/rel/tuple_test.go
+++ b/rel/tuple_test.go
@@ -114,8 +114,8 @@ func TestTupleEqual(t *testing.T) {
 
 func TestTupleBool(t *testing.T) {
 	t.Parallel()
-	assert.False(t, EmptyTuple.Bool())
-	assert.True(t, NewTuple(Attr{"a", NewNumber(42)}).Bool())
+	assert.False(t, EmptyTuple.IsTrue())
+	assert.True(t, NewTuple(Attr{"a", NewNumber(42)}).IsTrue())
 }
 
 func TestTupleLess(t *testing.T) {

--- a/rel/value.go
+++ b/rel/value.go
@@ -27,7 +27,7 @@ type Value interface {
 	Kind() int
 
 	// Bool returns true iff the Value is non-zero or non-empty.
-	Bool() bool
+	IsTrue() bool
 
 	// Less return true iff the Value is less than v. Number < Tuple < Set.
 	Less(v Value) bool

--- a/rel/value_number.go
+++ b/rel/value_number.go
@@ -70,7 +70,7 @@ func (n Number) Kind() int {
 }
 
 // Bool returns true iff the tuple has attributes.
-func (n Number) Bool() bool {
+func (n Number) IsTrue() bool {
 	return n != 0
 }
 
@@ -84,7 +84,7 @@ func (n Number) Less(v Value) bool {
 
 // Negate returns -n.
 func (n Number) Negate() Value {
-	if !n.Bool() {
+	if !n.IsTrue() {
 		return n
 	}
 	return NewNumber(-float64(n))

--- a/rel/value_set.go
+++ b/rel/value_set.go
@@ -92,7 +92,7 @@ func (s *genericSet) String() string {
 	switch s.flavor {
 	case setFlavorNormal:
 		// {} == none
-		if !s.Bool() {
+		if !s.IsTrue() {
 			return "{}"
 		}
 
@@ -100,7 +100,7 @@ func (s *genericSet) String() string {
 		if s.Count() == 1 {
 			e := s.Enumerator()
 			e.MoveNext()
-			if tuple, ok := e.Current().(Tuple); ok && !tuple.Bool() {
+			if tuple, ok := e.Current().(Tuple); ok && !tuple.IsTrue() {
 				return "true"
 			}
 		}
@@ -178,7 +178,7 @@ func (s *genericSet) Kind() int {
 }
 
 // Bool returns true iff the tuple has attributes.
-func (s *genericSet) Bool() bool {
+func (s *genericSet) IsTrue() bool {
 	return s.Count() > 0
 }
 
@@ -210,7 +210,7 @@ func (s *genericSet) Less(v Value) bool {
 
 // Negate returns {(negateTag): s}.
 func (s *genericSet) Negate() Value {
-	if !s.Bool() {
+	if !s.IsTrue() {
 		return s
 	}
 	return NewTuple(NewAttr(negateTag, s))
@@ -264,9 +264,9 @@ func (s *genericSet) With(value Value) Set {
 		}
 	}
 	flavor := setFlavorNormal
-	if (s.flavor == setFlavorArray || !s.Bool()) && isArrayAttr {
+	if (s.flavor == setFlavorArray || !s.IsTrue()) && isArrayAttr {
 		flavor = setFlavorArray
-	} else if (s.flavor == setFlavorString || !s.Bool()) && isStringAttr {
+	} else if (s.flavor == setFlavorString || !s.IsTrue()) && isStringAttr {
 		flavor = setFlavorString
 	}
 

--- a/rel/value_set_bytes.go
+++ b/rel/value_set_bytes.go
@@ -75,7 +75,7 @@ func (b Bytes) Kind() int {
 }
 
 // Bool returns true iff the tuple has attributes.
-func (b Bytes) Bool() bool {
+func (b Bytes) IsTrue() bool {
 	if len(b.b) == 0 {
 		panic("Empty string not allowed (should be == None)")
 	}
@@ -269,7 +269,7 @@ func (e *bytesEnumerator) Current() Value {
 // 	if b, ok := b.(Bytes); ok {
 // 		return b
 // 	}
-// 	if !b.Bool() {
+// 	if !b.IsTrue() {
 // 		return b
 // 	}
 

--- a/rel/value_set_closure.go
+++ b/rel/value_set_closure.go
@@ -54,7 +54,7 @@ func (c Closure) Kind() int {
 }
 
 // Bool returns true iff the tuple has attributes.
-func (c Closure) Bool() bool {
+func (c Closure) IsTrue() bool {
 	return true
 }
 

--- a/rel/value_set_dict.go
+++ b/rel/value_set_dict.go
@@ -35,7 +35,7 @@ func AsDict(s Set) (Dict, bool) {
 	if d, ok := s.(Dict); ok {
 		return d, true
 	}
-	if !s.Bool() {
+	if !s.IsTrue() {
 		return Dict{}, true
 	}
 	var mb frozen.MapBuilder
@@ -65,7 +65,7 @@ func (d Dict) Equal(v interface{}) bool {
 	case Dict:
 		return d.m.Equal(v.m)
 	case Set:
-		if d.Bool() != v.Bool() || d.Count() != v.Count() {
+		if d.IsTrue() != v.IsTrue() || d.Count() != v.Count() {
 			return false
 		}
 		match := DictTupleMatcher()
@@ -107,7 +107,7 @@ func (d Dict) Kind() int {
 	return dictKind
 }
 
-func (d Dict) Bool() bool {
+func (d Dict) IsTrue() bool {
 	return !d.m.IsEmpty()
 }
 

--- a/rel/value_set_eclosure.go
+++ b/rel/value_set_eclosure.go
@@ -54,7 +54,7 @@ func (c ExprClosure) Kind() int {
 }
 
 // Bool returns true iff the tuple has attributes.
-func (c ExprClosure) Bool() bool {
+func (c ExprClosure) IsTrue() bool {
 	return true
 }
 

--- a/rel/value_set_func.go
+++ b/rel/value_set_func.go
@@ -80,7 +80,7 @@ func (f *Function) Kind() int {
 }
 
 // Bool returns true iff the tuple has attributes.
-func (f *Function) Bool() bool {
+func (f *Function) IsTrue() bool {
 	return true
 }
 

--- a/rel/value_set_native_func.go
+++ b/rel/value_set_native_func.go
@@ -69,7 +69,7 @@ func (f *NativeFunction) Kind() int {
 }
 
 // Bool always returns true.
-func (f *NativeFunction) Bool() bool {
+func (f *NativeFunction) IsTrue() bool {
 	return true
 }
 

--- a/rel/value_set_str.go
+++ b/rel/value_set_str.go
@@ -116,7 +116,7 @@ func (s String) Kind() int {
 }
 
 // Bool returns true iff the tuple has attributes.
-func (s String) Bool() bool {
+func (s String) IsTrue() bool {
 	if len(s.s) == 0 {
 		panic("Empty string not allowed (should be == None)")
 	}
@@ -301,7 +301,7 @@ func (e *stringEnumerator) Current() Value {
 // 	if s, ok := s.(String); ok {
 // 		return s
 // 	}
-// 	if !s.Bool() {
+// 	if !s.IsTrue() {
 // 		return s
 // 	}
 

--- a/rel/value_tuple.go
+++ b/rel/value_tuple.go
@@ -182,7 +182,7 @@ func (t *GenericTuple) Kind() int {
 }
 
 // Bool returns true iff the tuple has attributes.
-func (t *GenericTuple) Bool() bool {
+func (t *GenericTuple) IsTrue() bool {
 	return t.Count() > 0
 }
 
@@ -235,7 +235,7 @@ func (t *GenericTuple) Negate() Value {
 			return x
 		}
 	}
-	if !t.Bool() {
+	if !t.IsTrue() {
 		return t
 	}
 	return NewTuple(NewAttr(negateTag, t))

--- a/syntax/std_str.go
+++ b/syntax/std_str.go
@@ -12,7 +12,7 @@ func formatValue(format string, value rel.Value) string {
 	v := value.Export()
 	switch format[len(format)-1] {
 	case 't':
-		v = value.Bool()
+		v = value.IsTrue()
 	case 'c', 'd', 'o', 'O', 'x', 'X', 'U':
 		v = int(value.Export().(float64))
 	case 'q':


### PR DESCRIPTION
Fixes #40.

Changes proposed in this pull request:
- Rename Value.Bool() to Value.IsTrue() to improve readability when testing. `if v.IsTrue()` reads more naturally than `if v.Bool()`.
