### PR TITLE
allow multiline expression in arrai interactive shell

### DIFF
--- a/cmd/arrai/shell.go
+++ b/cmd/arrai/shell.go
@@ -122,8 +122,7 @@ func shell(c *cli.Context) error {
 			if err != nil {
 				log.Error(ctx, err)
 			} else {
-				cleaned := strings.Split(rel.Repr(value), "\\n")
-				fmt.Fprintf(os.Stdout, "%s\n", strings.Join(cleaned, "\n"))
+				fmt.Fprintf(os.Stdout, "%s\n", rel.Repr(value))
 			}
 			l.SetPrompt("@> ")
 			collector.reset()

--- a/cmd/arrai/shell_test.go
+++ b/cmd/arrai/shell_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLineCollectorAppendLine(t *testing.T) {
+	t.Parallel()
+
+	c := newLineCollector()
+
+	// testing string with no opener
+	c.appendLine("random string")
+	assert.Equal(t, []string{"random string"}, c.lines)
+	assert.True(t, c.isBalanced())
+	c.reset()
+
+	// basic testing string with opener
+	c.appendLine("random {")
+	assert.Equal(t, []string{"random {"}, c.lines)
+	assert.Equal(t, 1, len(c.stack))
+	assert.Equal(t, "}", c.stack[0].char)
+	assert.Equal(t, true, c.stack[0].recursive)
+	assert.False(t, c.isBalanced())
+	c.appendLine("}")
+	assert.Equal(t, []string{"random {", "}"}, c.lines)
+	assert.Equal(t, 0, len(c.stack))
+	assert.True(t, c.isBalanced())
+	c.reset()
+
+	// testing with multiple openers
+	c.appendLine("{([")
+	assert.Equal(t, 3, len(c.stack))
+	assert.Equal(t, "}", c.stack[0].char)
+	assert.Equal(t, ")", c.stack[1].char)
+	assert.Equal(t, "]", c.stack[2].char)
+	c.appendLine("])}")
+	assert.Equal(t, 0, len(c.stack))
+	assert.True(t, c.isBalanced())
+	c.reset()
+
+	// testing context based opener
+	c.appendLine("nested closer $'{([")
+	c.appendLine("${")
+	assert.Equal(t, []string{"nested closer $'{([", "${"}, c.lines)
+	assert.Equal(t, 2, len(c.stack))
+	assert.Equal(t, "'", c.stack[0].char)
+	assert.Equal(t, true, c.stack[0].recursive)
+	assert.Equal(t, "}", c.stack[1].char)
+	assert.Equal(t, true, c.stack[1].recursive)
+	c.appendLine("}")
+	assert.Equal(t, 1, len(c.stack))
+	assert.Equal(t, "'", c.stack[0].char)
+	assert.Equal(t, true, c.stack[0].recursive)
+	c.appendLine("'")
+	assert.Equal(t, 0, len(c.stack))
+	assert.True(t, c.isBalanced())
+	c.reset()
+
+	// testing non recursive opener
+	c.appendLine("'")
+	c.appendLine("\"")
+	assert.Equal(t, []string{"'", "\""}, c.lines)
+	assert.Equal(t, 1, len(c.stack))
+	c.appendLine("'")
+	assert.Equal(t, 0, len(c.stack))
+	assert.True(t, c.isBalanced())
+	c.reset()
+
+	// testing escape
+	c.appendLine("`\"`")
+	assert.True(t, c.isBalanced())
+}
+
+func TestIsBalanced(t *testing.T) {
+	t.Parallel()
+
+	c := newLineCollector()
+	assert.True(t, c.isBalanced())
+
+	c.appendLine("random;")
+	assert.False(t, c.isBalanced())
+
+	c.appendLine("\\a \\b \\c")
+	assert.False(t, c.isBalanced())
+
+	c.appendLine("c:")
+	assert.False(t, c.isBalanced())
+
+	c.appendLine("\"")
+	assert.False(t, c.isBalanced())
+
+	c.appendLine("\"")
+	assert.True(t, c.isBalanced())
+}
+

--- a/cmd/arrai/shell_test.go
+++ b/cmd/arrai/shell_test.go
@@ -95,4 +95,3 @@ func TestIsBalanced(t *testing.T) {
 	c.appendLine("\"")
 	assert.True(t, c.isBalanced())
 }
-


### PR DESCRIPTION
Part of #163.

Changes proposed in this pull request:
- Allow multiline expression in arrai interactive shell

Current problem:
There's no way to get out of multiline mode. You have to make a balanced expression.

Checklist:
- [x] Added related tests (added automated test but unable to simulate real use case, but so far no errors)
- [ ] Made corresponding changes to the documentation
