### PR TITLE
Fix #203, add bitmask and intset functions to stdlib

### DIFF
--- a/docs/std-bits.md
+++ b/docs/std-bits.md
@@ -4,7 +4,7 @@ The `bits` library contains functions related to bit operations.
 
 ## `//bits.set(n <: number) <: set`
 
-`set` takes in the bitmask `n` and returns a set of number representing `n`.
+`set` takes in the bitmask `n` and returns a set of integers representing `n`.
 The set itself contains the positions of 1-bits in the binary representation
 of `n`
 

--- a/docs/std-bits.md
+++ b/docs/std-bits.md
@@ -4,9 +4,9 @@ The `bits` library contains functions related to bit operations.
 
 ## `//bits.set(n <: number) <: set`
 
-`set` takes in the number `n` and returns a set representing the
-bitmask of `n`. The set itself contains positions of `1`-bits of
-the binary representation of `n`
+`set` takes in the bitmask `n` and returns a set of number representing `n`.
+The set itself contains the positions of 1-bits in the binary representation
+of `n`
 
 `n` must be non-negative number.
 
@@ -20,9 +20,8 @@ Usage:
 
 ## `//bits.mask(s <: set) <: number`
 
-`mask` does the opposite of set. It takes a bitmask in the form
-of a set of numbers `s` and returns a numerical value represented
-by the bitmask.
+`mask` is the inverse of `set`. It takes a set `s` which represents the position
+of 1-bits in a binary representation of a bitmask and returns the bitmask.
 
 `s` must be a set of numbers.
 

--- a/docs/std-bits.md
+++ b/docs/std-bits.md
@@ -1,0 +1,35 @@
+# bits
+
+The `bits` library contains functions related to bit operations.
+
+## `//bits.set(n <: number) <: set`
+
+`set` takes in the number `n` and returns a set representing the
+bitmask of `n`. The set itself contains positions of `1`-bits of
+the binary representation of `n`
+
+`n` must be non-negative number.
+
+Usage:
+
+| example | equals |
+|:-|:-|
+|`//bits.set(42)` | `{1, 3, 5}` |
+|`//bits.set(72061992084439040)` | `{42, 56}` |
+|`//bits.set(0)` | `{}` |
+
+## `//bits.mask(s <: set) <: number`
+
+`mask` does the opposite of set. It takes a bitmask in the form
+of a set of numbers `s` and returns a numerical value represented
+by the bitmask.
+
+`s` must be a set of numbers.
+
+Usage:
+
+| example | equals |
+|:-|:-|
+|`//bits.mask({1, 3, 5})` | `42` |
+|`//bits.mask({42, 56})` | `72061992084439040` |
+|`//bits.mask({})` | `0` |

--- a/docs/std-bits.md
+++ b/docs/std-bits.md
@@ -8,7 +8,7 @@ The `bits` library contains functions related to bit operations.
 The set itself contains the positions of 1-bits in the binary representation
 of `n`
 
-`n` must be non-negative number.
+`n` must be a non-negative number.
 
 Usage:
 

--- a/docs/std.md
+++ b/docs/std.md
@@ -7,6 +7,7 @@ The arr.ai standard library is available via the `//` syntax.
 The following standard packages are available:
 
 - [`//archive`](std-archive.md): Archive format utilities
+- [`//bits`](std-bits.md): Bit utilities
 - [`//encoding`](std-encoding.md): Support for encoded data processing
 - [`//eval`](std-eval.md): Evaluate strings holding arr.ai code
 - [`//fn`](std-fn.md): Function manipulation utilities

--- a/syntax/std.go
+++ b/syntax/std.go
@@ -93,6 +93,7 @@ func StdScope() rel.Scope {
 				stdSeq(),
 				stdStr(),
 				stdUnicode(),
+				stdBits(),
 			))
 	})
 	return stdScopeVar

--- a/syntax/std_bits.go
+++ b/syntax/std_bits.go
@@ -1,0 +1,51 @@
+package syntax
+
+import (
+	"math"
+	"math/bits"
+
+	"github.com/arr-ai/arrai/rel"
+)
+
+func stdBits() rel.Attr {
+	return rel.NewTupleAttr("bits",
+		rel.NewNativeFunctionAttr("mask", mask),
+		rel.NewNativeFunctionAttr("set", set),
+	)
+}
+
+func set(v rel.Value) rel.Value {
+	n, isNumber := v.(rel.Number)
+	if !isNumber || float64(n) < 0 {
+		panic("argument has to be non-negative number")
+	}
+	var bitmask []rel.Value
+	if float64(n) == float64(int(n)) {
+		bitmask = setInt(int(n))
+	} else {
+		bitmask = maskFloat(float64(n))
+	}
+	return rel.NewSet(bitmask...)
+}
+
+func setInt(v int) (bitmask []rel.Value) {
+	for ; v != 0; v &= (v - 1) {
+		bitmask = append(bitmask, rel.NewNumber(float64(bits.TrailingZeros64(uint64(v)))))
+	}
+	return
+}
+
+func maskFloat(v float64) (bitmask []rel.Value) {
+	panic("unimplemented")
+}
+
+func mask(v rel.Value) rel.Value {
+	if s, isSet := v.(rel.Set); isSet {
+		var n float64
+		for e := s.Enumerator(); e.MoveNext(); {
+			n += math.Pow(2, float64(e.Current().(rel.Number)))
+		}
+		return rel.NewNumber(n)
+	}
+	panic("argument has to be a Set")
+}

--- a/syntax/std_bits_test.go
+++ b/syntax/std_bits_test.go
@@ -1,0 +1,29 @@
+package syntax
+
+import "testing"
+
+func TestBitsSetInt(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `{42, 56} `, `//bits.set(72061992084439040)`)
+	AssertCodesEvalToSameValue(t, `{1, 3, 5}`, `//bits.set(42)               `)
+	AssertCodesEvalToSameValue(t, `{7}      `, `//bits.set(128)              `)
+	AssertCodesEvalToSameValue(t, `{0}      `, `//bits.set(1)                `)
+	AssertCodesEvalToSameValue(t, `{}       `, `//bits.set(0)                `)
+
+	assertExprPanics(t, `//bits.set({})`)
+	assertExprPanics(t, `//bits.set(-1)`)
+}
+
+func TestBitsMask(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `72061992084439040`, `//bits.mask({42, 56}) `)
+	AssertCodesEvalToSameValue(t, `42               `, `//bits.mask({1, 3, 5})`)
+	AssertCodesEvalToSameValue(t, `128              `, `//bits.mask({7})      `)
+	AssertCodesEvalToSameValue(t, `1                `, `//bits.mask({0})      `)
+	AssertCodesEvalToSameValue(t, `0                `, `//bits.mask({})       `)
+
+	assertExprPanics(t, `//bits.mask({"number"})`)
+	assertExprPanics(t, `//bits.mask(3)         `)
+}


### PR DESCRIPTION
Fixes #203  .

Changes proposed in this pull request:
- Add `//bits.mask` and `//bits.set`

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
