### PR TITLE
Parallelise workflow build job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,7 +79,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test]
     steps:
 
     - name: Set up Go 1.13


### PR DESCRIPTION
Changes proposed in this pull request:
- Removes dependency of `build` job on [lint, test], thus allowing faster CI completion.
- 

Checklist:
- [x] Added related tests (n/a)
- [x] Made corresponding changes to the documentation (n/a)
