### PR TITLE
fix `` escape in shell

### DIFF
--- a/cmd/arrai/shell.go
+++ b/cmd/arrai/shell.go
@@ -260,6 +260,10 @@ func (l *lineCollector) appendLine(line string) {
 		if line[i] == '\\' {
 			increment = 2
 		} else if nextCloser := l.peek(); nextCloser != nil && strings.HasPrefix(line[i:], nextCloser.char) {
+			if nextCloser.char == "`" && strings.HasPrefix(line[i:], "``") {
+				increment = 2
+				continue
+			}
 			l.pop()
 			increment = len(nextCloser.char)
 		} else {

--- a/cmd/arrai/shell_test.go
+++ b/cmd/arrai/shell_test.go
@@ -74,6 +74,16 @@ func TestLineCollectorAppendLine(t *testing.T) {
 	assert.True(t, c.isBalanced())
 	c.reset()
 
+	// testing `` escape
+	c.appendLine("`stuff``")
+	assert.Equal(t, []string{"`stuff``"}, c.lines)
+	assert.Equal(t, 1, len(c.stack))
+	assert.False(t, c.isBalanced())
+	c.appendLine("`")
+	assert.Equal(t, 0, len(c.stack))
+	assert.True(t, c.isBalanced())
+	c.reset()
+
 	// testing escape
 	c.appendLine("`\"`")
 	assert.True(t, c.isBalanced())


### PR DESCRIPTION
Allows backtick escape

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
