### PR TITLE
fixes #25 multiplication in an arrow operation

### DIFF
--- a/syntax/expr_arrow_test.go
+++ b/syntax/expr_arrow_test.go
@@ -3,11 +3,20 @@ package syntax
 import "testing"
 
 func TestApplyExpr(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `42`, `6 -> 7 * .`)
+	AssertCodesEvalToSameValue(t, `42`, `6 -> . * 7`)
 	AssertCodesEvalToSameValue(t, `42`, `6 -> \x 7 * x`)
 }
 
 func TestApplyExprInsideMapExpr(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{2, 4, 8}`, `{1, 2, 3} => (2 -> \y y ^ .)`)
 	AssertCodesEvalToSameValue(t, `{2, 4, 8}`, `(\z {1, 2, 3} => (z -> \y y ^ .))(2)`)
+}
+
+func TestTransformExpr(t *testing.T) {
+	t.Parallel()
+	AssertCodesEvalToSameValue(t, `[2, 4, 6, 8] `, `[1, 2, 3, 4] >> . * 2`)
+	AssertCodesEvalToSameValue(t, `[1, 4, 9, 16]`, `[1, 2, 3, 4] >> . * .`)
 }

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -75,7 +75,7 @@ expr   -> C* amp="&"* @ C* arrow=(
 nest   -> C* "nest" names IDENT C*;
 unnest -> C* "unnest" IDENT C*;
 touch  -> C* ("->*" ("&"? IDENT | STR))+ "(" expr:"," ","? ")" C*;
-get    -> C* dot="." ("&"? IDENT | STR | "*") C*;
+get    -> C* dot="." ("&"? IDENT | STR ) C*;
 names  -> C* "|" C* IDENT:"," C* "|" C*;
 name   -> C* IDENT C* | C* STR C*;
 xstr   -> C* quote=/{\$"\s*} part=( sexpr | fragment=/{(?: \\. | \$[^{"] | [^\\"$] )+} )* '"' C*


### PR DESCRIPTION
Fixes #25 .

Changes proposed in this pull request:
Removes `*` from the get operation which fixes arrow operation

writing `. *` in an arrow operation (>>, ->, etc) are parsed as a get operation
instead of a math operation. While it is allowed in the grammar to do a get
operation with an asterisk, it is unclear as to what it does as it is not
handled yet during parsing. Removing the asterisk from `get` grammar is a very
fast fix for this problem. 

Checklist:
- [x] Added related tests
