### PR TITLE
fixes multiline string with escapes

### DIFF
--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -184,8 +184,9 @@ func (l *lineCollector) withLine(line string) *lineCollector {
 }
 
 func (l *lineCollector) appendLine(line string) {
-	increment := 1
+	var increment int
 	for i := 0; i < len(line); i += increment {
+		increment = 1
 		if nextCloser := l.peek(); line[i] == '\\' && nextCloser != nil && nextCloser.char != "`" {
 			increment = 2
 		} else if nextCloser != nil && strings.HasPrefix(line[i:], nextCloser.char) {

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -121,6 +121,22 @@ func TestIsBalanced(t *testing.T) {
 	assert.True(t, c.isBalanced())
 	c.reset()
 
+	c.appendLine("\"\\\"\"")
+	assert.True(t, c.isBalanced())
+	c.reset()
+
+	c.appendLine("\"\\\"x\"")
+	assert.True(t, c.isBalanced())
+	c.reset()
+
+	c.appendLine("\"\\\"xx\"")
+	assert.True(t, c.isBalanced())
+	c.reset()
+
+	c.appendLine("\"\\\"xxx\"")
+	assert.True(t, c.isBalanced())
+	c.reset()
+
 	c.appendLine(`let f = \x \y x + y; f(3, 4)`)
 	assert.True(t, c.isBalanced())
 	c.reset()


### PR DESCRIPTION
increments in `appendLine` wasn't reset every loop, this commit resets it which allows cases such as
```
"\"x"
```
Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
