### PR TITLE
tab completion on tuples and dictionaries that are currently typed

### DIFF
--- a/internal/shell/shell_completion.go
+++ b/internal/shell/shell_completion.go
@@ -1,3 +1,5 @@
+//+build wasm
+
 package shell
 
 import (

--- a/internal/shell/shell_completion.go
+++ b/internal/shell/shell_completion.go
@@ -78,22 +78,12 @@ func predictFromValue(val rel.Value) (predictions []string) {
 	case rel.Tuple:
 		predictions = v.Names().OrderedNames()
 		for i := 0; i < len(predictions); i++ {
-			if strings.Contains(predictions[i], " ") {
-				predictions[i] = fmt.Sprintf(`."%s"`, predictions[i])
-			} else {
-				predictions[i] = fmt.Sprintf(`.%s`, predictions[i])
-			}
+			predictions[i] = fmt.Sprintf(`.%s`, rel.TupleNameRepr(predictions[i]))
 		}
 	case rel.Dict:
 		predictions = make([]string, 0, v.Count())
 		for _, e := range v.OrderedEntries() {
-			key := e.MustGet("@")
-			switch k := key.(type) {
-			case rel.String:
-				predictions = append(predictions, fmt.Sprintf(`("%s")`, k.String()))
-			default:
-				predictions = append(predictions, fmt.Sprintf(`(%s)`, k.String()))
-			}
+			predictions = append(predictions, fmt.Sprintf(`(%s)`, rel.Repr(e.MustGet("@"))))
 		}
 	}
 	return

--- a/internal/shell/shell_completion.go
+++ b/internal/shell/shell_completion.go
@@ -1,0 +1,158 @@
+package shell
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/arr-ai/arrai/rel"
+)
+
+func (s *shellInstance) Do(line []rune, pos int) (newLine [][]rune, length int) {
+	l := getLastToken(line[:pos])
+	switch {
+	case strings.HasSuffix(l, "///"):
+		return [][]rune{line}, len(line)
+	case strings.HasPrefix(l, "//"):
+		var names []string
+		var lastName string
+		if l == "//" {
+			lastName, names = "", []string{}
+		} else {
+			names = strings.Split(l[2:], ".")
+			lastName, names = names[len(names)-1], names[:len(names)-1]
+		}
+		newLine, length = getScopePredictions(names, lastName, s.scope.MustGet(".").(rel.Tuple))
+		if l == "//" {
+			newLine = append(newLine, []rune("{"))
+		}
+	default:
+		currentExpr := strings.Join(s.collector.withLine(string(line[:pos])).lines, "\n")
+		realExpr, residue := s.trimExpr(currentExpr)
+		val, err := tryEval(realExpr, s.scope)
+		if err != nil {
+			return
+		}
+		newLine = formatPredictions(predictFromValue(val), residue)
+		length = len(residue)
+	}
+	return
+}
+
+//TODO: maybe needed for more advance predictions
+// func evalExprWithResidue(s *shellInstance, expr string, scope rel.Scope) (rel.Value, string, error) {
+// 	realExpr, residue := s.trimExpr(expr)
+// 	val, err := tryEval(realExpr, scope)
+// 	if err != nil {
+// 		return nil, residue, err
+// 	}
+// 	return val, residue, nil
+// }
+
+func (s *shellInstance) trimExpr(expr string) (string, string) {
+	if regexp.MustCompile(`[\(\.]$`).MatchString(expr) {
+		return expr[:len(expr)-1], string(expr[len(expr)-1])
+	}
+
+	//TODO:
+	// string get expression will be handled by the isBalanced operation`
+	// getOp := regexp.MustCompile(`\.(\*|\.|[$@A-Za-z_][0-9$@A-Za-z_]*)$`)
+	// if getOp.MatchString(expr) {
+	// 	residue = getOp.FindString(expr)
+	// 	realExpr = strings.TrimPrefix(expr, residue)
+	// 	return
+	// }
+
+	// for i := len(expr); i > 0; i-- {
+	// 	if s.collector.withLine(expr[:i]).isBalanced() {
+	// 		return expr[:i], expr[i:]
+	// 	}
+	// }
+	return expr, ""
+}
+
+func predictFromValue(val rel.Value) (predictions []string) {
+	switch v := val.(type) {
+	case rel.Tuple:
+		predictions = v.Names().OrderedNames()
+		for i := 0; i < len(predictions); i++ {
+			if strings.Contains(predictions[i], " ") {
+				predictions[i] = fmt.Sprintf(`."%s"`, predictions[i])
+			} else {
+				predictions[i] = fmt.Sprintf(`.%s`, predictions[i])
+			}
+		}
+	case rel.Dict:
+		predictions = make([]string, 0, v.Count())
+		for _, e := range v.OrderedEntries() {
+			key := e.MustGet("@")
+			switch k := key.(type) {
+			case rel.String:
+				predictions = append(predictions, fmt.Sprintf(`("%s")`, k.String()))
+			default:
+				predictions = append(predictions, fmt.Sprintf(`(%s)`, k.String()))
+			}
+		}
+	}
+	return
+}
+
+func formatPredictions(predictions []string, prefix string) [][]rune {
+	var p [][]rune
+	for i := 0; i < len(predictions); i++ {
+		if strings.HasPrefix(predictions[i], prefix) {
+			p = append(p, []rune(strings.TrimPrefix(predictions[i], prefix)))
+			// fmt.Printf("\nPrediction: %s\n", strings.TrimPrefix(predictions[i], prefix))
+		}
+	}
+	return p
+}
+
+func getLastToken(line []rune) string {
+	i := len(line) - 1
+	for ; i > 0; i-- {
+		if !isAlpha(line[i]) && line[i] != '.' {
+			if line[i] == '/' {
+				switch {
+				case strings.HasSuffix(string(line[:i+1]), "///"):
+					i -= 2
+				case strings.HasSuffix(string(line[:i+1]), "//"):
+					i--
+				}
+			} else {
+				i++
+			}
+			break
+		}
+	}
+
+	if i == len(line) || i < 0 {
+		return ""
+	}
+	return string(line[i:])
+}
+
+func isAlpha(l rune) bool {
+	return (l >= 'a' && l <= 'z') || (l >= 'A' && l <= 'Z')
+}
+
+func getScopePredictions(tuplePath []string, name string, scope rel.Tuple) ([][]rune, int) {
+	var newLine [][]rune
+	length := len(name)
+	for _, attr := range tuplePath {
+		if value, has := scope.Get(attr); has {
+			if u, is := value.(rel.Tuple); is {
+				scope = u
+				continue
+			}
+		}
+		return nil, 0
+	}
+
+	for _, attr := range scope.Names().OrderedNames() {
+		if strings.HasPrefix(attr, name) {
+			newLine = append(newLine, []rune(attr[length:]))
+		}
+	}
+	return newLine, length
+}

