### PR TITLE
add //.net.http.get and documentation

### DIFF
--- a/docs/std-net.md
+++ b/docs/std-net.md
@@ -1,0 +1,67 @@
+# net library
+
+## http
+
+### get
+
+`//.net.http.get(url)` sends a GET request to the provided URl and returns
+a tuple that represents the response.
+
+The schema of the response is the following:
+| attribute | content |
+|:-|:-|
+| `status` | a string that represents the status of the response e.g. `200 OK` |
+| `status_code` | a number that represents the status code of the response e.g. `200` |
+| `header` | a tuple that represents the header of the response, the attributes are the header field and the values are array of strings e.g. `("Content-Type": ["application/json; charset=utf-8"])` |
+| `body` | an array of bytes that represents the body of the response |
+
+#### example
+
+Expression:
+```
+//.net.http.get("https://raw.githubusercontent.com/arr-ai/arrai/cf1326f7b61178e3e98aff30540e10cb73449445/Makefile")
+```
+
+Result:
+```
+(
+  body: "all: test lint wasm
+
+# TODO: If this Makefile is ever used for CI, suppress timingsensitive there.
+test:
+	go test $(GOTESTFLAGS) -tags timingsensitive ./...
+
+lint:
+	golangci-lint run
+
+wasm:
+	GOOS=js GOARCH=wasm go build -o /tmp/arrai.wasm ./cmd/arrai"
+  ,
+  header:(
+    'Accept-Ranges': ['bytes'],
+    'Access-Control-Allow-Origin': ['*'],
+    'Cache-Control': ['max-age=300'],
+    'Connection': ['keep-alive'],
+    'Content-Security-Policy': ["default-src 'none'; style-src 'unsafe-inline'; sandbox"],
+    'Content-Type': ['text/plain; charset=utf-8'],
+    'Date': ['Mon, 13 Apr 2020 12:17:00 GMT'],
+    'Etag': ['W/"d7460fe5d998b2f25ba976ca6ef6646215c0b3314608fb5462a48f6412334f13"'],
+    'Expires': ['Mon, 13 Apr 2020 12:22:00 GMT'],
+    'Source-Age': ['246'],
+    'Strict-Transport-Security': ['max-age=31536000'],
+    'Vary': ['Authorization,Accept-Encoding'],
+    'Via': ['1.1 varnish (Varnish/6.0)', '1.1 varnish'],
+    'X-Cache': ['MISS, HIT'],
+    'X-Cache-Hits': ['0, 1'],
+    'X-Content-Type-Options': ['nosniff'],
+    'X-Fastly-Request-Id': ['fe13435de8287048b85b80e6057b941d3470dea6'],
+    'X-Frame-Options': ['deny'],
+    'X-Github-Request-Id': ['8956:2496:13C90C:1631AA:5E945745'],
+    'X-Served-By': ['cache-mel19034-MEL'],
+    'X-Timer': ['S1586780220.448718,VS0,VE1'],
+    'X-Xss-Protection': ['1; mode=block']
+    ),
+  status: '200 OK',
+  status_code: 200
+)
+```

--- a/docs/std-net.md
+++ b/docs/std-net.md
@@ -7,13 +7,18 @@
 `//.net.http.get(url)` sends a GET request to the provided URl and returns
 a tuple that represents the response.
 
-The schema of the response is the following:
-| attribute | content |
-|:-|:-|
-| `status` | a string that represents the status of the response e.g. `200 OK` |
-| `status_code` | a number that represents the status code of the response e.g. `200` |
-| `header` | a tuple that represents the header of the response, the attributes are the header field and the values are array of strings e.g. `("Content-Type": ["application/json; charset=utf-8"])` |
-| `body` | an array of bytes that represents the body of the response |
+The schema of the response is a tuple, as follows:
+```
+(
+    status: "200 OK", # A string indicating the status of the response
+    status_code: 200, # A number indicating the status code of the response
+    header: (         # A tuple containing the response header
+        "Content-Type": ["application/json; charset=utf-8"],
+        ...,
+    ),
+    body: ...,        # The body of the response as a byte array
+)
+```
 
 #### example
 

--- a/syntax/std.go
+++ b/syntax/std.go
@@ -90,6 +90,7 @@ func stdScope() rel.Scope {
 				stdOs(),
 				stdEncoding(),
 				stdUnicode(),
+				stdNet(),
 			))
 	})
 	return stdScopeVar

