### PR TITLE
Handle Bytes in //.json.decode

### DIFF
--- a/syntax/std_encoding_json.go
+++ b/syntax/std_encoding_json.go
@@ -11,10 +11,16 @@ func stdEncodingJSON() rel.Attr {
 	return rel.NewTupleAttr(
 		"json",
 		rel.NewNativeFunctionAttr("decode", func(v rel.Value) rel.Value {
-			s := mustAsString(v)
+			var bytes []byte
+			switch v := v.(type) {
+			case rel.String:
+				bytes = []byte(v.String())
+			case rel.Bytes:
+				bytes = v.Bytes()
+			}
 			var data interface{}
 			var err error
-			if err = json.Unmarshal([]byte(s), &data); err == nil {
+			if err = json.Unmarshal(bytes, &data); err == nil {
 				var d rel.Value
 				if d, err = translate.JSONToArrai(data); err == nil {
 					return d

--- a/syntax/std_encoding_json_test.go
+++ b/syntax/std_encoding_json_test.go
@@ -5,38 +5,41 @@ import "testing"
 func TestJSONDecode(t *testing.T) {
 	t.Parallel()
 	AssertCodePanics(t, `//.encoding.json.decode(123)`)
-	AssertCodesEvalToSameValue(t,
-		`{
-			"a": (s: "string"),
-			"b": 123,
-			"c": 123.321,
-			"d": (a: [1, (s: "string again"), (a: []), {}]),
-			"e": {
-				"f": {
-					"g": (s: "321")
-				},
-				"h": (a: [])
+
+	expected := `{
+		"a": (s: "string"),
+		"b": 123,
+		"c": 123.321,
+		"d": (a: [1, (s: "string again"), (a: []), {}]),
+		"e": {
+			"f": {
+				"g": (s: "321")
 			},
-			"i": (null: {}),
-			"j": (a: [(b: {()}), (b: {})]),
-			"k": (s: {})
-		}`,
-		`//.encoding.json.decode(
-			'{
-				"a": "string",
-				"b": 123,
-				"c": 123.321,
-				"d": [1, "string again", [], {}],
-				"e": {
-					"f": {
-						"g": "321"
-					},
-					"h": []
-				},
-				"i": null,
-				"j": [true, false],
-				"k": ""
-			}'
-		)`,
-	)
+			"h": (a: [])
+		},
+		"i": (null: {}),
+		"j": (a: [(b: {()}), (b: {})]),
+		"k": (s: {})
+	}`
+
+	encoding := `'{
+		"a": "string",
+		"b": 123,
+		"c": 123.321,
+		"d": [1, "string again", [], {}],
+		"e": {
+			"f": {
+				"g": "321"
+			},
+			"h": []
+		},
+		"i": null,
+		"j": [true, false],
+		"k": ""
+	}'`
+
+	// String
+	AssertCodesEvalToSameValue(t, expected, `//.encoding.json.decode(`+encoding+`)`)
+	// Bytes
+	AssertCodesEvalToSameValue(t, expected, `//.encoding.json.decode(//.unicode.utf8.encode(`+encoding+`))`)
 }


### PR DESCRIPTION
Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation

Don't yet have a way to express byte arrays easily, so testing will be added later #97.