### PR TITLE
Allow string syntax for get attribute

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -313,7 +313,7 @@ Arr.ai supports operations on numbers.
 
 ### Structure access expressions
 
-1. Tuple attribute: `tuple.attr`
+1. Tuple attribute: `tuple.attr` (string syntax is allowed, e.g.: `('👋': 42)."👋"`))
 2. Dot variable attribute: `.attr` (shorthand for `(.).attr`)
 3. Function call:
    1. `[2, 4, 6, 8](2) = 6`, `"hello"(1) = 101`

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/arr-ai/arrai
 go 1.13
 
 require (
-	github.com/ChloePlanet/arrai-examples v0.0.0-20200305000334-1c4ee0c3a8cc // indirect
+	github.com/ChloePlanet/arrai-examples v0.1.0 // indirect
 	github.com/arr-ai/frozen v0.13.0
 	github.com/arr-ai/hash v0.4.0
 	github.com/arr-ai/proto v0.0.0-20180422074755-2ffbedebee50

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChloePlanet/arrai-examples v0.0.0-20200305000334-1c4ee0c3a8cc h1:xHjN8t4LyINSj9yhKpTyZfnzsU11NCXBKryOsalk6l8=
 github.com/ChloePlanet/arrai-examples v0.0.0-20200305000334-1c4ee0c3a8cc/go.mod h1:gAgLjCoLny2WmCgo/lIzI2AIqzET9tCLHJR5afGy/q0=
+github.com/ChloePlanet/arrai-examples v0.1.0 h1:P2kgIKuHMsTCGCS8Vrob+lsug0VAD08Ir3wcf6KQXGk=
+github.com/ChloePlanet/arrai-examples v0.1.0/go.mod h1:gAgLjCoLny2WmCgo/lIzI2AIqzET9tCLHJR5afGy/q0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/arr-ai/frozen v0.13.0 h1:LUqRAVNbsH3SIHCxSSrVRvLOraCazaj3bazvJ9tdVbo=
 github.com/arr-ai/frozen v0.13.0/go.mod h1:YEr4TubkrAoA3f9U1R4PcEVB5ocBUdiS3NKh03cbVts=

--- a/syntax/expr_tuple_test.go
+++ b/syntax/expr_tuple_test.go
@@ -12,3 +12,10 @@ func TestTupleType(t *testing.T) {
 	AssertCodeEvalsToType(t, rel.ArrayItemTuple{}, `(@: 1, @item: 2)`)
 	AssertCodeEvalsToType(t, rel.DictEntryTuple{}, `(@: {1, 2}, @value: 2)`)
 }
+
+func TestTupleGet(t *testing.T) {
+	t.Parallel()
+	AssertCodesEvalToSameValue(t, `42`, `(a: 1, b: 42).b`)
+	AssertCodesEvalToSameValue(t, `42`, `(a: 1, '👋': 42)."👋"`)
+	AssertCodesEvalToSameValue(t, `42`, `(a: 1, '': 42).""`)
+}

--- a/syntax/expr_tuple_test.go
+++ b/syntax/expr_tuple_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestTupleType(t *testing.T) {
 	t.Parallel()
+
 	AssertCodeEvalsToType(t, rel.StringCharTuple{}, `(@: 1, @char: 65)`)
 	AssertCodeEvalsToType(t, rel.ArrayItemTuple{}, `(@: 1, @item: 2)`)
 	AssertCodeEvalsToType(t, rel.DictEntryTuple{}, `(@: {1, 2}, @value: 2)`)
@@ -16,6 +17,9 @@ func TestTupleType(t *testing.T) {
 func TestTupleGet(t *testing.T) {
 	t.Parallel()
 	AssertCodesEvalToSameValue(t, `42`, `(a: 1, b: 42).b`)
+	AssertCodesEvalToSameValue(t, `42`, `(a: 1, 'b': 42)."b"`)
+	AssertCodesEvalToSameValue(t, `42`, `(a: 1, "b": 42).'b'`)
+	AssertCodesEvalToSameValue(t, `42`, "(a: 1, `b`: 42).`b`")
 	AssertCodesEvalToSameValue(t, `42`, `(a: 1, '👋': 42)."👋"`)
 	AssertCodesEvalToSameValue(t, `42`, `(a: 1, '': 42).""`)
 }

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -255,8 +255,13 @@ func (pc ParseContext) CompileExpr(b ast.Branch) rel.Expr {
 			result = rel.DotIdent
 		}
 		for _, dot := range c.(ast.Many) {
-			ident := dot.One("IDENT").One("").(ast.Leaf).Scanner().String()
-			result = rel.NewDotExpr(result, ident)
+			if ident := dot.One("IDENT"); ident != nil {
+				result = rel.NewDotExpr(result, ident.One("").(ast.Leaf).Scanner().String())
+			}
+			if str := dot.One("STR"); str != nil {
+				s := str.One("").Scanner().String()
+				result = rel.NewDotExpr(result, parseArraiString(s))
+			}
 		}
 		return result
 	case "rel":


### PR DESCRIPTION
> **Reviewer note:** Only the final commit is relevant.

Changes proposed in this pull request:
- Allow attribute access to use string syntax, e.g. `('-x': 42)."-x"`. Empty names too: `('': 42).''`.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
