### PR TITLE
Tidy up import path syntax

### DIFF
--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -318,25 +318,14 @@ func (pc ParseContext) compilePackage(c ast.Children) rel.Expr {
 		pkgName := ident.(ast.Leaf).Scanner().String()
 		return NewPackageExpr(rel.NewDotExpr(rel.DotIdent, pkgName))
 	}
-	if local := pkg["local"]; local != nil {
+	if names := pkg.Many("name"); len(names) > 0 {
 		var sb strings.Builder
-		var pkgPathList []ast.Node
-		localTree := local.(ast.Many)[0].(ast.Node)
-		pkgNode := ast.First(localTree, "pkgname")
-		pkgBranch := ast.First(pkgNode, "PKG_PATH")
-		if pkgBranch != nil {
-			pkgPath := ast.First(pkgBranch, "PATH")
-			pkgPathList = ast.All(pkgPath, "")
-		} else {
-			pkgSTR := ast.First(pkgNode, "STR")
-			pkgPathList = ast.All(pkgSTR, "")
-		}
 
-		for i, p := range pkgPathList {
+		for i, name := range names {
 			if i > 0 {
 				sb.WriteRune('/')
 			}
-			sb.WriteString(strings.Trim(p.Scanner().String(), "'"))
+			sb.WriteString(parseName(name.(ast.Branch)))
 		}
 		filepath := sb.String()
 		if pc.SourceDir == "" {

--- a/syntax/package_test.go
+++ b/syntax/package_test.go
@@ -41,11 +41,11 @@ func TestPackageImportFromRoot(t *testing.T) {
 }
 
 func TestJsonPackageImportFromModuleRoot(t *testing.T) {
-	AssertCodesEvalToSameValue(t, `{'location': 'Melbourne', 'name': 'foo'}`, `///examples/json/foo.json`)
+	AssertCodesEvalToSameValue(t, `{'location': 'Melbourne', 'name': 'foo'}`, `///examples/json/'foo.json'`)
 }
 
 func TestJsonPackageImport(t *testing.T) {
-	AssertCodesEvalToSameValue(t, `{'location': 'Melbourne', 'name': 'foo'}`, `//./examples/json/foo.json`)
+	AssertCodesEvalToSameValue(t, `{'location': 'Melbourne', 'name': 'foo'}`, `//./examples/json/'foo.json'`)
 }
 
 // func TestPackageExternalImport(t *testing.T) {

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -52,7 +52,7 @@ expr   -> C* amp="&"* @ C* arrow=(
                       expr (":" end=expr? (":" step=expr)?)?
                       |     ":" end=expr  (":" step=expr)?
                   ):",",
-			  ")")
+              ")")
           )* C*
         > C* "{" C* rel=(names tuple=("(" v=@:",", ")"):",",?) "}" C*
         | C* "{" C* set=(elt=@:",",?) "}" C*
@@ -61,10 +61,10 @@ expr   -> C* amp="&"* @ C* arrow=(
         | C* "{:" C* embed=(grammar=@ ":" subgrammar=%%ast) ":}" C*
         | C* op="\\\\" @ C*
         | C* fn="\\" IDENT @ C*
-		| C* "//" pkg=( dot="."? ("/" local=pkgname)+
-                   | "." std=IDENT?
-                   | http=/{https?://}? fqdn=name:"." ("/" path=name)*
-                   )
+        | C* "//" pkg=( dot="."? ("/" name)+
+                      | "." std=IDENT?
+                      | http=/{https?://}? fqdn=name:"." ("/" path=name)*
+                      )
         | C* "(" tuple=(pairs=(name? ":" v=@):",",?) ")" C*
         | C* "(" @ ")" C*
         | C* let=("let" C* IDENT C* "=" C* @ %%bind C* ";" C* @) C*
@@ -78,7 +78,6 @@ touch  -> C* ("->*" ("&"? IDENT | STR))+ "(" expr:"," ","? ")" C*;
 get    -> C* dot="." ("&"? IDENT | STR | "*") C*;
 names  -> C* "|" C* IDENT:"," C* "|" C*;
 name   -> C* IDENT C* | C* STR C*;
-pkgname -> C* PKG_PATH C* | C* STR C*;
 xstr   -> C* quote=/{\$"\s*} part=( sexpr | fragment=/{(?: \\. | \$[^{"] | [^\\"$] )+} )* '"' C*
         | C* quote=/{\$'\s*} part=( sexpr | fragment=/{(?: \\. | \$[^{'] | [^\\'$] )+} )* "'" C*
         | C* quote=/{\$‵\s*} part=( sexpr | fragment=/{(?: ‵‵  | \$[^{‵] | [^‵  $] )+} )* "‵" C*;
@@ -89,10 +88,6 @@ sexpr  -> "${"
 
 ARROW  -> /{:>|=>|>>|orderby|order|where|sum|max|mean|median|min};
 IDENT  -> /{ \. | [$@A-Za-z_][0-9$@A-Za-z_]* };
-PKG_PATH ->  \s* PATH {
-    PATH    -> /{[a-zA-Z0-9._]+}:"/";
-    .wrapRE -> /{()};
-};
 STR    -> /{ " (?: \\. | [^\\"] )* "
            | ' (?: \\. | [^\\'] )* '
            | ‵ (?: ‵‵  | [^‵  ] )* ‵


### PR DESCRIPTION
Changes proposed in this pull request:
- Reinterpret `//./a.b` as equivalent to `(//./a).b` (currently equivalent to`//./'a.b'`.
- Consequently, importing files with extensions will require string-name syntax: `//./'a.b'`.

Checklist:
- [x] Added/updated related tests
- [x] Made corresponding changes to the documentation
