### PR TITLE
make install arrai, ai and ax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 all: parser test lint wasm
 
+install: all
+	go install ./cmd/arrai
+	[ -f $$(dirname $$(which arrai))/ai ] || ln -s arrai $$(dirname $$(which arrai))/ai
+	[ -f $$(dirname $$(which arrai))/ax ] || ln -s arrai $$(dirname $$(which arrai))/ax
+
 test:
 	go test $(GOTESTFLAGS) -tags timingsensitive ./...
 

--- a/rel/test_helpers.go
+++ b/rel/test_helpers.go
@@ -16,13 +16,13 @@ func intSet(elts ...interface{}) Set {
 	return result
 }
 
-func equalValues(expected, actual Value) bool {
+func EqualValues(expected, actual Value) bool {
 	return expected == nil && actual == nil || expected.Equal(actual)
 }
 
 // AssertEqualValues asserts that the two values are Equal.
 func AssertEqualValues(t *testing.T, expected, actual Value) bool {
-	if !equalValues(expected, actual) {
+	if !EqualValues(expected, actual) {
 		return assert.Fail(t, "values not equal", "expected: %s\nactual:   %s", expected, actual)
 	}
 	return true
@@ -45,7 +45,7 @@ func AssertExprsEvalToSameValue(t *testing.T, expected, expr Expr) bool {
 	if !assert.NoError(t, err, "evaluating expr: %s", expr) {
 		return false
 	}
-	return equalValues(expectedValue, value) ||
+	return EqualValues(expectedValue, value) ||
 		assert.Failf(t, "values not equal",
 			"\nexpected: %v\nactual:   %v\nexpr:     %v",
 			Repr(expectedValue), Repr(value), expr)

--- a/rel/value_set_native_func.go
+++ b/rel/value_set_native_func.go
@@ -1,6 +1,7 @@
 package rel
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/arr-ai/hash"
@@ -97,7 +98,16 @@ func (f *NativeFunction) Export() interface{} {
 }
 
 // Call calls the NativeFunction with the given parameter.
-func (f *NativeFunction) Call(expr Expr, local Scope) (Value, error) {
+func (f *NativeFunction) Call(expr Expr, local Scope) (_ Value, err error) {
+	defer func() {
+		switch r := recover().(type) {
+		case nil:
+		case error:
+			panic(wrapContext(r, expr))
+		default:
+			panic(wrapContext(fmt.Errorf("unexpected panic calling %s: %v", f, r), expr))
+		}
+	}()
 	if expr == nil {
 		return f.fn(nil), nil
 	}

--- a/syntax/std.go
+++ b/syntax/std.go
@@ -92,6 +92,7 @@ func StdScope() rel.Scope {
 				stdRel(),
 				stdSeq(),
 				stdStr(),
+				stdTest(),
 				stdUnicode(),
 				stdBits(),
 			))

--- a/syntax/std_tst.go
+++ b/syntax/std_tst.go
@@ -1,0 +1,44 @@
+package syntax
+
+import (
+	"fmt"
+
+	"github.com/arr-ai/arrai/rel"
+)
+
+func createTestCompareFuncAttr(name string, ok func(a, b rel.Value) bool, message string) rel.Attr {
+	return createNestedFuncAttr(name, 2, func(args ...rel.Value) rel.Value {
+		expected := args[0]
+		actual := args[1]
+		if !ok(expected, actual) {
+			panic(fmt.Errorf("%s\nexpected: %v\nactual:   %v", message, expected, actual))
+		}
+		return rel.None
+	})
+}
+
+func createTestCheckFuncAttr(name string, ok func(v rel.Value) bool) rel.Attr {
+	return rel.NewNativeFunctionAttr(name, func(value rel.Value) rel.Value {
+		if !ok(value) {
+			panic(fmt.Errorf("not %s\nvalue: %v", name, value))
+		}
+		return rel.None
+	})
+}
+
+func stdTest() rel.Attr {
+	return rel.NewTupleAttr("test",
+		rel.NewTupleAttr("assert",
+			createTestCompareFuncAttr("equal", func(e, a rel.Value) bool { return e.Equal(a) }, "not equal"),
+			createTestCompareFuncAttr("unequal", func(e, a rel.Value) bool { return !e.Equal(a) }, "not unequal"),
+			createTestCompareFuncAttr("size", func(e, a rel.Value) bool {
+				return int(e.(rel.Number).Float64()) == a.(rel.Set).Count()
+			}, "unexpected size"),
+			createTestCheckFuncAttr("false", func(v rel.Value) bool { return !v.IsTrue() }),
+			createTestCheckFuncAttr("true", func(v rel.Value) bool { return v.IsTrue() }),
+		),
+		rel.NewNativeFunctionAttr("suite", func(value rel.Value) rel.Value {
+			return nil
+		}),
+	)
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- `make install` installs arrai and creates symlinks `ai` and `ax`.

Checklist:
- [n/a] Added related tests
- [n/a] Made corresponding changes to the documentation
    - Currently, there are no install-from-source instructions
