### PR TITLE
Add import for json format(#65)

### DIFF
--- a/examples/json/foo.json
+++ b/examples/json/foo.json
@@ -1,0 +1,4 @@
+{
+    "name": "foo",
+    "location": "Melbourne"
+}

--- a/syntax/package_test.go
+++ b/syntax/package_test.go
@@ -32,8 +32,20 @@ func TestPackageImport(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `{1, 4, 9, 16}`, `//./examples/simple/simple`)
 }
 
+func TestPackageImportWithQuote(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `{1, 4, 9, 16}`, `//./'examples/simple/simple'`)
+}
+
 func TestPackageImportFromRoot(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `{1, 4, 9, 16}`, `///examples/simple/simple`)
+}
+
+func TestJsonPackageImportFromModuleRoot(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `{'location': 'Melbourne', 'name': 'foo'}`, `///examples/json/foo.json`)
+}
+
+func TestJsonPackageImport(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `{'location': 'Melbourne', 'name': 'foo'}`, `//./examples/json/foo.json`)
 }
 
 // func TestPackageExternalImport(t *testing.T) {


### PR DESCRIPTION
Fixes #65  .

Changes proposed in this pull request:
- syntax parse update grammar for local package to include file extension 
- change way to walk through the ast tree in local package

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
