### PR TITLE
Eval output

### DIFF
--- a/cmd/arrai/eval.go
+++ b/cmd/arrai/eval.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
+	"github.com/arr-ai/arrai/rel"
 	"github.com/arr-ai/arrai/syntax"
 	"github.com/urfave/cli/v2"
 )
@@ -26,9 +28,21 @@ func evalExpr(path, source string, w io.Writer) error {
 		return err
 	}
 
-	s := value.String()
+	var s string
+	switch v := value.(type) {
+	case rel.String:
+		s = v.String()
+	case rel.Set:
+		if !v.IsTrue() {
+			s = ""
+		} else {
+			s = rel.Repr(v)
+		}
+	default:
+		s = rel.Repr(v)
+	}
 	fmt.Fprintf(w, "%s", s)
-	if s[len(s)-1] != '\n' {
+	if s != "" && !strings.HasSuffix(s, "\n") {
 		if _, err := w.Write([]byte{'\n'}); err != nil {
 			return err
 		}

--- a/cmd/arrai/eval_test.go
+++ b/cmd/arrai/eval_test.go
@@ -16,3 +16,14 @@ func assertEvalOutputs(t *testing.T, expected, source string) bool { //nolint:un
 func TestEvalNumberULP(t *testing.T) {
 	assertEvalOutputs(t, `0.3`, `0.1 + 0.1 + 0.1`)
 }
+
+func TestEvalString(t *testing.T) {
+	assertEvalOutputs(t, ``, `""`)
+	assertEvalOutputs(t, ``, `{}`)
+	assertEvalOutputs(t, `abc`, `"abc"`)
+}
+
+func TestEvalComplex(t *testing.T) {
+	assertEvalOutputs(t, `[42, 'abc']`, `[42, "abc"]`)
+	assertEvalOutputs(t, `{42, 'abc'}`, `{"abc", 42}`)
+}

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -124,7 +124,7 @@ $ arrai e '"hello"(3)'                 # So are strings.
 $ arrai e '"hello" => (@:.@, @item:.@char)'
 [104, 101, 108, 108, 111]
 $ arrai e '[104, 101, 108, 108, 111] => (@:.@, @char:.@item)'
-"hello"
+hello
 $ arrai e '{
    (@: 1, @char: 101),
    (@: 3, @char: 108),

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -132,7 +132,7 @@ $ arrai e '{
    (@: 4, @char: 111),
    (@: 2, @char: 108),
 }'
-"hello"
+hello
 ```
 
 The last example underscores the point made earlier that strings are in fact

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/tealeg/xlsx v1.0.5 h1:+f8oFmvY8Gw1iUXzPk+kz+4GpbDZPK1FhPiQRd+ypgE=
 github.com/tealeg/xlsx v1.0.5/go.mod h1:btRS8dz54TDnvKNosuAqxrM1QgN1udgk9O34bDCnORM=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/rel/astnode_value.go
+++ b/rel/astnode_value.go
@@ -102,7 +102,7 @@ func ASTBranchFromValue(b Tuple) ast.Branch {
 				children = ast.One{Node: ASTBranchFromValue(value)}
 			case String:
 				children = ast.One{Node: ASTLeafFromValue(value)}
-			case genericSet:
+			case GenericSet:
 				c := make(ast.Many, 0, value.Count())
 				for _, v := range value.OrderedValues() {
 					c = append(c, ASTNodeFromValue(v.(Tuple).MustGet(ArrayItemAttr)))

--- a/rel/expr_darrow.go
+++ b/rel/expr_darrow.go
@@ -39,15 +39,15 @@ func (e *DArrowExpr) Eval(local Scope) (Value, error) {
 		return nil, err
 	}
 	if set, ok := value.(Set); ok {
-		result := NewSet()
+		values := []Value{}
 		for i := set.Enumerator(); i.MoveNext(); {
 			v, err := e.fn.body.Eval(local.With(e.fn.arg, i.Current()))
 			if err != nil {
 				return nil, err
 			}
-			result = result.With(v)
+			values = append(values, v)
 		}
-		return result, nil
+		return NewSet(values...), nil
 	}
 	return nil, errors.Errorf("=> not applicable to %T", value)
 }

--- a/rel/expr_tuple.go
+++ b/rel/expr_tuple.go
@@ -159,7 +159,8 @@ func (e *TupleExpr) Eval(local Scope) (Value, error) {
 			return nil, err
 		}
 	}
-	return tuple, nil
+	// TODO: Construct new tuple directly
+	return tuple.(*GenericTuple).Canonical(), nil
 }
 
 // Get returns the Expr for the given name or nil if not found.

--- a/rel/json.go
+++ b/rel/json.go
@@ -116,7 +116,7 @@ func jsonEscape(value Expr) interface{} {
 			result[name] = jsonEscape(value)
 		}
 		return result
-	case genericSet:
+	case GenericSet:
 		if x.Equal(False) {
 			return false
 		}

--- a/rel/ops_set.go
+++ b/rel/ops_set.go
@@ -8,9 +8,9 @@ import (
 
 // Intersect returns every Value from a that is also in b.
 func Intersect(a, b Set) Set {
-	if ga, ok := a.(genericSet); ok {
-		if gb, ok := b.(genericSet); ok {
-			return genericSet{set: ga.set.Intersection(gb.set)}
+	if ga, ok := a.(GenericSet); ok {
+		if gb, ok := b.(GenericSet); ok {
+			return GenericSet{set: ga.set.Intersection(gb.set)}
 		}
 	}
 	return a.Where(func(v Value) bool { return b.Has(v) })
@@ -25,9 +25,9 @@ func NIntersect(a Set, bs ...Set) Set {
 
 // Union returns every Values that is in either input Set or both.
 func Union(a, b Set) Set {
-	if ga, ok := a.(genericSet); ok {
-		if gb, ok := b.(genericSet); ok {
-			return genericSet{set: ga.set.Union(gb.set)}
+	if ga, ok := a.(GenericSet); ok {
+		if gb, ok := b.(GenericSet); ok {
+			return GenericSet{set: ga.set.Union(gb.set)}
 		}
 	}
 	for e := b.Enumerator(); e.MoveNext(); {
@@ -46,9 +46,9 @@ func NUnion(sets ...Set) Set {
 
 // Difference returns every Value from the first Set that is not in the second.
 func Difference(a, b Set) Set {
-	if ga, ok := a.(genericSet); ok {
-		if gb, ok := b.(genericSet); ok {
-			return genericSet{set: ga.set.Difference(gb.set)}
+	if ga, ok := a.(GenericSet); ok {
+		if gb, ok := b.(GenericSet); ok {
+			return GenericSet{set: ga.set.Difference(gb.set)}
 		}
 	}
 	return a.Where(func(v Value) bool { return !b.Has(v) })
@@ -56,9 +56,9 @@ func Difference(a, b Set) Set {
 
 // SymmetricDifference returns Values in either Set, but not in both.
 func SymmetricDifference(a, b Set) Set {
-	if ga, ok := a.(genericSet); ok {
-		if gb, ok := b.(genericSet); ok {
-			return genericSet{set: ga.set.SymmetricDifference(gb.set)}
+	if ga, ok := a.(GenericSet); ok {
+		if gb, ok := b.(GenericSet); ok {
+			return GenericSet{set: ga.set.SymmetricDifference(gb.set)}
 		}
 	}
 	return Union(Difference(a, b), Difference(b, a))
@@ -138,12 +138,12 @@ func (o *orderer) Swap(i, j int) {
 
 // PowerSet computes the power set of a set.
 func PowerSet(s Set) Set {
-	if gs, ok := s.(genericSet); ok {
+	if gs, ok := s.(GenericSet); ok {
 		var sb frozen.SetBuilder
 		for i := gs.set.Powerset().Range(); i.Next(); {
-			sb.Add(genericSet{set: i.Value().(frozen.Set)})
+			sb.Add(GenericSet{set: i.Value().(frozen.Set)})
 		}
-		return genericSet{set: sb.Finish()}
+		return GenericSet{set: sb.Finish()}
 	}
 	result := NewSet(None)
 	for e := s.Enumerator(); e.MoveNext(); {

--- a/rel/test_helpers.go
+++ b/rel/test_helpers.go
@@ -37,7 +37,7 @@ func AssertExprsEvalToSameValue(t *testing.T, expected, expr Expr) bool {
 		return false
 	}
 	if !AssertEqualValues(t, expectedValue, value) {
-		t.Logf("\nexpected:%v\nexpr:     %v", expected, expr)
+		t.Logf("\nexpected: %v\nexpr:     %v", expected, expr)
 		return false
 	}
 	return true
@@ -62,7 +62,7 @@ func AssertExprEvalsToType(t *testing.T, expected interface{}, expr Expr) bool {
 		return false
 	}
 	if !assert.IsType(t, expected, value) {
-		t.Logf("\nexpected:%v\nexpr:     %v", expected, expr)
+		t.Logf("\nexpected: %T\nexpr:     %v", expected, expr)
 		return false
 	}
 	return true

--- a/rel/value_repr.go
+++ b/rel/value_repr.go
@@ -159,7 +159,7 @@ func reprValue(v Value, w io.Writer) {
 	case Number:
 		reprNumber(v, w)
 	default:
-		panic(fmt.Errorf("Repr(): unexpected Value type %T: %[1]v", v))
+		panic(fmt.Errorf("Repr(): unexpected Value type %T: %[1]v", v)) //nolint:golint
 	}
 }
 

--- a/rel/value_repr.go
+++ b/rel/value_repr.go
@@ -6,12 +6,9 @@ import (
 	"strings"
 )
 
-var reprEscapes = map[byte][]byte{
-	'\'': escapesWithDelim('\''),
-	'"':  escapesWithDelim('"'),
-}
+var reprEscapes = escapesWithDelim()
 
-func escapesWithDelim(delim byte) []byte {
+func escapesWithDelim() []byte {
 	escapes := make([]byte, 32)
 	escapes['\a'] = 'a'
 	escapes['\b'] = 'b'
@@ -41,7 +38,6 @@ func reprOffset(offset int, w io.Writer) {
 }
 
 func reprEscape(s string, delim byte, w io.Writer) {
-	escapes := reprEscapes[delim]
 	fmt.Fprintf(w, "%c", delim)
 	// TODO: optimise by handling non-special characters in groups.
 	for _, c := range s {
@@ -49,7 +45,7 @@ func reprEscape(s string, delim byte, w io.Writer) {
 			fmt.Fprintf(w, `\%c`, c)
 		} else if c >= 32 {
 			fmt.Fprintf(w, "%c", c)
-		} else if escape := escapes[c]; escape != 0 {
+		} else if escape := reprEscapes[c]; escape != 0 {
 			fmt.Fprintf(w, `\%c`, escape)
 		} else {
 			fmt.Fprintf(w, `\x%02x`, c)

--- a/rel/value_repr.go
+++ b/rel/value_repr.go
@@ -69,6 +69,11 @@ func reprString(str String, w io.Writer) {
 	}
 }
 
+func reprBytes(b Bytes, w io.Writer) {
+	reprOffset(b.offset, w)
+	fmt.Fprint(w, b.String())
+}
+
 func reprArray(a Array, w io.Writer) {
 	reprOffset(a.offset, w)
 	fmt.Fprint(w, "[")
@@ -132,13 +137,15 @@ func reprTuple(t *GenericTuple, w io.Writer) {
 }
 
 func reprNumber(n Number, w io.Writer) {
-	fmt.Fprint(w, n.Float64())
+	fmt.Fprint(w, n.String())
 }
 
 func reprValue(v Value, w io.Writer) {
 	switch v := v.(type) {
 	case String:
 		reprString(v, w)
+	case Bytes:
+		reprBytes(v, w)
 	case Array:
 		reprArray(v, w)
 	case Dict:

--- a/rel/value_repr.go
+++ b/rel/value_repr.go
@@ -1,0 +1,167 @@
+package rel
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+var reprEscapes = map[byte][]byte{
+	'\'': escapesWithDelim('\''),
+	'"':  escapesWithDelim('"'),
+}
+
+func escapesWithDelim(delim byte) []byte {
+	escapes := make([]byte, 32)
+	escapes['\a'] = 'a'
+	escapes['\b'] = 'b'
+	escapes['\x1b'] = 'e'
+	escapes['\f'] = 'f'
+	escapes['\n'] = 'n'
+	escapes['\r'] = 'r'
+	escapes['\t'] = 't'
+	escapes['\v'] = 'v'
+	return escapes
+}
+
+type reprCommaSep bool
+
+func (s *reprCommaSep) Sep(w io.Writer) {
+	if !*s {
+		*s = true
+	} else {
+		fmt.Fprint(w, ", ")
+	}
+}
+
+func reprOffset(offset int, w io.Writer) {
+	if offset != 0 {
+		fmt.Fprintf(w, `%d\`, offset)
+	}
+}
+
+func reprEscape(s string, delim byte, w io.Writer) {
+	escapes := reprEscapes[delim]
+	fmt.Fprintf(w, "%c", delim)
+	// TODO: optimise by handling non-special characters in groups.
+	for _, c := range s {
+		if c == '\\' || c == rune(delim) {
+			fmt.Fprintf(w, `\%c`, c)
+		} else if c >= 32 {
+			fmt.Fprintf(w, "%c", c)
+		} else if escape := escapes[c]; escape != 0 {
+			fmt.Fprintf(w, `\%c`, escape)
+		} else {
+			fmt.Fprintf(w, `\x%02x`, c)
+		}
+	}
+	fmt.Fprintf(w, "%c", delim)
+}
+
+func reprString(str String, w io.Writer) {
+	reprOffset(str.offset, w)
+	s := string(str.s)
+	switch {
+	case !strings.Contains(s, "'"):
+		reprEscape(s, '\'', w)
+	default:
+		reprEscape(s, '"', w)
+	}
+}
+
+func reprArray(a Array, w io.Writer) {
+	reprOffset(a.offset, w)
+	fmt.Fprint(w, "[")
+	var sep reprCommaSep
+	for _, v := range a.values {
+		sep.Sep(w)
+		reprValue(v, w)
+	}
+	fmt.Fprint(w, "]")
+}
+
+func reprDict(d Dict, w io.Writer) {
+	fmt.Fprint(w, "{")
+	var sep reprCommaSep
+	for _, e := range d.OrderedEntries() {
+		sep.Sep(w)
+		reprValue(e.at, w)
+		fmt.Fprint(w, ": ")
+		reprValue(e.value, w)
+	}
+	fmt.Fprint(w, "}")
+}
+
+func reprSet(s GenericSet, w io.Writer) {
+	fmt.Fprint(w, "{")
+	var sep reprCommaSep
+	for _, v := range s.OrderedValues() {
+		sep.Sep(w)
+		reprValue(v, w)
+	}
+	fmt.Fprint(w, "}")
+}
+
+func reprStringCharTuple(t StringCharTuple, w io.Writer) {
+	fmt.Fprintf(w, "(@: %d, %s: %d)", t.at, StringCharAttr, t.char)
+}
+
+func reprArrayItemTuple(t ArrayItemTuple, w io.Writer) {
+	fmt.Fprintf(w, "(@: %d, %s: ", t.at, ArrayItemAttr)
+	reprValue(t.item, w)
+	fmt.Fprint(w, ")")
+}
+
+func reprDictEntryTuple(t DictEntryTuple, w io.Writer) {
+	fmt.Fprint(w, "(@: ")
+	reprValue(t.at, w)
+	fmt.Fprintf(w, ", %s: ", DictValueAttr)
+	reprValue(t.value, w)
+	fmt.Fprint(w, ")")
+}
+
+func reprTuple(t *GenericTuple, w io.Writer) {
+	fmt.Fprint(w, "(")
+	var sep reprCommaSep
+	for _, name := range TupleOrderedNames(t) {
+		sep.Sep(w)
+		fmt.Fprintf(w, "%s: ", TupleNameRepr(name))
+		reprValue(t.MustGet(name), w)
+	}
+	fmt.Fprint(w, ")")
+}
+
+func reprNumber(n Number, w io.Writer) {
+	fmt.Fprint(w, n.Float64())
+}
+
+func reprValue(v Value, w io.Writer) {
+	switch v := v.(type) {
+	case String:
+		reprString(v, w)
+	case Array:
+		reprArray(v, w)
+	case Dict:
+		reprDict(v, w)
+	case GenericSet:
+		reprSet(v, w)
+	case StringCharTuple:
+		reprStringCharTuple(v, w)
+	case ArrayItemTuple:
+		reprArrayItemTuple(v, w)
+	case DictEntryTuple:
+		reprDictEntryTuple(v, w)
+	case *GenericTuple:
+		reprTuple(v, w)
+	case Number:
+		reprNumber(v, w)
+	default:
+		panic(fmt.Errorf("unknown Value type %T: %[1]v", v))
+	}
+}
+
+func Repr(v Value) string {
+	var sb strings.Builder
+	reprValue(v, &sb)
+	return sb.String()
+}

--- a/rel/value_repr.go
+++ b/rel/value_repr.go
@@ -159,7 +159,7 @@ func reprValue(v Value, w io.Writer) {
 	case Number:
 		reprNumber(v, w)
 	default:
-		panic(fmt.Errorf("unknown Value type %T: %[1]v", v))
+		panic(fmt.Errorf("Repr(): unexpected Value type %T: %[1]v", v))
 	}
 }
 

--- a/rel/value_repr_test.go
+++ b/rel/value_repr_test.go
@@ -1,0 +1,24 @@
+package rel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepr(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, `{}`, Repr(NewString([]rune(""))))
+	assert.Equal(t, `'abc'`, Repr(NewString([]rune("abc"))))
+
+	assert.Equal(t, `{}`, Repr(NewSet()))
+	assert.Equal(t, `{1}`, Repr(NewSet(NewNumber(1))))
+	assert.Equal(t, `{1, 'abc'}`, Repr(NewSet(NewNumber(1), NewString([]rune("abc")))))
+
+	assert.Equal(t, `[1, 'abc']`, Repr(NewArray(NewNumber(1), NewString([]rune("abc")))))
+	assert.Equal(t, `{1: 2, {42, 'a'}: 43}`, Repr(NewDict(false,
+		NewDictEntryTuple(NewNumber(1), NewNumber(2)),
+		NewDictEntryTuple(NewSet(NewString([]rune("a")), NewNumber(42)), NewNumber(43)),
+	)))
+}

--- a/rel/value_repr_test.go
+++ b/rel/value_repr_test.go
@@ -21,4 +21,10 @@ func TestRepr(t *testing.T) {
 		NewDictEntryTuple(NewNumber(1), NewNumber(2)),
 		NewDictEntryTuple(NewSet(NewString([]rune("a")), NewNumber(42)), NewNumber(43)),
 	)))
+
+	assert.Equal(t, `(a: (b: 'foo'), c: ['bar'], d: {})`, Repr(NewTuple(
+		NewAttr("a", NewTuple(NewAttr("b", NewString([]rune("foo"))))),
+		NewAttr("c", NewArray(NewString([]rune("bar")))),
+		NewAttr("d", None),
+	)))
 }

--- a/rel/value_repr_test.go
+++ b/rel/value_repr_test.go
@@ -22,9 +22,9 @@ func TestRepr(t *testing.T) {
 		NewDictEntryTuple(NewSet(NewString([]rune("a")), NewNumber(42)), NewNumber(43)),
 	)))
 
-	assert.Equal(t, `(a: (b: 'foo'), c: ['bar'], d: {})`, Repr(NewTuple(
+	assert.Equal(t, `(a: (b: 'foo'), c: ['bar'], "d'": {})`, Repr(NewTuple(
 		NewAttr("a", NewTuple(NewAttr("b", NewString([]rune("foo"))))),
 		NewAttr("c", NewArray(NewString([]rune("bar")))),
-		NewAttr("d", None),
+		NewAttr("d'", None),
 	)))
 }

--- a/rel/value_set_generic.go
+++ b/rel/value_set_generic.go
@@ -8,14 +8,14 @@ import (
 	"github.com/arr-ai/frozen"
 )
 
-// genericSet is a set of Values.
-type genericSet struct {
+// GenericSet is a set of Values.
+type GenericSet struct {
 	set frozen.Set
 }
 
 // genericSet equivalents for Boolean true and false
 var (
-	None  = Set(genericSet{frozen.Set{}})
+	None  = Set(GenericSet{frozen.Set{}})
 	False = None
 	True  = None.With(EmptyTuple)
 
@@ -100,7 +100,7 @@ func NewBool(b bool) Set {
 }
 
 // Hash computes a hash for a genericSet.
-func (s genericSet) Hash(seed uintptr) uintptr {
+func (s GenericSet) Hash(seed uintptr) uintptr {
 	h := seed
 	for e := s.Enumerator(); e.MoveNext(); {
 		h ^= e.Current().Hash(0)
@@ -109,15 +109,15 @@ func (s genericSet) Hash(seed uintptr) uintptr {
 }
 
 // Equal tests two Sets for equality. Any other type returns false.
-func (s genericSet) Equal(v interface{}) bool {
-	if t, ok := v.(genericSet); ok {
+func (s GenericSet) Equal(v interface{}) bool {
+	if t, ok := v.(GenericSet); ok {
 		return s.set.Equal(t.set)
 	}
 	return false
 }
 
 // String returns a string representation of a genericSet.
-func (s genericSet) String() string {
+func (s GenericSet) String() string {
 	// {} == none
 	if !s.IsTrue() {
 		return "{}"
@@ -193,31 +193,31 @@ func (s genericSet) String() string {
 }
 
 // Eval returns the set.
-func (s genericSet) Eval(local Scope) (Value, error) {
+func (s GenericSet) Eval(local Scope) (Value, error) {
 	return s, nil
 }
 
 var genericSetKind = registerKind(200, reflect.TypeOf(Function{}))
 
 // Kind returns a number that is unique for each major kind of Value.
-func (s genericSet) Kind() int {
+func (s GenericSet) Kind() int {
 	return genericSetKind
 }
 
 // Bool returns true iff the tuple has attributes.
-func (s genericSet) IsTrue() bool {
+func (s GenericSet) IsTrue() bool {
 	return s.Count() > 0
 }
 
 // Less returns true iff v.Kind() < genericSet.Kind() or v is a
 // genericSet and t precedes v in a lexicographical comparison of their
 // sorted values.
-func (s genericSet) Less(v Value) bool {
+func (s GenericSet) Less(v Value) bool {
 	if s.Kind() != v.Kind() {
 		return s.Kind() < v.Kind()
 	}
 
-	x := v.(genericSet)
+	x := v.(GenericSet)
 	a := s.OrderedValues()
 	b := x.OrderedValues()
 	n := len(a)
@@ -236,7 +236,7 @@ func (s genericSet) Less(v Value) bool {
 }
 
 // Negate returns {(negateTag): s}.
-func (s genericSet) Negate() Value {
+func (s GenericSet) Negate() Value {
 	if !s.IsTrue() {
 		return s
 	}
@@ -244,7 +244,7 @@ func (s genericSet) Negate() Value {
 }
 
 // Export exports a genericSet as an array of exported Values.
-func (s genericSet) Export() interface{} {
+func (s GenericSet) Export() interface{} {
 	if s.set.IsEmpty() {
 		return []interface{}{}
 	}
@@ -259,33 +259,33 @@ func (s genericSet) Export() interface{} {
 }
 
 // Count returns the number of elements in the genericSet.
-func (s genericSet) Count() int {
+func (s GenericSet) Count() int {
 	return s.set.Count()
 }
 
 // Has returns true iff the given Value is in the genericSet.
-func (s genericSet) Has(value Value) bool {
+func (s GenericSet) Has(value Value) bool {
 	return s.set.Has(value)
 }
 
 // With returns the original genericSet with given value added. Iff the value was
 // already present, the original genericSet is returned.
-func (s genericSet) With(value Value) Set {
-	return genericSet{s.set.With(value)}
+func (s GenericSet) With(value Value) Set {
+	return GenericSet{s.set.With(value)}
 }
 
 // Without returns the original genericSet without the given value. Iff the value was
 // already absent, the original genericSet is returned.
-func (s genericSet) Without(value Value) Set {
+func (s GenericSet) Without(value Value) Set {
 	set := s.set.Without(value)
 	if set == s.set {
 		return s
 	}
-	return genericSet{set}
+	return GenericSet{set}
 }
 
 // Map maps values per f.
-func (s genericSet) Map(f func(v Value) Value) Set {
+func (s GenericSet) Map(f func(v Value) Value) Set {
 	result := NewSet()
 	for e := s.Enumerator(); e.MoveNext(); {
 		result = result.With(f(e.Current()))
@@ -294,13 +294,13 @@ func (s genericSet) Map(f func(v Value) Value) Set {
 }
 
 // Where returns a new genericSet with all the Values satisfying predicate p.
-func (s genericSet) Where(p func(v Value) bool) Set {
+func (s GenericSet) Where(p func(v Value) bool) Set {
 	s.set = s.set.Where(func(elem interface{}) bool { return p(elem.(Value)) })
 	return s
 }
 
 // Call ...
-func (s genericSet) Call(arg Value) Value {
+func (s GenericSet) Call(arg Value) Value {
 	for e := s.Enumerator(); e.MoveNext(); {
 		var at Value
 		var t Tuple
@@ -315,19 +315,19 @@ func (s genericSet) Call(arg Value) Value {
 }
 
 // Enumerator returns an enumerator over the Values in the genericSet.
-func (s genericSet) Enumerator() ValueEnumerator {
+func (s GenericSet) Enumerator() ValueEnumerator {
 	return &genericSetEnumerator{s.set.Range()}
 }
 
 // Any return any value from the set.
-func (s genericSet) Any() Value {
+func (s GenericSet) Any() Value {
 	for e := s.Enumerator(); e.MoveNext(); {
 		return e.Current()
 	}
 	panic("Any(): empty set")
 }
 
-func (s genericSet) ArrayEnumerator() (OffsetValueEnumerator, bool) {
+func (s GenericSet) ArrayEnumerator() (OffsetValueEnumerator, bool) {
 	return &arrayEnumerator{
 		i: s.set.OrderedRange(func(a, b interface{}) bool {
 			return a.(Tuple).MustGet("@").(Number) < b.(Tuple).MustGet("@").(Number)
@@ -366,7 +366,7 @@ func (vl ValueList) Swap(i, j int) {
 }
 
 // OrderedValues returns Values in a canonical ordering.
-func (s genericSet) OrderedValues() []Value {
+func (s GenericSet) OrderedValues() []Value {
 	a := make([]Value, s.Count())
 	i := 0
 	for e := s.Enumerator(); e.MoveNext(); {

--- a/rel/value_tuple.go
+++ b/rel/value_tuple.go
@@ -2,7 +2,6 @@ package rel
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -170,11 +169,14 @@ func TupleNameRepr(name string) string {
 	if identRE.Match([]byte(name)) {
 		return name
 	}
-	data, err := json.Marshal(name)
-	if err != nil {
-		panic(err)
+	var sb strings.Builder
+	switch {
+	case !strings.Contains(name, "'"):
+		reprEscape(name, '\'', &sb)
+	default:
+		reprEscape(name, '"', &sb)
 	}
-	return string(data)
+	return sb.String()
 }
 
 // String returns a string representation of a Tuple.

--- a/rel/value_tuple.go
+++ b/rel/value_tuple.go
@@ -157,30 +157,27 @@ var LexerNamePat = `([$@A-Za-z_][0-9$@A-Za-z_]*)`
 
 var identRE = regexp.MustCompile(`\A` + LexerNamePat + `\z`)
 
+func TupleNameRepr(name string) string {
+	if identRE.Match([]byte(name)) {
+		return name
+	} else {
+		data, err := json.Marshal(name)
+		if err != nil {
+			panic(err)
+		}
+		return string(data)
+	}
+}
+
 // String returns a string representation of a Tuple.
 func (t *GenericTuple) String() string {
 	var buf bytes.Buffer
 	buf.WriteRune('(')
-	for i, name := range tupleOrderedNames(t) {
+	for i, name := range TupleOrderedNames(t) {
 		if i != 0 {
 			buf.WriteString(", ")
 		}
-		if identRE.Match([]byte(name)) {
-			buf.WriteString(name)
-		} else {
-			data, err := json.Marshal(name)
-			if err != nil {
-				panic(err)
-			}
-			buf.Write(data)
-		}
-		buf.WriteString(": ")
-		value, found := t.Get(name)
-		if !found {
-			panic(fmt.Sprintf(
-				"walk() produced name, %v, which fails lookup", name))
-		}
-		buf.WriteString(value.String())
+		fmt.Fprintf(&buf, "%s: %s", TupleNameRepr(name), t.MustGet(name).String())
 	}
 	buf.WriteRune(')')
 	return buf.String()
@@ -228,8 +225,8 @@ func (t *GenericTuple) Less(v Value) bool {
 	}
 
 	x := v.(*GenericTuple)
-	a := tupleOrderedNames(t)
-	b := tupleOrderedNames(x)
+	a := TupleOrderedNames(t)
+	b := TupleOrderedNames(x)
 	n := len(a)
 	if n > len(b) {
 		n = len(b)
@@ -383,8 +380,8 @@ func (t *GenericTuple) Enumerator() AttrEnumerator {
 	return &GenericTupleEnumerator{i: t.tuple.Range()}
 }
 
-// orderedNames returns the names of this tuple in sorted order.
-func tupleOrderedNames(t *GenericTuple) []string {
+// TupleOrderedNames returns the names of this tuple in sorted order.
+func TupleOrderedNames(t *GenericTuple) []string {
 	if len(t.names) == 0 {
 		for e := t.Enumerator(); e.MoveNext(); {
 			name, _ := e.Current()

--- a/rel/value_tuple.go
+++ b/rel/value_tuple.go
@@ -122,6 +122,15 @@ func NewXML(tag []rune, attrs []Attr, children ...Value) Tuple {
 	return EmptyTuple.With("@xml", b.Finish())
 }
 
+func (t *GenericTuple) Canonical() Tuple {
+	attrs := make([]Attr, 0, t.Count())
+	for e := t.Enumerator(); e.MoveNext(); {
+		name, value := e.Current()
+		attrs = append(attrs, NewAttr(name, value))
+	}
+	return NewTuple(attrs...)
+}
+
 // Hash computes a hash for a GenericTuple.
 func (t *GenericTuple) Hash(seed uintptr) uintptr {
 	return t.tuple.Hash(seed)
@@ -160,13 +169,12 @@ var identRE = regexp.MustCompile(`\A` + LexerNamePat + `\z`)
 func TupleNameRepr(name string) string {
 	if identRE.Match([]byte(name)) {
 		return name
-	} else {
-		data, err := json.Marshal(name)
-		if err != nil {
-			panic(err)
-		}
-		return string(data)
 	}
+	data, err := json.Marshal(name)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
 }
 
 // String returns a string representation of a Tuple.

--- a/syntax/expr_set_test.go
+++ b/syntax/expr_set_test.go
@@ -24,6 +24,11 @@ func TestStringType(t *testing.T) {
 	AssertCodeEvalsToType(t, rel.String{}, `"abc" ++ "def"`)
 }
 
+func TestArrayToString(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `"hello"`, `[104, 101, 108, 108, 111] => (@:.@, @char:.@item)`)
+	AssertCodeEvalsToType(t, rel.String{}, `[104, 101, 108, 108, 111] => (@:.@, @char:.@item)`)
+}
+
 func TestArray(t *testing.T) {
 	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{|@,@item| (0, 1), (1, 2), (2, 3)}`, `[1, 2, 3]`)

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -464,7 +464,7 @@ func (pc ParseContext) CompileExpr(b ast.Branch) rel.Expr {
 					}
 					next = ""
 				}
