### PR TITLE
fix compare dict entry tuple key

### DIFF
--- a/rel/value_tuple_dict_entry.go
+++ b/rel/value_tuple_dict_entry.go
@@ -90,7 +90,7 @@ func (t DictEntryTuple) Less(v Value) bool {
 		return t.Kind() < v.Kind()
 	}
 	u := v.(DictEntryTuple)
-	if t.at != u.at {
+	if !t.at.Equal(u.at) {
 		return t.at.Less(u.at)
 	}
 	return t.value.Less(u.value)


### PR DESCRIPTION
A fix to use the `Equal` method to compare the keys in dictionary entry tuple
