### PR TITLE
Fix #199, add command `arrai file.arrai`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ echo {0..10} | ax '2^.'
 ```
 -->
 
+### Run an arrai file
+
+```bash
+arrai path/to/file.arrai
+```
+
+or use the `run` command
+
+```bash
+arrai run path/to/file.arrai
+```
+
+`arrai run` can be used to avoid ambiguity between filename and a command.
+For example, running an arrai file named `run`.
+
 ### Start a server
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ arrai run path/to/file.arrai
 ```
 
 `arrai run` can be used to avoid ambiguity between filename and a command.
-For example, running an arrai file named `run`.
+For example, running an arrai file named `run` (`arrai run run`). Alternatively, include a
+subdirectory component in the filename (`arrai ./run`).
 
 ### Start a server
 

--- a/cmd/arrai/file_util.go
+++ b/cmd/arrai/file_util.go
@@ -8,9 +8,10 @@ import (
 
 func isExecCommand(arg string, cmds []*cli.Command) bool {
 	for _, cmd := range cmds {
-		names := append(make([]string, 0, 1+len(cmd.Aliases)), cmd.Name)
-		names = append(names, cmd.Aliases...)
-		for _, name := range names {
+		if arg == cmd.Name {
+			return true
+		}
+		for _, name := range cmd.Aliases {
 			if arg == name {
 				return true
 			}

--- a/cmd/arrai/file_util.go
+++ b/cmd/arrai/file_util.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+func isExecCommand(arg string, cmds []*cli.Command) bool {
+	for _, cmd := range cmds {
+		names := append(make([]string, 0, 1+len(cmd.Aliases)), cmd.Name)
+		names = append(names, cmd.Aliases...)
+		for _, name := range names {
+			if arg == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fetchCommand(args []string) string {
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "-") {
+			return arg
+		}
+	}
+	return ""
+}

--- a/cmd/arrai/file_util_test.go
+++ b/cmd/arrai/file_util_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsExecCommand(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isExecCommand("eval", cmds))
+	assert.True(t, isExecCommand("e", cmds))
+	assert.False(t, isExecCommand("./eval", cmds))
+	assert.False(t, isExecCommand("eval.arrai", cmds))
+	assert.False(t, isExecCommand("file", cmds))
+}
+
+func TestFetchCommand(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"command",
+		fetchCommand([]string{"-flag", "--flag", "command"}),
+	)
+
+	assert.Equal(t,
+		"command",
+		fetchCommand([]string{"-flag", "command", "--flag"}),
+	)
+
+	assert.Equal(t,
+		"",
+		fetchCommand([]string{"-flag", "-flag-again", "--flag"}),
+	)
+}

--- a/cmd/arrai/main.go
+++ b/cmd/arrai/main.go
@@ -8,13 +8,25 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var cmds = []*cli.Command{
+	shellCommand,
+	runCommand,
+	evalCommand,
+	jsonCommand,
+	observeCommand,
+	serveCommand,
+	syncCommand,
+	transformCommand,
+	updateCommand,
+}
+
 func main() {
 	app := cli.NewApp()
 	// logrus.SetLevel(logrus.InfoLevel)
 
 	app.EnableBashCompletion = true
-
-	switch path.Base(os.Args[0]) {
+	args := os.Args
+	switch path.Base(args[0]) {
 	case "ai":
 		app.Name = "ai"
 		app.Usage = "arr.ai interactive shell"
@@ -26,21 +38,42 @@ func main() {
 	default:
 		app.Name = "arrai"
 		app.Usage = "the ultimate data engine"
-
-		app.Commands = []*cli.Command{
-			shellCommand,
-			runCommand,
-			evalCommand,
-			jsonCommand,
-			observeCommand,
-			serveCommand,
-			syncCommand,
-			transformCommand,
-			updateCommand,
+		app.Commands = cmds
+		if len(os.Args) > 1 {
+			if execCmd := fetchCommand(args[1:]); execCmd != "" && !isExecCommand(execCmd, app.Commands) {
+				tmpArgs := append(make([]string, 0, 1+len(args)), args[0], "run")
+				args = append(tmpArgs, args[1:]...)
+			}
 		}
+		//nolint:lll
+		cli.AppHelpTemplate = `NAME:
+   {{.Name}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
+
+   or
+
+   {{.HelpName}} [global options] filepath [arguments...]
+   {{if len .Authors}}
+AUTHOR:
+   {{range .Authors}}{{ . }}{{end}}
+   {{end}}{{if .Commands}}
+COMMANDS:
+{{range .Commands}}{{if not .HideHelp}}   {{join .Names ", "}}{{ "\t"}}{{.Usage}}{{ "\n" }}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+GLOBAL OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}{{if .Copyright }}
+COPYRIGHT:
+   {{.Copyright}}
+   {{end}}{{if .Version}}
+VERSION:
+   {{.Version}}
+   {{end}}
+`
 	}
 
-	err := app.Run(os.Args)
+	err := app.Run(args)
 	if err != nil {
 		logrus.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #199 .

Changes proposed in this pull request:
- you can run arrai script by doing the command `arrai path/to/file.arrai`

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