-				exprs[i] = rel.NewCallExprCurry(libStrExpand,
+				exprs[i] = rel.NewCallExprCurry(stdStrExpand,
 					rel.NewString([]rune(format)),
 					pc.CompileExpr(expr),
 					rel.NewString([]rune(delim)),
@@ -479,7 +479,7 @@ func (pc ParseContext) CompileExpr(b ast.Branch) rel.Expr {
 				exprs[i] = rel.NewString([]rune(s))
 			}
 		}
-		return rel.NewCallExpr(libStrConcat, rel.NewArrayExpr(exprs...))
+		return rel.NewCallExpr(stdStrConcat, rel.NewArrayExpr(exprs...))
 	case "NUM":
 		s := c.(ast.One).Node.One("").Scanner().String()
 		n, err := strconv.ParseFloat(s, 64)

--- a/syntax/parse_string.go
+++ b/syntax/parse_string.go
@@ -40,6 +40,8 @@ func parseArraiStringFragment(s string, validEscapes string, indent string) stri
 				sb.WriteByte('\a')
 			case 'b':
 				sb.WriteByte('\b')
+			case 'e':
+				sb.WriteByte('\x1b')
 			case 'f':
 				sb.WriteByte('\f')
 			case 'n':
@@ -54,6 +56,8 @@ func parseArraiStringFragment(s string, validEscapes string, indent string) stri
 				sb.WriteByte('\\')
 			case '\'':
 				sb.WriteByte('\'')
+			case '"':
+				sb.WriteByte('"')
 			case 'i':
 				sb.WriteString(indent)
 			default:

--- a/syntax/std_str.go
+++ b/syntax/std_str.go
@@ -33,7 +33,7 @@ func formatValue(format string, value rel.Value) string {
 }
 
 var (
-	libStrConcat = createNestedFunc("concat", 1, func(args ...rel.Value) rel.Value {
+	stdStrConcat = createNestedFunc("concat", 1, func(args ...rel.Value) rel.Value {
 		var sb strings.Builder
 		for i, ok := args[0].(rel.Set).ArrayEnumerator(); ok && i.MoveNext(); {
 			sb.WriteString(mustAsString(i.Current()))
@@ -41,7 +41,7 @@ var (
 		return rel.NewString([]rune(sb.String()))
 	})
 
-	libStrExpand = createNestedFunc("expand", 4, func(args ...rel.Value) rel.Value {
+	stdStrExpand = createNestedFunc("expand", 4, func(args ...rel.Value) rel.Value {
 		format := mustAsString(args[0])
 		if format != "" {
 			format = "%" + format
@@ -67,6 +67,10 @@ var (
 			s += mustAsString(args[3])
 		}
 		return rel.NewString([]rune(s))
+	})
+
+	stdStrRepr = rel.NewNativeFunction("repr", func(value rel.Value) rel.Value {
+		return rel.NewString([]rune(rel.Repr(value)))
 	})
 )
 
@@ -117,8 +121,9 @@ func stdStr() rel.Attr {
 			}
 			return rel.NewString([]rune(strings.Join(toJoin, mustAsString(args[1]))))
 		}),
-		rel.NewAttr("concat", libStrConcat),
-		rel.NewAttr("expand", libStrExpand),
+		rel.NewAttr("concat", stdStrConcat),
+		rel.NewAttr("expand", stdStrExpand),
+		rel.NewAttr("repr", stdStrRepr),
 	)
 }
 

--- a/syntax/test_helpers.go
+++ b/syntax/test_helpers.go
@@ -31,7 +31,7 @@ func AssertCodesEvalToSameValue(t *testing.T, expected, code string) bool {
 	return true
 }
 
-// RequireCodesEvalToSameValue requires that code evaluate to the same value as
+// RequireCodesEvalToSameValue requires that code evaluates to the same value as
 // expected.
 func RequireCodesEvalToSameValue(t *testing.T, expected string, code string) {
 	pc := ParseContext{SourceDir: ".."}
@@ -44,7 +44,7 @@ func RequireCodesEvalToSameValue(t *testing.T, expected string, code string) {
 	rel.AssertExprsEvalToSameValue(t, expectedExpr, codeExpr)
 }
 
-// AssertCodeEvalsToType asserts that the exprs evaluate to the same value.
+// AssertCodeEvalsToType asserts that code evaluates to the same type as expected.
 func AssertCodeEvalsToType(t *testing.T, expected interface{}, code string) bool {
 	pc := ParseContext{SourceDir: ".."}
 	ast, err := pc.Parse(parser.NewScanner(code))

--- a/syntax/test_helpers.go
+++ b/syntax/test_helpers.go
@@ -53,7 +53,7 @@ func AssertCodeEvalsToType(t *testing.T, expected interface{}, code string) bool
 	}
 	codeExpr := pc.CompileExpr(ast)
 	if !rel.AssertExprEvalsToType(t, expected, codeExpr) {
-		t.Logf("\nexpected: %s\ncode:     %s", expected, code)
+		t.Logf("\nexpected: %T\ncode:     %s", expected, code)
 		return false
 	}
 	return true


### PR DESCRIPTION
Strings (including the empty set) print bare.
Everything else prints as a valid arr.ai value.

Fixes #75.

Changes proposed in this pull request:
- Print strings as bare text. Treat empty set as empty string.
- Print everything else as a valid arr.ai value.
- Fix tuple expr canonicalization.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation no
