### PR TITLE
Implement //.os.stdin

### DIFF
--- a/docs/std-os.md
+++ b/docs/std-os.md
@@ -6,18 +6,6 @@
 the command line when running an arrai program. `//.os.args(0)` is the path of
 the arr.ai program that was invoked from the command line.
 
-## path_separator
-
-`//.os.path_separator` returns the path separator of the current operating
-system. `/` for UNIX-like machine and `\` for Windows machine. It returns a
-string.
-
-## path_list_separator
-
-`//.os.path_list_separator` returns the path list separator of the current
-operating system. `:` for UNIX-like machine and `;` for Windows machine. It
-returns a string.
-
 ## cwd
 
 `//.os.cwd` returns a string representing the current user directory.
@@ -31,3 +19,20 @@ filepath in the form of an array of bytes.
 
 `//.os.get_env()` is a function that returns the environment variable that
 corresponds to the provided key in the form of a string.
+
+## path_separator
+
+`//.os.path_separator` returns the path separator of the current operating
+system. `/` for UNIX-like machine and `\` for Windows machine. It returns a
+string.
+
+## path_list_separator
+
+`//.os.path_list_separator` returns the path list separator of the current
+operating system. `:` for UNIX-like machine and `;` for Windows machine. It
+returns a string.
+
+## stdin
+
+`//.os.stdin` holds all the bytes read from stdin. The bytes are read when
+`//.os.stdin` is accessed for the first time.