--- a/syntax/std_net.go
+++ b/syntax/std_net.go
@@ -1,0 +1,45 @@
+package syntax
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/arr-ai/arrai/rel"
+)
+
+func stdNet() rel.Attr {
+	return rel.NewTupleAttr(
+		"net",
+		rel.NewTupleAttr(
+			"http",
+			rel.NewNativeFunctionAttr("get", func(v rel.Value) rel.Value {
+				resp, err := http.Get(mustAsString(v))
+				if err != nil {
+					panic(err)
+				}
+
+				buf, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					panic(err)
+				}
+				defer resp.Body.Close()
+
+				header := rel.NewTuple()
+				for k, vs := range resp.Header {
+					vals := make([]rel.Value, 0, len(vs))
+					for _, v := range vs {
+						vals = append(vals, rel.NewString([]rune(v)))
+					}
+					header = header.With(k, rel.NewArray(vals...))
+				}
+
+				return rel.NewTuple(
+					rel.NewAttr("status", rel.NewString([]rune(resp.Status))),
+					rel.NewAttr("status_code", rel.NewNumber(float64(resp.StatusCode))),
+					rel.NewAttr("header", header),
+					rel.NewAttr("body", rel.NewBytes(buf)),
+				)
+			}),
+		),
+	)
+}

--- a/syntax/std_net_test.go
+++ b/syntax/std_net_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/arr-ai/arrai/rel"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,15 +32,13 @@ wasm:
 	)
 	require.NoError(t, err)
 
-	assert.True(t, expectedBody.Equal(result.(rel.Tuple).MustGet("body")))
-	assert.True(t, expectedStatus.Equal(result.(rel.Tuple).MustGet("status")))
-	assert.True(t, expectedStatusCode.Equal(result.(rel.Tuple).MustGet("status_code")))
-	assert.True(t, rel.
-		NewArray(expectedContentType).
-		Equal(
-			result.(rel.Tuple).
-				MustGet("header").(rel.Tuple).
-				MustGet("Content-Type"),
-		),
+	rel.AssertEqualValues(t, expectedBody, result.(rel.Tuple).MustGet("body"))
+	rel.AssertEqualValues(t, expectedStatus, result.(rel.Tuple).MustGet("status"))
+	rel.AssertEqualValues(t, expectedStatusCode, result.(rel.Tuple).MustGet("status_code"))
+	rel.AssertEqualValues(t,
+		rel.NewArray(expectedContentType),
+		result.(rel.Tuple).
+			MustGet("header").(rel.Tuple).
+			MustGet("Content-Type"),
 	)
 }

--- a/syntax/std_net_test.go
+++ b/syntax/std_net_test.go
@@ -1,0 +1,47 @@
+package syntax
+
+import (
+	"testing"
+
+	"github.com/arr-ai/arrai/rel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetGet(t *testing.T) {
+	t.Parallel()
+
+	expectedBody := rel.NewBytes([]byte(`all: test lint wasm
+
+# TODO: If this Makefile is ever used for CI, suppress timingsensitive there.
+test:
+	go test $(GOTESTFLAGS) -tags timingsensitive ./...
+
+lint:
+	golangci-lint run
+
+wasm:
+	GOOS=js GOARCH=wasm go build -o /tmp/arrai.wasm ./cmd/arrai
+`))
+	expectedStatus := rel.NewString([]rune("200 OK"))
+	expectedStatusCode := rel.NewNumber(float64(200))
+	expectedContentType := rel.NewString([]rune("text/plain; charset=utf-8"))
+
+	result, err := EvaluateExpr(
+		"",
+		`//.net.http.get("https://raw.githubusercontent.com/arr-ai/arrai/cf1326f7b61178e3e98aff30540e10cb73449445/Makefile")`,
+	)
+	require.NoError(t, err)
+
+	assert.True(t, expectedBody.Equal(result.(rel.Tuple).MustGet("body")))
+	assert.True(t, expectedStatus.Equal(result.(rel.Tuple).MustGet("status")))
+	assert.True(t, expectedStatusCode.Equal(result.(rel.Tuple).MustGet("status_code")))
+	assert.True(t, rel.
+		NewArray(expectedContentType).
+		Equal(
+			result.(rel.Tuple).
+				MustGet("header").(rel.Tuple).
+				MustGet("Content-Type"),
+		),
+	)
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Add basic `//.net.http.get` and test 
- Add documentation

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
