### PR TITLE
Support tuples in pattern matching

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Let us know about an unexpected error, a crash, or an incorrect behavior.
-labels: bug
+
 ---
 
 Please **do not post any internal, closed source snippets** on this public issue tracker!

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Let us know about an unexpected error, a crash, or an incorrect behavior.
-
+labels: bug
 ---
 
 Please **do not post any internal, closed source snippets** on this public issue tracker!

--- a/rel/expr_ident.go
+++ b/rel/expr_ident.go
@@ -56,3 +56,7 @@ func (e IdentExpr) Eval(local Scope) (Value, error) {
 	}
 	return nil, IdentLookupFailed{local, e}
 }
+
+func (e IdentExpr) Bind(scope Scope, value Value) Scope {
+	return EmptyScope.With(e.ident, value)
+}

--- a/rel/pattern.go
+++ b/rel/pattern.go
@@ -24,6 +24,24 @@ func ExprAsPattern(expr Expr) Pattern {
 	}
 }
 
+type IdentPattern struct {
+	ident string
+}
+
+func NewIdentPattern(ident string) IdentPattern {
+	return IdentPattern{ident}
+}
+
+func (p IdentPattern) Bind(scope Scope, value Value) Scope {
+	scope.MustGet(p.ident)
+	scope.MatchedWith(p.ident, value)
+	return EmptyScope.With(p.ident, value)
+}
+
+func (p IdentPattern) String() string {
+	return p.ident
+}
+
 type ArrayPattern struct {
 	items []Pattern
 }
@@ -49,7 +67,6 @@ func (p ArrayPattern) Bind(scope Scope, value Value) Scope {
 		if len(array.Values()) < i+1 {
 			panic(fmt.Sprintf("length of value %s shorter than array pattern %s", array.Values(), p.items))
 		}
-		scope.MatchedUpdate(item.Bind(scope, array.Values()[i]))
 		result = result.MatchedUpdate(item.Bind(scope, array.Values()[i]))
 	}
 
