### PR TITLE
Fix #204, {()} always print true

### DIFF
--- a/rel/value_repr.go
+++ b/rel/value_repr.go
@@ -94,7 +94,7 @@ func reprDict(d Dict, w io.Writer) {
 }
 
 func reprSet(s GenericSet, w io.Writer) {
-	if s == True {
+	if s.Equal(True) {
 		fmt.Fprintf(w, "true")
 		return
 	}

--- a/rel/value_repr.go
+++ b/rel/value_repr.go
@@ -94,6 +94,10 @@ func reprDict(d Dict, w io.Writer) {
 }
 
 func reprSet(s GenericSet, w io.Writer) {
+	if s == True {
+		fmt.Fprintf(w, "true")
+		return
+	}
 	fmt.Fprint(w, "{")
 	var sep reprCommaSep
 	for _, v := range s.OrderedValues() {


### PR DESCRIPTION
Fixes #204  .

Changes proposed in this pull request:
- `{()}` now is printed as `true`
