### PR TITLE
Fix #188, //rel.union accepts set of sets

### DIFF
--- a/docs/std-rel.md
+++ b/docs/std-rel.md
@@ -2,12 +2,11 @@
 
 The `rel` library contains functions for relational operations.
 
-## `//rel.union(s <: set_of_sets|array_of_sets) <: set`
+## `//rel.union(s <: set_of_sets) <: set`
 
-`union` takes either a set of sets or an array of sets `s` and does a union operation on
-each member of `s`. It returns the unioned sets.
+`union` takes a set of sets `s` and does a union operation on each member of `s`.
+It returns the unioned sets.
 
 | example | equals |
 |:-|:-|
-| `//rel.union([{1, 2}, {3, 4, 2, 10}, {4, 5, 'another', 'duplicate'}, {'duplicate'}])` | `{1, 2, 3, 4, 5, 10, 'another', 'duplicate'}` |
 | `//rel.union({{1, 2}, {3, 4, 2, 10}, {4, 5, 'another', 'duplicate'}, {'duplicate'}})` | `{1, 2, 3, 4, 5, 10, 'another', 'duplicate'}` |

--- a/docs/std-rel.md
+++ b/docs/std-rel.md
@@ -2,11 +2,12 @@
 
 The `rel` library contains functions for relational operations.
 
-## `//rel.union(s <: array_of_sets) <: set`
+## `//rel.union(s <: set_of_sets|array_of_sets) <: set`
 
-`union` takes an array of sets `s` and does a union operation on each member of `s`. It
-returns the unioned sets.
+`union` takes either a set of sets or an array of sets `s` and does a union operation on
+each member of `s`. It returns the unioned sets.
 
 | example | equals |
 |:-|:-|
 | `//rel.union([{1, 2}, {3, 4, 2, 10}, {4, 5, 'another', 'duplicate'}, {'duplicate'}])` | `{1, 2, 3, 4, 5, 10, 'another', 'duplicate'}` |
+| `//rel.union({{1, 2}, {3, 4, 2, 10}, {4, 5, 'another', 'duplicate'}, {'duplicate'}})` | `{1, 2, 3, 4, 5, 10, 'another', 'duplicate'}` |

--- a/examples/grpc/grpc-proto.arrai
+++ b/examples/grpc/grpc-proto.arrai
@@ -16,17 +16,17 @@ let endpoints = app.endpoints where !//str.has_prefix(.@item.name, "enum ");
             message ${.key} {
                 ${.fields >> proto.field(.)::\i}
             }`::\n\i:\n}
-        ${//rel.union(app.types >> proto.imports(.fields))::\i:\n}
+        ${//rel.union((app.types >> proto.imports(.fields)) => .@item)::\i:\n}
         ${app.alias >> $`
             message ${.key} {
                 string alias${.type} = 1;
             }`::}
         ${$`
-            ${//rel.union(endpoints >> (.params >> $`
+            ${//rel.union((endpoints >> (.params >> $`
                 import "${//str.sub(grpc.type(.), ".", "/")}.proto";`
                     if //str.contains(grpc.type(.), "google.protobuf")
                 => .@item
-            ))::\i:\n}
+            )) => .@item)::\i:\n}
             service ${app.name} {
                 ${endpoints >> (proto.endpointInfo(.)).rpcMethod::\i}
             }

--- a/syntax/std_rel.go
+++ b/syntax/std_rel.go
@@ -9,7 +9,18 @@ func stdRel() rel.Attr {
 		rel.NewNativeFunctionAttr("union", func(v rel.Value) rel.Value {
 			s := v.(rel.Set)
 			sets := make([]rel.Set, 0, s.Count())
-			for e, ok := s.ArrayEnumerator(); ok && e.MoveNext(); {
+			var e rel.ValueEnumerator
+			switch u := v.(type) {
+			case rel.Array:
+				var ok bool
+				e, ok = u.ArrayEnumerator()
+				if !ok {
+					panic("wat")
+				}
+			case rel.Set:
+				e = u.Enumerator()
+			}
+			for e.MoveNext() {
 				sets = append(sets, e.Current().(rel.Set))
 			}
 			return rel.NUnion(sets...)

--- a/syntax/std_rel.go
+++ b/syntax/std_rel.go
@@ -9,18 +9,7 @@ func stdRel() rel.Attr {
 		rel.NewNativeFunctionAttr("union", func(v rel.Value) rel.Value {
 			s := v.(rel.Set)
 			sets := make([]rel.Set, 0, s.Count())
-			var e rel.ValueEnumerator
-			switch u := v.(type) {
-			case rel.Array:
-				var ok bool
-				e, ok = u.ArrayEnumerator()
-				if !ok {
-					panic("wat")
-				}
-			case rel.Set:
-				e = u.Enumerator()
-			}
-			for e.MoveNext() {
+			for e := s.Enumerator(); e.MoveNext(); {
 				sets = append(sets, e.Current().(rel.Set))
 			}
 			return rel.NUnion(sets...)

--- a/syntax/std_rel_test.go
+++ b/syntax/std_rel_test.go
@@ -9,8 +9,4 @@ func TestRelUnion(t *testing.T) {
 	AssertCodeEvalsToType(t, `{1, 2, 3}   `, `//rel.union({{1}, {2}, {3}})         `)
 	AssertCodeEvalsToType(t, `{1}         `, `//rel.union({{1}, {1}, {1}})         `)
 	AssertCodeEvalsToType(t, `{}          `, `//rel.union({})                      `)
-	AssertCodeEvalsToType(t, `{1, 2, 3, 4}`, `//rel.union([{1, 2}, {2, 3}, {3, 4}])`)
-	AssertCodeEvalsToType(t, `{1, 2, 3}   `, `//rel.union([{1}, {2}, {3}])         `)
-	AssertCodeEvalsToType(t, `{1}         `, `//rel.union([{1}, {1}, {1}])         `)
-	AssertCodeEvalsToType(t, `{}          `, `//rel.union([])                      `)
 }

--- a/syntax/std_rel_test.go
+++ b/syntax/std_rel_test.go
@@ -1,0 +1,16 @@
+package syntax
+
+import "testing"
+
+func TestRelUnion(t *testing.T) {
+	t.Parallel()
+
+	AssertCodeEvalsToType(t, `{1, 2, 3, 4}`, `//rel.union({{1, 2}, {2, 3}, {3, 4}})`)
+	AssertCodeEvalsToType(t, `{1, 2, 3}   `, `//rel.union({{1}, {2}, {3}})         `)
+	AssertCodeEvalsToType(t, `{1}         `, `//rel.union({{1}, {1}, {1}})         `)
+	AssertCodeEvalsToType(t, `{}          `, `//rel.union({})                      `)
+	AssertCodeEvalsToType(t, `{1, 2, 3, 4}`, `//rel.union([{1, 2}, {2, 3}, {3, 4}])`)
+	AssertCodeEvalsToType(t, `{1, 2, 3}   `, `//rel.union([{1}, {2}, {3}])         `)
+	AssertCodeEvalsToType(t, `{1}         `, `//rel.union([{1}, {1}, {1}])         `)
+	AssertCodeEvalsToType(t, `{}          `, `//rel.union([])                      `)
+}


### PR DESCRIPTION
Fixes #188  .

Changes proposed in this pull request:
- `//rel.union` can now take an array of sets or set of sets

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
