### PR TITLE
replaced multiline prompt to ' > '

### DIFF
--- a/cmd/arrai/shell.go
+++ b/cmd/arrai/shell.go
@@ -144,7 +144,7 @@ func (s *shellInstance) parseCmd(line string, l *readline.Instance) error {
 		}
 	}
 	if len(s.collector.lines) != 0 {
-		l.SetPrompt("@: ")
+		l.SetPrompt(" > ")
 	}
 	return nil
 }


### PR DESCRIPTION
Now multiline prompts look like this
```bash
@> let a = 42;
 > let b = 54;
 > a + b
```