### PR TITLE
Cleaner array detection and usage

### DIFF
--- a/rel/value_set_array.go
+++ b/rel/value_set_array.go
@@ -28,9 +28,16 @@ func NewOffsetArray(offset int, values ...Value) Set {
 }
 
 func AsArray(s Set) (Array, bool) {
-	if s, ok := s.(Array); ok {
+	switch s := s.(type) {
+	case Array:
 		return s, true
+	case Set:
+		return Array{}, !s.IsTrue()
 	}
+	return Array{}, false
+}
+
+func asArray(s Set) (Array, bool) {
 	if i := s.Enumerator(); i.MoveNext() {
 		t, is := i.Current().(ArrayItemTuple)
 		if !is {

--- a/rel/value_set_generic.go
+++ b/rel/value_set_generic.go
@@ -60,7 +60,7 @@ func NewSet(values ...Value) Set {
 				for _, value := range values {
 					set = set.With(value)
 				}
-				array, is := AsArray(set)
+				array, is := asArray(set)
 				if !is {
 					panic("unsupported array expr")
 				}

--- a/syntax/std_str.go
+++ b/syntax/std_str.go
@@ -43,15 +43,18 @@ var (
 
 		var s string
 		if delim := mustAsString(args[2]); strings.HasPrefix(delim, ":") {
-			var sb strings.Builder
-			n := 0
-			for i, ok := args[1].(rel.Set).ArrayEnumerator(); ok && i.MoveNext(); n++ {
-				if n > 0 {
-					sb.WriteString(delim[1:])
+			if array, is := rel.AsArray(args[1].(rel.Set)); is {
+				var sb strings.Builder
+				for i, value := range array.Values() {
+					if i > 0 {
+						sb.WriteString(delim[1:])
+					}
+					sb.WriteString(formatValue(format, value))
 				}
-				sb.WriteString(formatValue(format, i.Current()))
+				s = sb.String()
+			} else {
+				panic(fmt.Errorf("arg not an array in ${arg::}: %v", args[1]))
 			}
-			s = sb.String()
 		} else {
 			s = formatValue(format, args[1])
 		}


### PR DESCRIPTION
Changes proposed in this pull request:
- Rework `AsArray` to be more efficient by assuming an array-like `Set` is always an `Array`.
- Keep original `AsArray` as `asArray` for internal use.

Checklist:
- [n/a] Added related tests (existing)
- [n/a] Made corresponding changes to the documentation (no language change)