@@ -111,7 +128,6 @@ func (p TuplePattern) Bind(scope Scope, value Value) Scope {
 	result := EmptyScope
 	for _, attr := range p.attrs {
 		tupleExpr := tuple.MustGet(attr.name)
-		scope.MatchedUpdate(attr.pattern.Bind(scope, tupleExpr))
 		result = result.MatchedUpdate(attr.pattern.Bind(scope, tupleExpr))
 	}
 

--- a/rel/pattern.go
+++ b/rel/pattern.go
@@ -5,27 +5,12 @@ import (
 	"fmt"
 )
 
+// Pattern can be inside an Expr, Expr can be a Pattern.
 type Pattern interface {
 	// Require a String() method.
 	fmt.Stringer
 
 	Bind(scope Scope, value Value) Scope
-}
-
-type IdentPattern struct {
-	ident string
-}
-
-func NewIdentPattern(ident string) IdentPattern {
-	return IdentPattern{ident}
-}
-
-func (p IdentPattern) Bind(scope Scope, value Value) Scope {
-	return EmptyScope.With(p.ident, value)
-}
-
-func (p IdentPattern) String() string {
-	return p.ident
 }
 
 type ValuePattern struct {

--- a/rel/pattern.go
+++ b/rel/pattern.go
@@ -33,6 +33,13 @@ func NewArrayPattern(elements ...Pattern) ArrayPattern {
 }
 
 func (p ArrayPattern) Bind(scope Scope, value Value) Scope {
+	if s, is := value.(GenericSet); is {
+		if s.set.IsEmpty() {
+			return EmptyScope
+		} else {
+			panic(fmt.Sprintf("value %s is not an array", value))
+		}
+	}
 	array, is := value.(Array)
 	if !is {
 		panic(fmt.Sprintf("value %s is not an array", value))

--- a/rel/scope.go
+++ b/rel/scope.go
@@ -90,6 +90,8 @@ func (s Scope) Without(name ...string) Scope {
 	return Scope{s.m.Without(frozen.NewSetFromStrings(name...))}
 }
 
+// s.Update(t) merges s and t, choosing t's binding in the event of a name clash.
+// It's like calling s.With(t0).With(t1).With(t2)... for each element of t
 func (s Scope) Update(t Scope) Scope {
 	return Scope{m: s.m.Update(t.m)}
 }

--- a/rel/scope.go
+++ b/rel/scope.go
@@ -81,7 +81,26 @@ func (s Scope) MustGet(name string) Expr {
 // With returns a new scope with all the old bindings and a new or replacement
 // binding for the given name to the given Expr.
 func (s Scope) With(name string, expr Expr) Scope {
+	if name == "_" {
+		return s
+	}
 	return Scope{s.m.With(name, expr)}
+}
+
+// MatchedWith returns a new scope. New keys are added as With,
+// but existing keys fail unless the new value equals the existing value
+func (s Scope) MatchedWith(name string, expr Expr) Scope {
+	if name == "_" {
+		return s
+	}
+
+	if v, exists := s.Get(name); exists {
+		if v.String() != expr.String() {
+			panic(fmt.Sprintf("%s is redefined differently", name))
+		}
+	}
+
+	return s.With(name, expr)
 }
 
 // Without returns a new scope with with all the old bindings except the ones
@@ -94,6 +113,22 @@ func (s Scope) Without(name ...string) Scope {
 // It's like calling s.With(t0).With(t1).With(t2)... for each element of t
 func (s Scope) Update(t Scope) Scope {
 	return Scope{m: s.m.Update(t.m)}
+}
+
+// MatchedUpdate merges s and t. New keys are added as Update,
+// but existing keys fail unless the new value equals the existing value
+func (s Scope) MatchedUpdate(t Scope) Scope {
+	t = t.Without("_")
+	for e := s.Enumerator(); e.MoveNext(); {
+		name, v := e.Current()
+		if expr, exists := t.Get(name); exists {
+			if expr.String() != v.String() {
+				panic(fmt.Sprintf("the value of %s is different in both scopes", name))
+			}
+		}
+	}
+
+	return s.Update(t)
 }
 
 // Project returns a new scope with just names from the input scope.

--- a/rel/value_number.go
+++ b/rel/value_number.go
@@ -1,6 +1,7 @@
 package rel
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"unsafe"
@@ -108,4 +109,12 @@ func (n Number) Negate() Value {
 // Export exports a Number.
 func (n Number) Export() interface{} {
 	return n.Float64()
+}
+
+func (n Number) Bind(scope Scope, value Value) Scope {
+	if !n.Equal(value) {
+		panic(fmt.Sprintf("%s doesn't equal to %s", n, value))
+	}
+
+	return EmptyScope
 }

--- a/rel/value_set_func.go
+++ b/rel/value_set_func.go
@@ -27,7 +27,7 @@ func ExprAsFunction(expr Expr) *Function {
 	if fn, ok := expr.(*Function); ok {
 		return fn
 	}
-	return NewFunction(NewIdentPattern("."), expr).(*Function)
+	return NewFunction(IdentExpr{ident: "."}, expr).(*Function)
 }
 
 // Arg returns a function's formal argument.

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -72,4 +72,5 @@ C      -> /{ # .* $ };
   | C* "{" C* dict=((key=top ":" value=top):",",?) "}" C*
   | C* "[" C* array=(item=top:",",?) C* "]" C*
   | C* "(" tuple=(pairs=(name? ":" v=top):",",?) ")" C*
+  | C* "(" identpattern=IDENT ")" C*
 };

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -135,6 +135,9 @@ func (pc ParseContext) compilePattern(b ast.Branch) rel.Pattern {
 	if tuple := b.One("tuple"); tuple != nil {
 		return pc.compileTuplePattern(tuple.(ast.Branch))
 	}
+	if ident := b.One("identpattern"); ident != nil {
+		return rel.NewIdentPattern(ident.Scanner().String())
+	}
 	expr := pc.CompileExpr(b)
 	return rel.ExprAsPattern(expr)
 }

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -39,3 +39,13 @@ func TestExprLetArrayPattern(t *testing.T) {
 	AssertCodePanics(t, `let x = 3; let [(x)] = [2]; x`)
 	AssertCodePanics(t, `let x = 3; let [b, (x)] = [2, 1]; b`)
 }
+
+func TestExprLetTuplePattern(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `4`, `let (a:x, b:y) = (a:4, b:7); x`)
+	AssertCodesEvalToSameValue(t, `4`, `let (a:x) = (b:7, a:4); x`)
+	AssertCodesEvalToSameValue(t, `4`, `let (a:x, b:x) = (a:4, b:4); x`)
+	AssertCodesEvalToSameValue(t, `4`, `let (a:x, a:x) = (a:4, a:4); x`)
+	AssertCodesEvalToSameValue(t, `4`, `let x = 4; let (a:x) = (a:4); x`)
+	AssertCodePanics(t, `let x = 5; let (a:x) = (a:4); x`)
+	AssertCodePanics(t, `let (a:x, b:x) = (a:4, b:7); x`)
+}

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -16,6 +16,7 @@ func TestExprLetValuePattern(t *testing.T) {
 }
 
 func TestExprLetArrayPattern(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `1`, `let [] = []; 1`)
 	AssertCodesEvalToSameValue(t, `9`, `let [a, b, c] = [1, 2, 3]; 9`)
 	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [a, b, c] = [1, 2, 3]; [a, b, c]`)
 	AssertCodesEvalToSameValue(t, `2`, `let [a, b, c] = [1, 2, 3]; [a, b, c](1)`)
@@ -41,6 +42,7 @@ func TestExprLetArrayPattern(t *testing.T) {
 }
 
 func TestExprLetTuplePattern(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `4`, `let () = (); 4`)
 	AssertCodesEvalToSameValue(t, `4`, `let (a:x, b:y) = (a:4, b:7); x`)
 	AssertCodesEvalToSameValue(t, `4`, `let (a:x) = (b:7, a:4); x`)
 	AssertCodesEvalToSameValue(t, `4`, `let (a:x, b:x) = (a:4, b:4); x`)

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -6,6 +6,7 @@ func TestExprLetIdentPattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `7`, `let x = 6; 7`)
 	AssertCodesEvalToSameValue(t, `42`, `let x = 6; x * 7`)
 	AssertCodesEvalToSameValue(t, `[1, 2]`, `let x = 1; [x, 2]`)
+	AssertCodesEvalToSameValue(t, `2`, `let x = 1; let x = x + 1; x`)
 }
 
 func TestExprLetValuePattern(t *testing.T) {
@@ -30,14 +31,16 @@ func TestExprLetArrayPattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `3`, `let x = 3; let [(x)] = [3]; x`)
 	AssertCodesEvalToSameValue(t, `2`, `let x = 3; let [b, (x)] = [2, 3]; b`)
 	AssertCodesEvalToSameValue(t, `2`, `let x = 3; let [_, b, (x)] = [1, 2, 3]; b`)
+	AssertCodesEvalToSameValue(t, `2`, `let x = 3; let [x] = [2]; x`)
 
+	AssertCodePanics(t, `let [(x)] = [2]; x`)
+	AssertCodePanics(t, `let x = 3; let [(x)] = [2]; x`)
 	AssertCodePanics(t, `let [x, y] = 1; x`)
 	AssertCodePanics(t, `let [x, x] = [1]; x`)
 	AssertCodePanics(t, `let [x, y] = [1]; x`)
 	AssertCodePanics(t, `let [x, x] = [1, 2]; x`)
 	AssertCodeErrors(t, `let [_] = [1]; _`,
 		"Name \"_\" not found in {} \n\n\x1b[1;37m:1:16:\x1b[0m\nlet [_]")
-	AssertCodePanics(t, `let x = 3; let [(x)] = [2]; x`)
 	AssertCodePanics(t, `let x = 3; let [b, (x)] = [2, 1]; b`)
 }
 
@@ -48,6 +51,7 @@ func TestExprLetTuplePattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `4`, `let (a:x, b:x) = (a:4, b:4); x`)
 	AssertCodesEvalToSameValue(t, `4`, `let (a:x, a:x) = (a:4, a:4); x`)
 	AssertCodesEvalToSameValue(t, `4`, `let x = 4; let (a:x) = (a:4); x`)
-	AssertCodePanics(t, `let x = 5; let (a:x) = (a:4); x`)
+	AssertCodesEvalToSameValue(t, `4`, `let x = 5; let (a:x) = (a:4); x`)
+	AssertCodePanics(t, `let x = 5; let (a:(x)) = (a:4); x`)
 	AssertCodePanics(t, `let (a:x, b:x) = (a:4, b:7); x`)
 }

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -86,6 +86,7 @@ C      -> /{ # .* $ };
   | C* "{" C* dict=((key=top ":" value=top):",",?) "}" C*
   | C* "[" C* array=(item=top:",",?) C* "]" C*
   | C* "(" tuple=(pairs=(name? ":" v=top):",",?) ")" C*
+  | C* "(" identpattern=IDENT ")" C*
 };
 
 `), nil)


### PR DESCRIPTION
Fixes #236  .

Changes proposed in this pull request:
- Support (m: x, n: y)
  - syntax/expr_let_test.go
- Remove `ValuePattern`. Implement `IdentExpr` and `Number` as `Pattern` accordingly.
  - rel/value_number.go
  - rel/expr_ident.go
  - rel/pattern.go
- `IdentPattern` for `(x)`, `IdentExpr` for `x`
  - syntax/arrai.wbnf
  - rel/pattern.go
- Refactor `compilePattern`
  - syntax/compile.go
- add `MatchedWith` and `MatchedUpdate` to handle `_` and different `Value`s
  - rel/scope.go

Checklist:
- [x] Added related tests
