### PR TITLE
Implicitly named attrs

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -157,7 +157,8 @@ The core syntax for literals can expresses numbers, tuples and sets.
    * **(⛔NYI)** Octal: `0o173`
    * **(⛔NYI)** Binary: `0b 111 1011`
 
-2. Tuples: `()`, `(a:1)`, `('t.m.o.l.': 42)`, `(x: (a: (), b: 2), y: -3i)`
+2. Tuples: `()`, `(a:1)`, `('t.m.o.l.': 42)`, `(x: (a: (), b: 2), y: -3i)`,
+   `(:x, :y)`
 
    Like structs in the C family of languages, names are not values in their own
    right. They cannot be stored in variables or data structures and therefore
@@ -169,6 +170,10 @@ The core syntax for literals can expresses numbers, tuples and sets.
    tuples do not have to conform to definitions stipulating the available fields
    or the types of values they can hold. A tuple can have any fields and each
    fields can hold any value of any type.
+
+   As an extension to the normal `key: value` syntax, attributes may omit `key`
+   if `value` is an expression of the form `name` or `expr.name`. E.g.: `(:x,
+   :.y, :a.b.z) = (x: x, y: y, z: a.b.z)`.
 
 3. Sets: `{}`, `{1, 2, 3}`, `{(a:1, b:2), (a:4, b:7)}`, `{2, {}, (c:4)}`
 

--- a/syntax/expr_tuple_test.go
+++ b/syntax/expr_tuple_test.go
@@ -33,3 +33,10 @@ func TestTupleCallGet(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `2`, `(a: \x (b: x)).a(2).b`)
 	AssertCodesEvalToSameValue(t, `2`, `let t = (a: \x (b: x)); t.a(2).b`)
 }
+
+func TestTupleLiteral(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; let y = 2; (x: x, y: y)`)
+	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; let y = 2; (:x, :y)`)
+	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let t = (x: 1, y: 2); (:t.x, :t.y)`)
+	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `(x: 1, y: 2) -> (:.x, :.y)`)
+}

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -1,6 +1,7 @@
 package syntax
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
@@ -64,7 +65,7 @@ expr   -> C* amp="&"* @ C* arrow=(
                    | "." std=IDENT?
                    | http=/{https?://}? fqdn=name:"." ("/" path=name)*
                    )
-        | C* "(" tuple=(pairs=(name ":" v=@ | ":" vk=(@ "." k=IDENT)):",",?) ")" C*
+        | C* "(" tuple=(pairs=(name? ":" v=@):",",?) ")" C*
         | C* "(" @ ")" C*
         | C* let=("let" C* IDENT C* "=" C* @ %%bind C* ";" C* @) C*
         | C* xstr C*
@@ -132,7 +133,7 @@ func parseName(name ast.Branch) string {
 		s := children.(ast.One).Node.One("").(ast.Leaf).Scanner().String()
 		return parseArraiString(s)
 	default:
-		panic("wat?")
+		panic(fmt.Errorf("unexpected name: %v", name))
 	}
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Support unnamed tuple attributes, e.g.: `(:x, :t.y)`.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
