### PR TITLE
fix multiline balance check for arrai argument

### DIFF
--- a/cmd/arrai/shell.go
+++ b/cmd/arrai/shell.go
@@ -233,7 +233,7 @@ func (l *lineCollector) isBalanced() bool {
 	}
 
 	// check for function argument
-	if regexp.MustCompile(`\\.+$`).Match([]byte(lastLine)) {
+	if regexp.MustCompile(`\\[^ \t\n]+$`).Match([]byte(lastLine)) {
 		return false
 	}
 

--- a/cmd/arrai/shell_test.go
+++ b/cmd/arrai/shell_test.go
@@ -102,5 +102,4 @@ func TestIsBalanced(t *testing.T) {
 
 	c.appendLine(`let f = \x \y`)
 	assert.False(t, c.isBalanced())
-	c.reset()
 }

--- a/cmd/arrai/shell_test.go
+++ b/cmd/arrai/shell_test.go
@@ -94,4 +94,13 @@ func TestIsBalanced(t *testing.T) {
 
 	c.appendLine("\"")
 	assert.True(t, c.isBalanced())
+	c.reset()
+
+	c.appendLine(`let f = \x \y x + y; f(3, 4)`)
+	assert.True(t, c.isBalanced())
+	c.reset()
+
+	c.appendLine(`let f = \x \y`)
+	assert.False(t, c.isBalanced())
+	c.reset()
 }


### PR DESCRIPTION
initially to check if a line ends in an argument `\a \b`, it checks
with the regex `\\.+$` which fails on cases like
```
let f = \x \y x + y; f(3, 4)
```

Checklist:
- [x] Added related tests

