### PR TITLE
Fix without operator

### DIFF
--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -5,7 +5,7 @@ expr   -> C* amp="&"* @ C* arrow=(
               binding="->" C* "\\" C* IDENT C* %%bind C* @ |
               binding="->" C* %%bind @
           )* C*
-        > C* @:binop=("with" | "without") C*
+        > C* @:binop=("without" | "with") C*
         > C* @:binop="||" C*
         > C* @:binop="&&" C*
         > C* @:compare=/{!?(?:<:|<>?=?|>=?|=)} C*

--- a/syntax/expr_set_with_without_test.go
+++ b/syntax/expr_set_with_without_test.go
@@ -1,0 +1,25 @@
+package syntax
+
+import "testing"
+
+func TestExprSetWith(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `{{}}`, `{} with {}`)
+	AssertCodesEvalToSameValue(t, `{{}}`, `{{}} with {}`)
+	AssertCodesEvalToSameValue(t, `{{}, 1}`, `{1} with {}`)
+	AssertCodesEvalToSameValue(t, `{{}, 1}`, `{1, {}} with {}`)
+	AssertCodesEvalToSameValue(t, `{1}`, `{} with 1`)
+	AssertCodesEvalToSameValue(t, `{1}`, `{1} with 1`)
+	AssertCodesEvalToSameValue(t, `{1, {}}`, `{{}} with 1`)
+	AssertCodesEvalToSameValue(t, `{1, {}}`, `{{}, 1} with 1`)
+}
+
+func TestExprSetWithout(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `{}`, `{} without {}`)
+	AssertCodesEvalToSameValue(t, `{}`, `{{}} without {}`)
+	AssertCodesEvalToSameValue(t, `{1}`, `{1} without {}`)
+	AssertCodesEvalToSameValue(t, `{1}`, `{1, {}} without {}`)
+	AssertCodesEvalToSameValue(t, `{}`, `{} without 1`)
+	AssertCodesEvalToSameValue(t, `{{}}`, `{{}} without 1`)
+	AssertCodesEvalToSameValue(t, `{}`, `{1} without 1`)
+	AssertCodesEvalToSameValue(t, `{{}}`, `{1, {}} without 1`)
+}

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -19,7 +19,7 @@ expr   -> C* amp="&"* @ C* arrow=(
               binding="->" C* "\\" C* IDENT C* %%bind C* @ |
               binding="->" C* %%bind @
           )* C*
-        > C* @:binop=("with" | "without") C*
+        > C* @:binop=("without" | "with") C*
         > C* @:binop="||" C*
         > C* @:binop="&&" C*
         > C* @:compare=/{!?(?:<:|<>?=?|>=?|=)} C*


### PR DESCRIPTION
Fixes #177.

Changes proposed in this pull request:
- Swap `with` and `without` in parser so that `with` doesn't suppress `without` under PEG semantics.

Checklist:
- [x] Added related tests
- [n/a] Made corresponding changes to the documentation