--- a/internal/shell/shell_completion.go
+++ b/internal/shell/shell_completion.go
@@ -1,4 +1,4 @@
-//+build wasm
+//+build !wasm
 
 package shell
 

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -195,24 +195,32 @@ func TestCompletionCurrentExpr(t *testing.T) {
 	assertTabCompletion(t, []string{"a", "b"}, 1, "(a: 1, b: 2).\t", nil)
 	assertTabCompletion(t, []string{"a", "b"}, 1, "(a: 1, b: 2).\t + 123", nil)
 	assertTabCompletion(t, []string{".c"}, 0, "(a: (c: 3), b: 2).a\t", nil)
-	assertTabCompletion(t, []string{`"random string"`}, 1, "(`random string`: 1).\t", nil)
+	assertTabCompletion(t, []string{`'random string'`}, 1, "(`random string`: 1).\t", nil)
 	assertTabCompletion(t, []string{".a"}, 0, "x\t", map[string]string{"x": "(a: 1)"})
+	assertTabCompletion(t,
+		[]string{"a", `'b"b'`, `"c'c"`, "'d`d'", "\"e\\\"e'e`ee\""}, 1,
+		"(a: 1, 'b\"b': 2, \"c'c\": 3, \"d`d\": 4, \"e\\\"e'e`ee\": 5).\t", nil)
 
-	assertTabCompletion(t, []string{`("a")`}, 0, "{`a`: 1}\t", nil)
-	assertTabCompletion(t, []string{`("a")`, `("b")`}, 0, "{`a`: 1, `b`: 2}\t", nil)
-	assertTabCompletion(t, []string{`("a")`, `("b")`}, 0, "{`a`: 1, `b`: 2}\t + 123", nil)
-	assertTabCompletion(t, []string{`"a")`}, 1, "{`a`: 1}(\t", nil)
-	assertTabCompletion(t, []string{`"a")`, `"b")`}, 1, "{`a`: 1, `b`: 2}(\t", nil)
-	assertTabCompletion(t, []string{`"a")`, `"b")`}, 1, "{`a`: 1, `b`: 2}(\t + 123", nil)
-	assertTabCompletion(t, []string{`"c")`}, 1, "{`a`: {`c`: 3}, `b`: 2}(`a`)(\t", nil)
-	assertTabCompletion(t, []string{`"random string")`}, 1, "{`random string`: 1}(\t", nil)
-	assertTabCompletion(t, []string{`(2)`, `("string")`, `([1, 2, 3])`}, 0, "{`string`: 1, 2: 20, [1, 2, 3]: 30}\t", nil)
-	assertTabCompletion(t, []string{`("a")`}, 0, "x\t", map[string]string{"x": "{`a`: 1}"})
+	assertTabCompletion(t, []string{`('a')`}, 0, "{`a`: 1}\t", nil)
+	assertTabCompletion(t, []string{`('a')`, `('b')`}, 0, "{`a`: 1, `b`: 2}\t", nil)
+	assertTabCompletion(t, []string{`('a')`, `('b')`}, 0, "{`a`: 1, `b`: 2}\t + 123", nil)
+	assertTabCompletion(t, []string{`'a')`}, 1, "{`a`: 1}(\t", nil)
+	assertTabCompletion(t, []string{`'a')`, `'b')`}, 1, "{`a`: 1, `b`: 2}(\t", nil)
+	assertTabCompletion(t, []string{`'a')`, `'b')`}, 1, "{`a`: 1, `b`: 2}(\t + 123", nil)
+	assertTabCompletion(t, []string{`'c')`}, 1, "{`a`: {`c`: 3}, `b`: 2}(`a`)(\t", nil)
+	assertTabCompletion(t, []string{`'random string')`}, 1, "{`random string`: 1}(\t", nil)
+	assertTabCompletion(t, []string{`('a')`}, 0, "x\t", map[string]string{"x": "{`a`: 1}"})
+	assertTabCompletion(t,
+		[]string{"('a')", `('b"b')`, `("c'c")`, "('d`d')", "(\"e\\\"e'e`ee\")"}, 0,
+		"{'a': 1, 'b\"b': 2, \"c'c\": 3, \"d`d\": 4, \"e\\\"e'e`ee\": 5}\t", nil)
+	assertTabCompletion(t,
+		[]string{`(2)`, `('string')`, `([1, 2, 3])`}, 0,
+		"{`string`: 1, 2: 20, [1, 2, 3]: 30}\t", nil)
 
 	assertTabCompletion(t, []string{`.a`}, 0, "let x = (a: 1); x\t", nil)
-	assertTabCompletion(t, []string{`("a")`}, 0, "let x = {`a`: 1}; x\t", nil)
+	assertTabCompletion(t, []string{`('a')`}, 0, "let x = {`a`: 1}; x\t", nil)
 	assertTabCompletion(t, []string{`.a`}, 0, "x\t", map[string]string{"x": `(a: {"b": (c: 3)})`})
-	assertTabCompletion(t, []string{`("b")`}, 0, "x.a\t", map[string]string{"x": `(a: {"b": (c: 3)})`})
+	assertTabCompletion(t, []string{`('b')`}, 0, "x.a\t", map[string]string{"x": `(a: {"b": (c: 3)})`})
 	assertTabCompletion(t, []string{`.c`}, 0, "x.a(`b`)\t", map[string]string{"x": `(a: {"b": (c: 3)})`})
 }
 

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/arr-ai/arrai/rel"
 	"github.com/arr-ai/arrai/syntax"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLineCollectorAppendLine(t *testing.T) {
@@ -137,6 +138,8 @@ func TestGetLastToken(t *testing.T) {
 	assert.Equal(t, "//", getLastToken([]rune("//str.contains(//")))
 	assert.Equal(t, "//arch", getLastToken([]rune("//str.contains(//arch")))
 	assert.Equal(t, "tuple.", getLastToken([]rune("//str.contains(tuple.")))
+	assert.Equal(t, "x.", getLastToken([]rune("x.")))
+	assert.Equal(t, "x", getLastToken([]rune("x")))
 	assert.Equal(t, "", getLastToken([]rune("//str.contains(")))
 	assert.Equal(t, "", getLastToken([]rune("")))
 }
@@ -159,12 +162,66 @@ func TestTabCompletionStdlib(t *testing.T) {
 	assertTabCompletionWithPrefix(t, prefix, strlib, "//"+lib+".%s\t", nil)
 }
 
+func TestTrimExpr(t *testing.T) {
+	t.Parallel()
+
+	sh := newShellInstance(newLineCollector(), syntax.StdScope())
+
+	realExpr, residue := sh.trimExpr(`x.`)
+	assert.Equal(t, "x", realExpr)
+	assert.Equal(t, ".", residue)
+
+	realExpr, residue = sh.trimExpr(`abc(`)
+	assert.Equal(t, "abc", realExpr)
+	assert.Equal(t, "(", residue)
+
+	realExpr, residue = sh.trimExpr(`x`)
+	assert.Equal(t, "x", realExpr)
+	assert.Equal(t, "", residue)
+
+	//TODO: more advanced predictions
+	// realExpr, residue = sh.trimExpr(`abc.ab`)
+	// assert.Equal(t, "abc", realExpr)
+	// assert.Equal(t, ".ab", residue)
+}
+
+func TestCompletionCurrentExpr(t *testing.T) {
+	t.Parallel()
+
+	assertTabCompletion(t, []string{".a"}, 0, "(a: 1)\t", nil)
+	assertTabCompletion(t, []string{".a", ".b"}, 0, "(a: 1, b: 2)\t", nil)
+	assertTabCompletion(t, []string{".a", ".b"}, 0, "(a: 1, b: 2)\t + 123", nil)
+	assertTabCompletion(t, []string{"a"}, 1, "(a: 1).\t", nil)
+	assertTabCompletion(t, []string{"a", "b"}, 1, "(a: 1, b: 2).\t", nil)
+	assertTabCompletion(t, []string{"a", "b"}, 1, "(a: 1, b: 2).\t + 123", nil)
+	assertTabCompletion(t, []string{".c"}, 0, "(a: (c: 3), b: 2).a\t", nil)
+	assertTabCompletion(t, []string{`"random string"`}, 1, "(`random string`: 1).\t", nil)
+	assertTabCompletion(t, []string{".a"}, 0, "x\t", map[string]string{"x": "(a: 1)"})
+
+	assertTabCompletion(t, []string{`("a")`}, 0, "{`a`: 1}\t", nil)
+	assertTabCompletion(t, []string{`("a")`, `("b")`}, 0, "{`a`: 1, `b`: 2}\t", nil)
+	assertTabCompletion(t, []string{`("a")`, `("b")`}, 0, "{`a`: 1, `b`: 2}\t + 123", nil)
+	assertTabCompletion(t, []string{`"a")`}, 1, "{`a`: 1}(\t", nil)
+	assertTabCompletion(t, []string{`"a")`, `"b")`}, 1, "{`a`: 1, `b`: 2}(\t", nil)
+	assertTabCompletion(t, []string{`"a")`, `"b")`}, 1, "{`a`: 1, `b`: 2}(\t + 123", nil)
+	assertTabCompletion(t, []string{`"c")`}, 1, "{`a`: {`c`: 3}, `b`: 2}(`a`)(\t", nil)
+	assertTabCompletion(t, []string{`"random string")`}, 1, "{`random string`: 1}(\t", nil)
+	assertTabCompletion(t, []string{`(2)`, `("string")`, `([1, 2, 3])`}, 0, "{`string`: 1, 2: 20, [1, 2, 3]: 30}\t", nil)
+	assertTabCompletion(t, []string{`("a")`}, 0, "x\t", map[string]string{"x": "{`a`: 1}"})
+
+	assertTabCompletion(t, []string{`.a`}, 0, "let x = (a: 1); x\t", nil)
+	assertTabCompletion(t, []string{`("a")`}, 0, "let x = {`a`: 1}; x\t", nil)
+	assertTabCompletion(t, []string{`.a`}, 0, "x\t", map[string]string{"x": `(a: {"b": (c: 3)})`})
+	assertTabCompletion(t, []string{`("b")`}, 0, "x.a\t", map[string]string{"x": `(a: {"b": (c: 3)})`})
+	assertTabCompletion(t, []string{`.c`}, 0, "x.a(`b`)\t", map[string]string{"x": `(a: {"b": (c: 3)})`})
+}
+
 func assertTabCompletionWithPrefix(
 	t *testing.T,
 	prefix string,
 	choices []string,
 	format string,
-	scopeValues map[string]rel.Expr,
+	scopeValues map[string]string,
 ) {
 	var libWithPrefix []string
 	for _, c := range choices {
@@ -179,11 +236,13 @@ func assertTabCompletion(t *testing.T,
 	expectedPredictions []string,
 	expectedLength int,
 	line string,
-	scopeValues map[string]rel.Expr,
+	scopeValues map[string]string,
 ) {
 	scope := syntax.StdScope()
 	for name, expr := range scopeValues {
-		scope = scope.With(name, expr)
+		val, err := syntax.EvaluateExpr("", expr)
+		require.NoError(t, err)
+		scope = scope.With(name, val)
 	}
 	sh := newShellInstance(newLineCollector(), scope)
 	predictions, length := sh.Do([]rune(line), strings.Index(line, "\t"))


### PR DESCRIPTION
Changes proposed in this pull request:
- This commit allows tab completion on tuples and dictionaries that are currently being typed on
- Moved some of the completion code into `shell_completion.go`

It allows these cases:
```
(a: 1)<tab>
(a: 1).<tab>
{"a": 1}<tab>
{"a": 1}(<tab>
```

TODO:
- move shell completion test to `shell_completion_test.go`
- prefix based completion

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