--- a/rel/expr_dot.go
+++ b/rel/expr_dot.go
@@ -50,7 +50,14 @@ func (x *DotExpr) Eval(local Scope) (Value, error) {
 		if x.attr[:1] != "&" {
 			if value, found := t.Get("&" + x.attr); found {
 				tupleScope := local.With("self", t)
-				return value.(*Function).Call(nil, tupleScope)
+				switch f := value.(type) {
+				case *Function:
+					return f.Call(nil, tupleScope)
+				case *NativeFunction:
+					return f.Call(nil, tupleScope)
+				default:
+					panic(fmt.Errorf("not a function: %v", f))
+				}
 			}
 		}
 		return nil, errors.Errorf("Missing attr %s", x.attr)

--- a/rel/value_set_generic.go
+++ b/rel/value_set_generic.go
@@ -20,6 +20,7 @@ var (
 	True  = None.With(EmptyTuple)
 
 	stringCharTupleType = reflect.TypeOf(StringCharTuple{})
+	bytesByteTupleType  = reflect.TypeOf(BytesByteTuple{})
 	arrayItemTupleType  = reflect.TypeOf(ArrayItemTuple{})
 	dictEntryTupleType  = reflect.TypeOf(DictEntryTuple{})
 )
@@ -46,6 +47,15 @@ func NewSet(values ...Value) Set {
 					panic("unsupported array expr")
 				}
 				return s
+			case bytesByteTupleType:
+				for _, value := range values {
+					set = set.With(value)
+				}
+				b, is := AsBytes(set)
+				if !is {
+					panic("unsupported array expr")
+				}
+				return b
 			case arrayItemTupleType:
 				for _, value := range values {
 					set = set.With(value)

--- a/rel/value_set_native_func.go
+++ b/rel/value_set_native_func.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 
 	"github.com/arr-ai/hash"
-	"github.com/go-errors/errors"
 )
 
 // NativeFunction represents a binary relation uniquely mapping inputs to outputs.
@@ -94,7 +93,7 @@ func (f *NativeFunction) Export() interface{} {
 // Call calls the NativeFunction with the given parameter.
 func (f *NativeFunction) Call(expr Expr, local Scope) (Value, error) {
 	if expr == nil {
-		return nil, errors.Errorf("missing function arg")
+		return f.fn(nil), nil
 	}
 	value, err := expr.Eval(local)
 	if err != nil {

--- a/rel/value_set_str.go
+++ b/rel/value_set_str.go
@@ -26,7 +26,7 @@ func NewOffsetString(s []rune, offset int) Set {
 	return String{s: s, offset: offset}
 }
 
-func AsString(s Set) (String, bool) {
+func AsString(s Set) (String, bool) { //nolint:dupl
 	if s, ok := s.(String); ok {
 		return s, true
 	}

--- a/rel/value_tuple.go
+++ b/rel/value_tuple.go
@@ -77,6 +77,11 @@ func NewTuple(attrs ...Attr) Tuple {
 					int(attrs[0].Value.(Number).Float64()),
 					rune(attrs[1].Value.(Number).Float64()),
 				)
+			case BytesByteAttr:
+				return NewBytesByteTuple(
+					int(attrs[0].Value.(Number).Float64()),
+					byte(attrs[1].Value.(Number).Float64()),
+				)
 			case ArrayItemAttr:
 				return NewArrayItemTuple(int(attrs[0].Value.(Number).Float64()), attrs[1].Value)
 			case DictValueAttr:

--- a/rel/value_tuple_bytes_byte.go
+++ b/rel/value_tuple_bytes_byte.go
@@ -98,7 +98,10 @@ func (t BytesByteTuple) Less(v Value) bool {
 }
 
 func (t BytesByteTuple) Negate() Value {
-	return BytesByteTuple{at: -t.at, byteval: -t.byteval}
+	return NewTuple(
+		NewAttr("@", NewNumber(-float64(t.at))),
+		NewAttr("@byte", NewNumber(-float64(t.byteval))),
+	)
 }
 
 // Export exports a Tuple.

--- a/rel/value_tuple_bytes_byte.go
+++ b/rel/value_tuple_bytes_byte.go
@@ -1,0 +1,223 @@
+package rel //nolint:dupl
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/arr-ai/hash"
+)
+
+// BytesByteTuple represents a tuple of the form (@: at, @byte: byteval).
+type BytesByteTuple struct {
+	at      int
+	byteval byte
+}
+
+// NewBytesByteTuple constructs a BytesByteTuple.
+func NewBytesByteTuple(at int, byteval byte) BytesByteTuple {
+	return BytesByteTuple{at: at, byteval: byteval}
+}
+
+func newBytesByteTupleFromTuple(t Tuple) (BytesByteTuple, bool) {
+	var at int
+	var byteval byte
+	m := NewTupleMatcher(
+		map[string]Matcher{
+			"@":           MatchInt(func(i int) { at = i }),
+			BytesByteAttr: MatchInt(func(i int) { byteval = byte(i) }),
+		},
+		Lit(EmptyTuple),
+	)
+	if m.Match(t) {
+		return NewBytesByteTuple(at, byteval), true
+	}
+	return BytesByteTuple{}, false
+}
+
+func maybeNewBytesByteTupleFromTuple(t Tuple) Tuple {
+	if t, ok := newBytesByteTupleFromTuple(t); ok {
+		return t
+	}
+	return t
+}
+
+func (t BytesByteTuple) asGenericTuple() Tuple {
+	return newTuple(
+		NewIntAttr("@", t.at),
+		NewIntAttr(BytesByteAttr, int(t.byteval)),
+	)
+}
+
+// Hash computes a hash for a BytesByteTuple.
+func (t BytesByteTuple) Hash(seed uintptr) uintptr {
+	h := hash.Int(t.at, seed)
+	return hash.Uint8(t.byteval, h)
+}
+
+// Equal tests two Tuples for equality. Any other type returns false.
+func (t BytesByteTuple) Equal(v interface{}) bool {
+	if u, ok := v.(BytesByteTuple); ok {
+		return t == u
+	}
+	return false
+}
+
+// String returns a string representation of a Tuple.
+func (t BytesByteTuple) String() string {
+	return fmt.Sprintf("(@: %d, %s: %d)", t.at, BytesByteAttr, t.byteval)
+}
+
+// Eval returns the tuple.
+func (t BytesByteTuple) Eval(local Scope) (Value, error) {
+	return t, nil
+}
+
+var bytesByteTupleKind = registerKind(304, reflect.TypeOf((*BytesByteTuple)(nil)))
+
+// Kind returns a number that is unique for each major kind of Value.
+func (t BytesByteTuple) Kind() int {
+	return bytesByteTupleKind
+}
+
+// Bool returns true iff the tuple has attributes.
+func (t BytesByteTuple) IsTrue() bool {
+	return true
+}
+
+// Less returns true iff v is not a number or tuple, or v is a tuple and t
+// precedes v in a lexicographical comparison of their name/value pairs.
+func (t BytesByteTuple) Less(v Value) bool {
+	if t.Kind() != v.Kind() {
+		return t.Kind() < v.Kind()
+	}
+	u := v.(BytesByteTuple)
+	if t.at != u.at {
+		return t.at < u.at
+	}
+	return t.byteval < u.byteval
+}
+
+func (t BytesByteTuple) Negate() Value {
+	return BytesByteTuple{at: -t.at, byteval: -t.byteval}
+}
+
+// Export exports a Tuple.
+func (t BytesByteTuple) Export() interface{} {
+	return map[string]interface{}{
+		"@":           t.at,
+		BytesByteAttr: t.byteval,
+	}
+}
+
+// Count returns how many attributes are in the Tuple.
+func (t BytesByteTuple) Count() int {
+	return 2
+}
+
+// Get returns the Value associated with a name, and true iff it was found.
+func (t BytesByteTuple) Get(name string) (Value, bool) {
+	switch name {
+	case "@":
+		return NewNumber(float64(t.at)), true
+	case BytesByteAttr:
+		return NewNumber(float64(t.byteval)), true
+	}
+	return nil, false
+}
+
+// MustGet returns e.Get(name) or panics if an error occurs.
+func (t BytesByteTuple) MustGet(name string) Value {
+	if v, has := t.Get(name); has {
+		return v
+	}
+	panic(fmt.Errorf("%q not found", name))
+}
+
+// With returns a Tuple with all name/Value pairs in t (except the one for the
+// given name, if present) with the addition of the given name/Value pair.
+func (t BytesByteTuple) With(name string, value Value) Tuple {
+	return maybeNewBytesByteTupleFromTuple(t.asGenericTuple().With(name, value))
+}
+
+// Without returns a Tuple with all name/Value pairs in t exception the one of
+// the given name.
+func (t BytesByteTuple) Without(name string) Tuple {
+	if name == "@" || name == BytesByteAttr {
+		return t.asGenericTuple().Without(name)
+	}
+	return t
+}
+
+func (t BytesByteTuple) Map(f func(Value) Value) Tuple {
+	at := f(NewNumber(float64(t.at)))
+	byteval := f(NewNumber(float64(t.byteval)))
+	if at, ok := at.(Number); ok {
+		if at, is := at.Int(); is {
+			if byteval, ok := byteval.(Number); ok {
+				if byteval, is := byteval.Int(); is {
+					return NewBytesByteTuple(at, byte(byteval))
+				}
+			}
+		}
+	}
+	return t.asGenericTuple().Map(f)
+}
+
+// HasName returns true iff the Tuple has an attribute with the given name.
+func (t BytesByteTuple) HasName(name string) bool {
+	return name == "@" || name == BytesByteAttr
+}
+
+// Attributes returns attributes as a map.
+func (t BytesByteTuple) Attributes() map[string]Value {
+	return map[string]Value{
+		"@":           NewNumber(float64(t.at)),
+		BytesByteAttr: NewNumber(float64(t.byteval)),
+	}
+}
+
+// Names returns the attribute names.
+func (t BytesByteTuple) Names() Names {
+	return NewNames("@", BytesByteAttr)
+}
+
+// Project returns a tuple with the given names from this tuple, or nil if any
+// name wasn't found.
+func (t BytesByteTuple) Project(names Names) Tuple {
+	if names.Has("@") && names.Has(BytesByteAttr) {
+		return t
+	}
+	return t.asGenericTuple().Project(names)
+}
+
+// Enumerator returns an enumerator over the Values in the BytesByteTuple.
+func (t BytesByteTuple) Enumerator() AttrEnumerator {
+	return &bytesByteTupleEnumerator{t: t, i: -1}
+}
+
+type bytesByteTupleEnumerator struct {
+	t     BytesByteTuple
+	i     int
+	name  string
+	value Value
+}
+
+func (e *bytesByteTupleEnumerator) MoveNext() bool {
+	if e.i == 1 {
+		return false
+	}
+	e.i++
+	switch e.i {
+	case 0:
+		e.name = "@"
+		e.value = NewNumber(float64(e.t.at))
+	case 1:
+		e.name = BytesByteAttr
+		e.value = NewNumber(float64(e.t.byteval))
+	}
+	return true
+}
+
+func (e *bytesByteTupleEnumerator) Current() (string, Value) {
+	return e.name, e.value
+}

--- a/rel/value_tuple_bytes_byte_test.go
+++ b/rel/value_tuple_bytes_byte_test.go
@@ -1,0 +1,274 @@
+package rel //nolint:dupl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBytesByteTuple(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		at      int
+		byteval byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want BytesByteTuple
+	}{
+		{name: "default", want: BytesByteTuple{}},
+		{name: "0@0", want: BytesByteTuple{}, args: args{at: 0, byteval: 0}},
+		{name: "0@1", want: BytesByteTuple{at: 1, byteval: 0}, args: args{at: 1, byteval: 0}},
+		{name: "a@0", want: BytesByteTuple{at: 0, byteval: 'a'}, args: args{at: 0, byteval: 'a'}},
+		{name: "a@1", want: BytesByteTuple{at: 1, byteval: 'a'}, args: args{at: 1, byteval: 'a'}},
+		{name: "a@-1", want: BytesByteTuple{at: -1, byteval: 'a'}, args: args{at: -1, byteval: 'a'}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			assert.EqualValues(t, test.want, NewBytesByteTuple(test.args.at, test.args.byteval))
+		})
+	}
+}
+
+func TestNewBytesByteTupleFromTuple(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		t Tuple
+	}
+	tests := []struct {
+		name string
+		args args
+		want BytesByteTuple
+		ok   bool
+	}{
+		{
+			name: "0@0",
+			want: NewBytesByteTuple(0, 0),
+			ok:   true,
+			args: args{t: NewTuple(NewIntAttr("@", 0), NewIntAttr(BytesByteAttr, 0))},
+		},
+		{
+			name: "a@0",
+			want: NewBytesByteTuple(0, 'a'),
+			ok:   true,
+			args: args{t: NewTuple(NewIntAttr("@", 0), NewIntAttr(BytesByteAttr, 'a'))},
+		},
+		{
+			name: "a@42",
+			want: NewBytesByteTuple(42, 'a'),
+			ok:   true,
+			args: args{t: NewTuple(NewIntAttr("@", 42), NewIntAttr(BytesByteAttr, 'a'))},
+		},
+		{
+			name: "no-@",
+			want: BytesByteTuple{},
+			ok:   false,
+			args: args{t: NewTuple(NewIntAttr("at", 0), NewIntAttr(BytesByteAttr, 'a'))},
+		},
+		{
+			name: "no-ByteAttr",
+			want: BytesByteTuple{},
+			ok:   false,
+			args: args{t: NewTuple(NewIntAttr("@", 0), NewIntAttr("byte", 'a'))},
+		},
+	}
+	for _, test := range tests { //nolint:dupl
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := newBytesByteTupleFromTuple(test.args.t)
+			got2 := maybeNewBytesByteTupleFromTuple(test.args.t)
+			if test.ok {
+				assert.True(t, ok)
+				AssertEqualValues(t, test.want, got)
+				AssertEqualValues(t, test.want, got2)
+			} else {
+				assert.False(t, ok)
+				AssertEqualValues(t, test.args.t, got2)
+			}
+		})
+	}
+}
+
+func TestBytesByteTuple_Equal(t *testing.T) {
+	t.Parallel()
+	values := []Value{
+		None,
+		NewNumber(42),
+		NewBytesByteTuple(0, 0),
+		NewBytesByteTuple(0, 'a'),
+		NewBytesByteTuple(42, 0),
+		NewBytesByteTuple(42, 'a'),
+		NewBytesByteTuple(42, 'b'),
+		NewBytesByteTuple(43, 'b'),
+	}
+	for i, x := range values {
+		for j, y := range values {
+			assert.Equal(t, i == j, x.Equal(y), "values[%d]=%v, values[%d]=%v", i, x, j, y)
+		}
+	}
+}
+
+func TestBytesByteTuple_String(t *testing.T) { //nolint:dupl
+	t.Parallel()
+	tests := []struct {
+		name  string
+		tuple BytesByteTuple
+		want  string
+	}{
+		{name: "0@0", want: "(@: 0, @byte: 0)", tuple: NewBytesByteTuple(0, 0)},
+		{name: "a@0", want: "(@: 0, @byte: 97)", tuple: NewBytesByteTuple(0, 'a')},
+		{name: "0@42", want: "(@: 42, @byte: 0)", tuple: NewBytesByteTuple(42, 0)},
+		{name: "a@42", want: "(@: 42, @byte: 97)", tuple: NewBytesByteTuple(42, 'a')},
+		{name: "b@42", want: "(@: 42, @byte: 98)", tuple: NewBytesByteTuple(42, 'b')},
+		{name: "b@43", want: "(@: 43, @byte: 98)", tuple: NewBytesByteTuple(43, 'b')},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, test.tuple.String())
+		})
+	}
+}
+
+func TestBytesByteTuple_Eval(t *testing.T) {
+	t.Parallel()
+	tuple := NewBytesByteTuple(42, 'a')
+	value, err := tuple.Eval(EmptyScope)
+	require.NoError(t, err)
+	assert.Equal(t, tuple, value)
+}
+
+func TestBytesByteTuple_IsTrue(t *testing.T) {
+	t.Parallel()
+	values := []Value{
+		NewBytesByteTuple(0, 0),
+		NewBytesByteTuple(0, 'a'),
+		NewBytesByteTuple(42, 0),
+		NewBytesByteTuple(42, 'z'),
+	}
+	for i, x := range values {
+		assert.True(t, x.IsTrue(), "values[%d]=%v", i, x)
+	}
+}
+
+func TestBytesByteTuple_Less(t *testing.T) {
+	t.Parallel()
+	assert.True(t, !NewBytesByteTuple(0, 0).Less(NewBytesByteTuple(0, 0)))
+	assert.True(t, NewBytesByteTuple(0, 0).Less(NewBytesByteTuple(0, 'a')))
+	assert.True(t, NewBytesByteTuple(0, 'a').Less(NewBytesByteTuple(42, 0)))
+}
+
+func TestBytesByteTuple_Negate(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, NewBytesByteTuple(0, 0), NewBytesByteTuple(0, 0).Negate())
+}
+
+func TestBytesByteTuple_Export(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, map[string]interface{}{"@": 1, "@byte": uint8('a')}, NewBytesByteTuple(1, 'a').Export())
+}
+
+func TestBytesByteTuple_Count(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 2, NewBytesByteTuple(0, 0).Count())
+	assert.Equal(t, 2, NewBytesByteTuple(1, 'a').Count())
+}
+
+func TestBytesByteTuple_Get(t *testing.T) { //nolint:dupl
+	t.Parallel()
+
+	assertGet := func(tuple Tuple, attr string, value Value) {
+		v, has := tuple.Get(attr)
+		if assert.True(t, has) {
+			assert.Equal(t, value, v)
+		}
+	}
+	assertGet(NewBytesByteTuple(1, 'a'), "@", NewNumber(1))
+	assertGet(NewBytesByteTuple(1, 'a'), "@byte", NewNumber('a'))
+
+	assertNotGet := func(tuple Tuple, attr string) bool {
+		v, has := tuple.Get(attr)
+		return assert.False(t, has, "%q => %v", attr, v)
+	}
+	assertNotGet(NewBytesByteTuple(1, 'a'), "@@")
+}
+
+func TestBytesByteTuple_MustGet(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, NewNumber(1), NewBytesByteTuple(1, 'a').MustGet("@"))
+	assert.Equal(t, NewNumber('a'), NewBytesByteTuple(1, 'a').MustGet("@byte"))
+	assert.Panics(t, func() { NewBytesByteTuple(1, 'a').MustGet("byteval") })
+}
+
+func TestBytesByteTuple_With(t *testing.T) {
+	t.Parallel()
+	AssertEqualValues(t, NewBytesByteTuple(42, 'a'), NewBytesByteTuple(1, 'a').With("@", NewNumber(42)))
+	AssertEqualValues(t, NewBytesByteTuple(1, 'b'), NewBytesByteTuple(1, 'a').With("@byte", NewNumber('b')))
+	AssertEqualValues(t, NewTuple(
+		NewIntAttr("@", 1),
+		NewIntAttr("@byte", 'a'),
+		NewIntAttr("x", 'b'),
+	), NewBytesByteTuple(1, 'a').With("x", NewNumber('b')))
+}
+
+func TestBytesByteTuple_Without(t *testing.T) {
+	t.Parallel()
+	AssertEqualValues(t, NewTuple(NewIntAttr("@byte", 'a')), NewBytesByteTuple(1, 'a').Without("@"))
+	AssertEqualValues(t, NewTuple(NewIntAttr("@", 1)), NewBytesByteTuple(1, 'a').Without("@byte"))
+	AssertEqualValues(t, NewBytesByteTuple(1, 'a'), NewBytesByteTuple(1, 'a').Without("x"))
+}
+
+func TestBytesByteTuple_Map(t *testing.T) {
+	t.Parallel()
+	AssertEqualValues(t,
+		NewBytesByteTuple(2, 'b'),
+		NewBytesByteTuple(1, 'a').Map(func(v Value) Value {
+			return NewNumber(v.(Number).Float64() + 1)
+		}),
+	)
+}
+
+func TestBytesByteTuple_HasName(t *testing.T) {
+	t.Parallel()
+	assert.True(t, NewBytesByteTuple(1, 'a').HasName("@"))
+	assert.True(t, NewBytesByteTuple(1, 'a').HasName("@byte"))
+	assert.False(t, NewBytesByteTuple(1, 'a').HasName("@item"))
+}
+
+func TestBytesByteTuple_Attributes(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t,
+		map[string]Value{"@": NewNumber(1), "@byte": NewNumber('a')},
+		NewBytesByteTuple(1, 'a').Attributes())
+}
+
+func TestBytesByteTuple_Names(t *testing.T) {
+	t.Parallel()
+	assert.True(t, NewBytesByteTuple(1, 'a').Names().Equal(NewNames("@", "@byte")))
+}
+
+func TestBytesByteTuple_Project(t *testing.T) {
+	t.Parallel()
+	AssertEqualValues(t,
+		NewTuple(NewIntAttr("@", 1)),
+		NewBytesByteTuple(1, 'a').Project(NewNames("@")))
+	AssertEqualValues(t,
+		NewTuple(NewIntAttr("@byte", 'a')),
+		NewBytesByteTuple(1, 'a').Project(NewNames("@byte")))
+	assert.Nil(t, NewBytesByteTuple(1, 'a').Project(NewNames("x")))
+}
+
+func TestBytesByteTuple_Enumerator(t *testing.T) {
+	t.Parallel()
+	attrs := map[string]int{}
+	for e := NewBytesByteTuple(1, 'a').Enumerator(); e.MoveNext(); {
+		name, value := e.Current()
+		v, has := attrs[name]
+		require.False(t, has, "%q => %v %v", name, v, value)
+		attrs[name] = int(value.(Number).Float64())
+	}
+	assert.Equal(t, map[string]int{"@": 1, "@byte": 'a'}, attrs)
+}

