### PR TITLE
fix #213, string escape no longer triggers multiline mode

### DIFF
--- a/cmd/arrai/shell.go
+++ b/cmd/arrai/shell.go
@@ -257,9 +257,9 @@ func newLineCollector() *lineCollector {
 func (l *lineCollector) appendLine(line string) {
 	increment := 1
 	for i := 0; i < len(line); i += increment {
-		if line[i] == '\\' {
+		if nextCloser := l.peek(); line[i] == '\\' && nextCloser != nil && nextCloser.char != "`" {
 			increment = 2
-		} else if nextCloser := l.peek(); nextCloser != nil && strings.HasPrefix(line[i:], nextCloser.char) {
+		} else if nextCloser != nil && strings.HasPrefix(line[i:], nextCloser.char) {
 			if nextCloser.char == "`" && strings.HasPrefix(line[i:], "``") {
 				increment = 2
 				continue
@@ -307,7 +307,7 @@ func (l *lineCollector) isBalanced() bool {
 	}
 
 	// check for function argument
-	if regexp.MustCompile(`\\[^ \t\n]+$`).Match([]byte(lastLine)) {
+	if regexp.MustCompile(`\\([$@A-Za-z_][0-9$@A-Za-z_]*|\.)$`).Match([]byte(lastLine)) {
 		return false
 	}
 

--- a/cmd/arrai/shell_test.go
+++ b/cmd/arrai/shell_test.go
@@ -85,7 +85,10 @@ func TestLineCollectorAppendLine(t *testing.T) {
 	c.reset()
 
 	// testing escape
-	c.appendLine("`\"`")
+	c.appendLine("'\\\"'")
+	c.appendLine("'\\\\'")
+	c.appendLine("'\\n'")
+	c.appendLine("`\\`")
 	assert.True(t, c.isBalanced())
 }
 

--- a/cmd/arrai/shell_test.go
+++ b/cmd/arrai/shell_test.go
@@ -104,6 +104,12 @@ func TestIsBalanced(t *testing.T) {
 	c.appendLine("\\a \\b \\c")
 	assert.False(t, c.isBalanced())
 
+	c.appendLine("\\.")
+	assert.False(t, c.isBalanced())
+
+	c.appendLine("\\a random")
+	assert.True(t, c.isBalanced())
+
 	c.appendLine("c:")
 	assert.False(t, c.isBalanced())
 


### PR DESCRIPTION
Fixes #213 .

Changes proposed in this pull request:
- string escape isn't considered as an argument

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
