### PR TITLE
//.tuple and //.dict

### DIFF
--- a/docs/std-eval.md
+++ b/docs/std-eval.md
@@ -1,10 +1,12 @@
 # strconv library
 
-`eval` has one function which is `value` which takes a string respresenting an expression and returns an arrai value.
+`eval` has one function which is `value` which takes a string respresenting an
+expression and returns an arrai value.
 
-However, `eval` is only supported to evaluate simple values e.g. numbers, tuples, sets, arrays, strings etc.
+However, `eval` is only supported to evaluate simple values e.g. numbers,
+tuples, sets, arrays, strings etc.
 
 ## Example
 
-Evaluating `//.eval.value("'true'")` will return `true`
-Evaluating `//.eval.value("(test: 'test', number:123)")` will return `(test: 'test', number:123)`
+- `//.eval.value("'true'") = true`
+- `//.eval.value("(test: 'test', number:123)") = (test: 'test', number:123)`

--- a/docs/std-os.md
+++ b/docs/std-os.md
@@ -1,23 +1,33 @@
-# os library
+# //.os library
 
-# args
+## args
 
-`//.os.args` returns the provided arguments when running an arrai program. It returns an array of strings.
+`//.os.args` returns an array of strings representing the arguments provided on
+the command line when running an arrai program. `//.os.args(0)` is the path of
+the arr.ai program that was invoked from the command line.
 
-# path_separator
+## path_separator
 
-`//.os.path_separator` returns the path separator of the current operating system.
-`/` for UNIX-like machine and `\` for Windows machine. It returns a string.
+`//.os.path_separator` returns the path separator of the current operating
+system. `/` for UNIX-like machine and `\` for Windows machine. It returns a
+string.
 
-# path_list_separator
-`//.os.path_list_separator` returns the path list separator of the current operating system.
-`:` for UNIX-like machine and `;` for Windows machine. It returns a string.
+## path_list_separator
 
-# cwd
+`//.os.path_list_separator` returns the path list separator of the current
+operating system. `:` for UNIX-like machine and `;` for Windows machine. It
+returns a string.
+
+## cwd
+
 `//.os.cwd` returns a string representing the current user directory.
 
-# file
-`//.os.file()` is a function that returns the content of a file represented by a filepath in the form of an array of bytes.
+## file
 
-# get_env
-`//.os.get_eng()` is a function that returns the environment variable that corresponds to the provided key in the form of a string.
+`//.os.file()` is a function that returns the content of a file represented by a
+filepath in the form of an array of bytes.
+
+## get_env
+
+`//.os.get_eng()` is a function that returns the environment variable that
+corresponds to the provided key in the form of a string.

--- a/docs/std-os.md
+++ b/docs/std-os.md
@@ -29,5 +29,5 @@ filepath in the form of an array of bytes.
 
 ## get_env
 
-`//.os.get_eng()` is a function that returns the environment variable that
+`//.os.get_env()` is a function that returns the environment variable that
 corresponds to the provided key in the form of a string.

