### PR TITLE
wasm safe //.os.file

### DIFF
--- a/syntax/std_os.go
+++ b/syntax/std_os.go
@@ -1,10 +1,6 @@
 package syntax
 
-import (
-	"io/ioutil"
-
-	"github.com/arr-ai/arrai/rel"
-)
+import "github.com/arr-ai/arrai/rel"
 
 func stdOs() rel.Attr {
 	return rel.NewAttr("os", rel.NewTuple(
@@ -12,13 +8,7 @@ func stdOs() rel.Attr {
 		rel.NewAttr("path_separator", pathSeparator()),
 		rel.NewAttr("path_list_separator", pathListSeparator()),
 		rel.NewAttr("cwd", cwd()),
-		rel.NewNativeFunctionAttr("file", func(value rel.Value) rel.Value {
-			f, err := ioutil.ReadFile(value.(rel.String).String())
-			if err != nil {
-				panic(err)
-			}
-			return rel.NewBytes(f)
-		}),
+		rel.NewNativeFunctionAttr("file", file),
 		rel.NewNativeFunctionAttr("get_env", getEnv),
 	))
 }

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -3,6 +3,7 @@
 package syntax
 
 import (
+	"io/ioutil"
 	"os"
 
 	"github.com/arr-ai/arrai/rel"
@@ -30,4 +31,12 @@ func cwd() rel.Value {
 		panic(err)
 	}
 	return rel.NewString([]rune(wd))
+}
+
+func file(v rel.Value) rel.Value {
+	f, err := ioutil.ReadFile(v.(rel.String).String())
+	if err != nil {
+		panic(err)
+	}
+	return rel.NewBytes(f)
 }

--- a/syntax/std_os_wasm.go
+++ b/syntax/std_os_wasm.go
@@ -25,3 +25,7 @@ func pathListSeparator() rel.Value {
 func cwd() rel.Value {
 	return rel.NewSet()
 }
+
+func file(rel.Value) rel.Value {
+	return rel.NewBytes([]byte{})
+}

--- a/syntax/std_os_wasm.go
+++ b/syntax/std_os_wasm.go
@@ -7,25 +7,25 @@ import (
 )
 
 func getArgs() rel.Value {
-	return rel.NewSet()
+	panic("not implemented")
 }
 
 func getEnv(value rel.Value) rel.Value {
-	return rel.NewSet()
+	panic("not implemented")
 }
 
 func pathSeparator() rel.Value {
-	return rel.NewSet()
+	panic("not implemented")
 }
 
 func pathListSeparator() rel.Value {
-	return rel.NewSet()
+	panic("not implemented")
 }
 
 func cwd() rel.Value {
-	return rel.NewSet()
+	panic("not implemented")
 }
 
 func file(rel.Value) rel.Value {
-	return rel.NewBytes([]byte{})
+	panic("not implemented")
 }


### PR DESCRIPTION
Fixes issue mentioned from the [comment](https://github.com/arr-ai/arrai/issues/60#issuecomment-596186873)  .

Changes proposed in this pull request:
- Add wasm safe build for `//.os.file`