--- a/rel/value_tuple_bytes_byte_test.go
+++ b/rel/value_tuple_bytes_byte_test.go
@@ -164,6 +164,11 @@ func TestBytesByteTuple_Less(t *testing.T) {
 func TestBytesByteTuple_Negate(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, NewBytesByteTuple(0, 0), NewBytesByteTuple(0, 0).Negate())
+	assert.Equal(t, NewBytesByteTuple(-1, 0), NewBytesByteTuple(1, 0).Negate())
+	assert.Equal(t,
+		NewTuple(NewAttr("@", NewNumber(-1)), NewAttr("@byte", NewNumber(-1))),
+		NewBytesByteTuple(1, 1).Negate(),
+	)
 }
 
 func TestBytesByteTuple_Export(t *testing.T) {

--- a/rel/value_tuple_str_char.go
+++ b/rel/value_tuple_str_char.go
@@ -1,4 +1,4 @@
-package rel
+package rel //nolint:dupl
 
 import (
 	"fmt"

--- a/rel/value_tuple_str_char_test.go
+++ b/rel/value_tuple_str_char_test.go
@@ -1,4 +1,4 @@
-package rel
+package rel //nolint:dupl
 
 import (
 	"testing"
@@ -111,7 +111,7 @@ func TestStringCharTuple_Equal(t *testing.T) {
 	}
 }
 
-func TestStringCharTuple_String(t *testing.T) {
+func TestStringCharTuple_String(t *testing.T) { //nolint:dupl
 	t.Parallel()
 	tests := []struct {
 		name  string
@@ -178,7 +178,7 @@ func TestStringCharTuple_Count(t *testing.T) {
 	assert.Equal(t, 2, NewStringCharTuple(1, 'a').Count())
 }
 
-func TestStringCharTuple_Get(t *testing.T) {
+func TestStringCharTuple_Get(t *testing.T) { //nolint:dupl
 	t.Parallel()
 
 	assertGet := func(tuple Tuple, attr string, value Value) {

--- a/syntax/std_os.go
+++ b/syntax/std_os.go
@@ -10,5 +10,6 @@ func stdOs() rel.Attr {
 		rel.NewAttr("cwd", stdOsCwd()),
 		rel.NewNativeFunctionAttr("file", stdOsFile),
 		rel.NewNativeFunctionAttr("get_env", stdOsGetEnv),
+		rel.NewNativeFunctionAttr("&stdin", stdOsStdin),
 	)
 }

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -3,6 +3,7 @@
 package syntax
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 
@@ -41,8 +42,10 @@ func stdOsFile(v rel.Value) rel.Value {
 	return rel.NewBytes(f)
 }
 
+var stdOsStdinHandle io.Reader = os.Stdin
+
 func stdOsStdin(_ rel.Value) rel.Value {
-	f, err := ioutil.ReadAll(os.Stdin)
+	f, err := ioutil.ReadAll(stdOsStdinHandle)
 	if err != nil {
 		panic(err)
 	}

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -3,7 +3,6 @@
 package syntax
 
 import (
-	"io"
 	"io/ioutil"
 	"os"
 
@@ -42,12 +41,4 @@ func stdOsFile(v rel.Value) rel.Value {
 	return rel.NewBytes(f)
 }
 
-var stdOsStdinHandle io.Reader = os.Stdin
-
-func stdOsStdin(_ rel.Value) rel.Value {
-	f, err := ioutil.ReadAll(stdOsStdinHandle)
-	if err != nil {
-		panic(err)
-	}
-	return rel.NewBytes(f)
-}
+var stdOsStdinVar = newStdOsStdin(os.Stdin)

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -40,3 +40,11 @@ func stdOsFile(v rel.Value) rel.Value {
 	}
 	return rel.NewBytes(f)
 }
+
+func stdOsStdin(_ rel.Value) rel.Value {
+	f, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+	return rel.NewBytes(f)
+}

--- a/syntax/std_os_test.go
+++ b/syntax/std_os_test.go
@@ -7,12 +7,15 @@ import (
 
 func TestStdOsStdin(t *testing.T) {
 	// Not parallelisable
-	stdin := stdOsStdinHandle
-	defer func() { stdOsStdinHandle = stdin }()
+	stdin := stdOsStdinVar.reader
+	defer func() { stdOsStdinVar.reset(stdin) }()
 
-	stdOsStdinHandle = bytes.NewBuffer([]byte(""))
+	// Access twice to ensure caching behaves properly.
+	stdOsStdinVar.reset(bytes.NewBuffer([]byte("")))
+	AssertCodesEvalToSameValue(t, `{}`, `//.os.stdin`)
 	AssertCodesEvalToSameValue(t, `{}`, `//.os.stdin`)
 
-	stdOsStdinHandle = bytes.NewBuffer([]byte("abc"))
+	stdOsStdinVar.reset(bytes.NewBuffer([]byte("abc")))
+	AssertCodesEvalToSameValue(t, `{|@,@byte| (0,97), (1,98), (2,99)}`, `//.os.stdin`)
 	AssertCodesEvalToSameValue(t, `{|@,@byte| (0,97), (1,98), (2,99)}`, `//.os.stdin`)
 }

--- a/syntax/std_os_test.go
+++ b/syntax/std_os_test.go
@@ -6,8 +6,13 @@ import (
 )
 
 func TestStdOsStdin(t *testing.T) {
+	// Not parallelisable
 	stdin := stdOsStdinHandle
+	defer func() { stdOsStdinHandle = stdin }()
+
+	stdOsStdinHandle = bytes.NewBuffer([]byte(""))
+	AssertCodesEvalToSameValue(t, `{}`, `//.os.stdin`)
+
 	stdOsStdinHandle = bytes.NewBuffer([]byte("abc"))
 	AssertCodesEvalToSameValue(t, `{|@,@byte| (0,97), (1,98), (2,99)}`, `//.os.stdin`)
-	stdOsStdinHandle = stdin
 }

--- a/syntax/std_os_test.go
+++ b/syntax/std_os_test.go
@@ -1,0 +1,13 @@
+package syntax
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestStdOsStdin(t *testing.T) {
+	stdin := stdOsStdinHandle
+	stdOsStdinHandle = bytes.NewBuffer([]byte("abc"))
+	AssertCodesEvalToSameValue(t, `{|@,@byte| (0,97), (1,98), (2,99)}`, `//.os.stdin`)
+	stdOsStdinHandle = stdin
+}

--- a/syntax/std_os_wasm.go
+++ b/syntax/std_os_wasm.go
@@ -29,3 +29,7 @@ func stdOsCwd() rel.Value {
 func stdOsFile(rel.Value) rel.Value {
 	panic("not implemented")
 }
+
+func stdOsStdin(_ rel.Value) rel.Value {
+	panic("not implemented")
+}

--- a/syntax/std_os_wasm.go
+++ b/syntax/std_os_wasm.go
@@ -30,6 +30,4 @@ func stdOsFile(rel.Value) rel.Value {
 	panic("not implemented")
 }
 
-func stdOsStdin(_ rel.Value) rel.Value {
-	panic("not implemented")
-}
+var stdOsStdinVar = newStdOsStdin(nil)


### PR DESCRIPTION
When accessed, `//.os.stdin` reads stdin into a byte array.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