--- a/docs/std.md
+++ b/docs/std.md
@@ -1,0 +1,29 @@
+# Standard library reference
+
+The arr.ai standard library is available via the `//.` syntax.
+
+## Packages
+
+The following standard packages are available:
+
+- [//.eval](std-eval.md)
+- [//.os](std-os.md)
+
+## Core functions
+
+The following functions are available at the root of the standard library.
+
+### dict
+
+`//.dict` converts tuples to dictionaries.
+
+- `//.dict(()) = {}`
+- `//.dict((a: 1, b: 2)) = {"a": 1, "b": 2}`
+
+### tuple
+
+`//.tuple` converts dictionaries to tuples. All keys must be strings. The
+operation is shallow, so dictionary-structured values won't be converted.
+
+- `//.tuple({} = ()`
+- `//.tuple({"a": 1, "b": 2}) = (a: 1, b: 2)`

--- a/rel/test_helpers.go
+++ b/rel/test_helpers.go
@@ -70,5 +70,5 @@ func AssertExprEvalsToType(t *testing.T, expected interface{}, expr Expr) bool {
 
 // AssertExprPanics asserts that the expr panics when evaluates.
 func AssertExprPanics(t *testing.T, expr Expr) bool {
-	return assert.Panics(t, func() { expr.Eval(EmptyScope) })
+	return assert.Panics(t, func() { expr.Eval(EmptyScope) }) //nolint:errcheck
 }

--- a/rel/test_helpers.go
+++ b/rel/test_helpers.go
@@ -67,3 +67,8 @@ func AssertExprEvalsToType(t *testing.T, expected interface{}, expr Expr) bool {
 	}
 	return true
 }
+
+// AssertExprPanics asserts that the expr panics when evaluates.
+func AssertExprPanics(t *testing.T, expr Expr) bool {
+	return assert.Panics(t, func() { expr.Eval(EmptyScope) })
+}

--- a/syntax/std_test.go
+++ b/syntax/std_test.go
@@ -4,14 +4,22 @@ import "testing"
 
 func TestStdTuple(t *testing.T) {
 	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `()`, `//.tuple({})`)
 	AssertCodesEvalToSameValue(t, `(a:1)`, `//.tuple({"a":1})`)
 	AssertCodesEvalToSameValue(t, `(a:1, b:2)`, `//.tuple({"a":1, "b":2})`)
+
+	AssertCodePanics(t, `//.tuple((a:1))`)
+	AssertCodePanics(t, `//.tuple(42)`)
 }
 
 func TestStdDict(t *testing.T) {
 	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `{}`, `//.dict(())`)
 	AssertCodesEvalToSameValue(t, `{"a":1}`, `//.dict((a:1))`)
 	AssertCodesEvalToSameValue(t, `{"a":1, "b":2}`, `//.dict((a:1, b:2))`)
+
+	AssertCodePanics(t, `//.dict({42:43})`)
+	AssertCodePanics(t, `//.dict(42)`)
 }

--- a/syntax/std_test.go
+++ b/syntax/std_test.go
@@ -1,0 +1,17 @@
+package syntax
+
+import "testing"
+
+func TestStdTuple(t *testing.T) {
+	t.Parallel()
+	AssertCodesEvalToSameValue(t, `()`, `//.tuple({})`)
+	AssertCodesEvalToSameValue(t, `(a:1)`, `//.tuple({"a":1})`)
+	AssertCodesEvalToSameValue(t, `(a:1, b:2)`, `//.tuple({"a":1, "b":2})`)
+}
+
+func TestStdDict(t *testing.T) {
+	t.Parallel()
+	AssertCodesEvalToSameValue(t, `{}`, `//.dict(())`)
+	AssertCodesEvalToSameValue(t, `{"a":1}`, `//.dict((a:1))`)
+	AssertCodesEvalToSameValue(t, `{"a":1, "b":2}`, `//.dict((a:1, b:2))`)
+}

--- a/syntax/test_helpers.go
+++ b/syntax/test_helpers.go
@@ -59,6 +59,21 @@ func AssertCodeEvalsToType(t *testing.T, expected interface{}, code string) bool
 	return true
 }
 
+// AssertCodePanics asserts that the code panics when executed.
+func AssertCodePanics(t *testing.T, code string) bool {
+	pc := ParseContext{SourceDir: ".."}
+	ast, err := pc.Parse(parser.NewScanner(code))
+	if !assert.NoError(t, err, "parsing code: %s", code) {
+		return false
+	}
+	codeExpr := pc.CompileExpr(ast)
+	if !rel.AssertExprPanics(t, codeExpr) {
+		t.Logf("code:     %s", code)
+		return false
+	}
+	return true
+}
+
 // AssertScan asserts that a lexer's next produced token is as expected.
 func AssertScan(t *testing.T, l *Lexer, tok Token, intf interface{}, lexeme string) bool {
 	if !assert.True(t, l.Scan()) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Implement `//.tuple` to convert dictionaries to tuples.
- Implement `//.dict` to convert tuples to dictionaries.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
