### PR TITLE
fix get operation with quoted field names

### DIFF
--- a/cmd/arrai/eval_test.go
+++ b/cmd/arrai/eval_test.go
@@ -16,3 +16,11 @@ func assertEvalOutputs(t *testing.T, expected, source string) bool { //nolint:un
 func TestEvalNumberULP(t *testing.T) {
 	assertEvalOutputs(t, `0.3`, `0.1 + 0.1 + 0.1`)
 }
+
+func TestEvalDoubleQuoteTupleAccess(t *testing.T) {
+	assertEvalOutputs(t, `42`, `("😅":42)."😅"`)
+	assertEvalOutputs(t, `42`, `("😅":42).'😅'`)
+	assertEvalOutputs(t, `42`, "('😅':42).`😅`")
+	assertEvalOutputs(t, `42`, `(x:42)."x"`)
+	assertEvalOutputs(t, `42`, `("":42).""`)
+}

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -256,20 +256,8 @@ func (pc ParseContext) CompileExpr(b ast.Branch) rel.Expr {
 			result = rel.DotIdent
 		}
 		for _, dot := range c.(ast.Many) {
-			var ident string
 			//TODO: handle get operation for "*", the grammar allows this
-			switch name, child := which(dot.(ast.Branch), "STR", "IDENT"); name {
-			case "STR":
-				ident = child.(ast.One).Node.One("").Scanner().String()
-				if ident != "\"\"" {
-					ident = ident[1 : len(ident)-1]
-				} else {
-					ident = ""
-				}
-			default:
-				ident = child.(ast.One).Node.One("").(ast.Leaf).Scanner().String()
-			}
-			result = rel.NewDotExpr(result, ident)
+			result = rel.NewDotExpr(result, parseName(dot.(ast.Branch)))
 		}
 		return result
 	case "rel":

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -256,7 +256,19 @@ func (pc ParseContext) CompileExpr(b ast.Branch) rel.Expr {
 			result = rel.DotIdent
 		}
 		for _, dot := range c.(ast.Many) {
-			ident := dot.One("IDENT").One("").(ast.Leaf).Scanner().String()
+			var ident string
+			//TODO: handle get operation for "*", the grammar allows this
+			switch name, child := which(dot.(ast.Branch), "STR", "IDENT"); name {
+			case "STR":
+				ident = child.(ast.One).Node.One("").Scanner().String()
+				if ident != "\"\"" {
+					ident = ident[1 : len(ident)-1]
+				} else {
+					ident = ""
+				}
+			default:
+				ident = child.(ast.One).Node.One("").(ast.Leaf).Scanner().String()
+			}
 			result = rel.NewDotExpr(result, ident)
 		}
 		return result


### PR DESCRIPTION
Fixes the bug where `get` operations would panic if you use a field surrounded by quotes (e.g. `(x: 42).'x'`.

Changes proposed in this pull request:
- Handled `STR` in get operations
- Corresponding tests

Checklist:
- [x] Added related tests

TODO:

Handle `(x: 42).*`. Not entirely sure what getting `*` would do but it is allowed in the grammar.
