### PR TITLE
enable stdlib completion in the middle of an expression

### DIFF
--- a/cmd/arrai/shell.go
+++ b/cmd/arrai/shell.go
@@ -121,9 +121,8 @@ func (s *shellInstance) Do(line []rune, pos int) (newLine [][]rune, length int) 
 		if l == "//" {
 			newLine = append(newLine, []rune("{"))
 		}
-		return
 	}
-	return newLine, length
+	return
 }
 
 func getLastToken(line []rune) string {

--- a/cmd/arrai/shell.go
+++ b/cmd/arrai/shell.go
@@ -117,7 +117,7 @@ func (s *shellInstance) Do(line []rune, pos int) (newLine [][]rune, length int) 
 			names = strings.Split(l[2:], ".")
 			lastName, names = names[len(names)-1], names[:len(names)-1]
 		}
-		newLine, length = s.getScopePredictions(names, lastName)
+		newLine, length = getScopePredictions(names, lastName, s.scope.MustGet(".").(rel.Tuple))
 		if l == "//" {
 			newLine = append(newLine, []rune("{"))
 		}
@@ -151,21 +151,20 @@ func isAlpha(l rune) bool {
 	return (l >= 'a' && l <= 'z') || (l >= 'A' && l <= 'Z')
 }
 
-func (s *shellInstance) getScopePredictions(tuplePath []string, name string) ([][]rune, int) {
+func getScopePredictions(tuplePath []string, name string, scope rel.Tuple) ([][]rune, int) {
 	var newLine [][]rune
 	length := len(name)
-	t := s.scope.MustGet(".").(rel.Tuple)
 	for _, attr := range tuplePath {
-		if value, has := t.Get(attr); has {
+		if value, has := scope.Get(attr); has {
 			if u, is := value.(rel.Tuple); is {
-				t = u
+				scope = u
 				continue
 			}
 		}
 		return nil, 0
 	}
 
-	for _, attr := range t.Names().OrderedNames() {
+	for _, attr := range scope.Names().OrderedNames() {
 		if strings.HasPrefix(attr, name) {
 			newLine = append(newLine, []rune(attr[length:]))
 		}

--- a/cmd/arrai/shell_test.go
+++ b/cmd/arrai/shell_test.go
@@ -1,8 +1,13 @@
+//nolint:unparam
 package main
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/arr-ai/arrai/rel"
+	"github.com/arr-ai/arrai/syntax"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -115,4 +120,58 @@ func TestGetLastToken(t *testing.T) {
 	assert.Equal(t, "tuple.", getLastToken([]rune("//str.contains(tuple.")))
 	assert.Equal(t, "", getLastToken([]rune("//str.contains(")))
 	assert.Equal(t, "", getLastToken([]rune("")))
+}
+
+func TestTabCompletionStdlib(t *testing.T) {
+	t.Parallel()
+	stdlib := syntax.StdScope().MustGet(".").(rel.Tuple)
+	stdlibNames := stdlib.Names().OrderedNames()
+
+	assertTabCompletion(t, append(stdlibNames, "{"), 0, "//\t", nil)
+	assertTabCompletion(t, append(stdlibNames, "{"), 0, "//str.contains(//\t", nil)
+	prefix := "s"
+
+	assertTabCompletionWithPrefix(t, prefix, stdlibNames, "//%s\t", nil)
+	assertTabCompletionWithPrefix(t, prefix, stdlibNames, "x(//%s\t", nil)
+	assertTabCompletionWithPrefix(t, prefix, stdlibNames, "x(//%s\t + random)", nil)
+
+	lib := "str"
+	strlib := stdlib.MustGet(lib).(rel.Tuple).Names().OrderedNames()
+	assertTabCompletionWithPrefix(t, prefix, strlib, "//"+lib+".%s\t", nil)
+}
+
+func assertTabCompletionWithPrefix(
+	t *testing.T,
+	prefix string,
+	choices []string,
+	format string,
+	scopeValues map[string]rel.Expr,
+) {
+	var libWithPrefix []string
+	for _, c := range choices {
+		if strings.HasPrefix(c, prefix) {
+			libWithPrefix = append(libWithPrefix, strings.TrimPrefix(c, prefix))
+		}
+	}
+	assertTabCompletion(t, libWithPrefix, len(prefix), fmt.Sprintf(format, prefix), scopeValues)
+}
+
+func assertTabCompletion(t *testing.T,
+	expectedPredictions []string,
+	expectedLength int,
+	line string,
+	scopeValues map[string]rel.Expr,
+) {
+	scope := syntax.StdScope()
+	for name, expr := range scopeValues {
+		scope = scope.With(name, expr)
+	}
+	sh := newShellInstance(newLineCollector(), scope)
+	predictions, length := sh.Do([]rune(line), strings.Index(line, "\t"))
+	strPredictions := make([]string, 0, len(predictions))
+	for _, p := range predictions {
+		strPredictions = append(strPredictions, string(p))
+	}
+	assert.Equal(t, expectedPredictions, strPredictions)
+	assert.Equal(t, expectedLength, length)
 }

--- a/cmd/arrai/shell_test.go
+++ b/cmd/arrai/shell_test.go
@@ -103,3 +103,16 @@ func TestIsBalanced(t *testing.T) {
 	c.appendLine(`let f = \x \y`)
 	assert.False(t, c.isBalanced())
 }
+
+func TestGetLastToken(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "//str", getLastToken([]rune("//str")))
+	assert.Equal(t, "//", getLastToken([]rune("//")))
+	assert.Equal(t, "///", getLastToken([]rune("///")))
+	assert.Equal(t, "//", getLastToken([]rune("//str.contains(//")))
+	assert.Equal(t, "//arch", getLastToken([]rune("//str.contains(//arch")))
+	assert.Equal(t, "tuple.", getLastToken([]rune("//str.contains(tuple.")))
+	assert.Equal(t, "", getLastToken([]rune("//str.contains(")))
+	assert.Equal(t, "", getLastToken([]rune("")))
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Initially completion relies on a line beginning with `//` to check
if it is trying to access stdlib. This commit allows getting the
last token and do a completion based on that token. It allows
completion in the middle of an expression.
 

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
