### PR TITLE
fix index method of Array, String, and Bytes

### DIFF
--- a/rel/value_set_array.go
+++ b/rel/value_set_array.go
@@ -265,7 +265,7 @@ func (a Array) Call(arg Value) Value {
 
 func (a Array) index(pos int) int {
 	pos -= a.offset
-	if 0 <= pos && pos < len(a.values) {
+	if 0 <= pos && pos <= len(a.values) {
 		return pos
 	}
 	return -1

--- a/rel/value_set_array.go
+++ b/rel/value_set_array.go
@@ -223,7 +223,7 @@ func (a Array) With(value Value) Set {
 // was already absent, the original Array is returned.
 func (a Array) Without(value Value) Set {
 	if t, ok := value.(ArrayItemTuple); ok {
-		if i := a.index(t.at); i >= 0 && t.item == a.values[i] {
+		if i := a.index(t.at); i >= 0 && i < len(a.values) && t.item == a.values[i] {
 			if t.at == a.offset {
 				return Array{values: a.values[1:], offset: a.offset + 1}
 			}

--- a/rel/value_set_bytes.go
+++ b/rel/value_set_bytes.go
@@ -186,7 +186,7 @@ func (b Bytes) With(value Value) Set {
 // was already absent, the original Bytes is returned.
 func (b Bytes) Without(value Value) Set {
 	if pos, byt, ok := isBytesTuple(value); ok {
-		if i := b.index(pos); i >= 0 && byt == b.b[i] {
+		if i := b.index(pos); i >= 0 && i < len(b.b) && byt == b.b[i] {
 			if pos == b.offset+i {
 				return Bytes{b: b.b[:i], offset: b.offset}
 			}

--- a/rel/value_set_bytes.go
+++ b/rel/value_set_bytes.go
@@ -225,7 +225,7 @@ func (b Bytes) Call(arg Value) Value {
 
 func (b Bytes) index(pos int) int {
 	pos -= b.offset
-	if 0 <= pos && pos < len(b.b) {
+	if 0 <= pos && pos <= len(b.b) {
 		return pos
 	}
 	return -1

--- a/rel/value_set_str.go
+++ b/rel/value_set_str.go
@@ -179,7 +179,7 @@ func (s String) With(value Value) Set {
 // was already absent, the original String is returned.
 func (s String) Without(value Value) Set {
 	if t, ok := value.(StringCharTuple); ok {
-		if i := s.index(t.at); i >= 0 && t.char == s.s[i] {
+		if i := s.index(t.at); i >= 0 && i < len(s.s) && t.char == s.s[i] {
 			if t.at == s.offset+i {
 				return String{s: s.s[:i], offset: s.offset}
 			}

--- a/rel/value_set_str.go
+++ b/rel/value_set_str.go
@@ -218,7 +218,7 @@ func (s String) Call(arg Value) Value {
 
 func (s String) index(pos int) int {
 	pos -= s.offset
-	if 0 <= pos && pos < len(s.s) {
+	if 0 <= pos && pos <= len(s.s) {
 		return pos
 	}
 	return -1


### PR DESCRIPTION
the index method will not allow returning `len(array.values)`, it affects appending values to the array. This change will allow that.