### PR TITLE
fix autocomplete when predictions have shared quote prefixes

### DIFF
--- a/internal/shell/shell_completion.go
+++ b/internal/shell/shell_completion.go
@@ -52,8 +52,9 @@ func (s *shellInstance) Do(line []rune, pos int) (newLine [][]rune, length int) 
 // }
 
 func (s *shellInstance) trimExpr(expr string) (string, string) {
-	if regexp.MustCompile(`[\(\.]$`).MatchString(expr) {
-		return expr[:len(expr)-1], string(expr[len(expr)-1])
+	if re := regexp.MustCompile("[(.]('|`|\")?$"); re.MatchString(expr) {
+		prefix := re.FindString(expr)
+		return expr[:len(expr)-len(prefix)], prefix
 	}
 
 	//TODO:

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -195,6 +195,18 @@ func TestTrimExpr(t *testing.T) {
 	assert.Equal(t, "x", realExpr)
 	assert.Equal(t, "", residue)
 
+	realExpr, residue = sh.trimExpr(`x.'`)
+	assert.Equal(t, "x", realExpr)
+	assert.Equal(t, ".'", residue)
+
+	realExpr, residue = sh.trimExpr(`abc("`)
+	assert.Equal(t, "abc", realExpr)
+	assert.Equal(t, "(\"", residue)
+
+	realExpr, residue = sh.trimExpr("x(`")
+	assert.Equal(t, "x", realExpr)
+	assert.Equal(t, "(`", residue)
+
 	//TODO: more advanced predictions
 	// realExpr, residue = sh.trimExpr(`abc.ab`)
 	// assert.Equal(t, "abc", realExpr)


### PR DESCRIPTION
//TODO this is a quick fix, a better trimming function is needed

This allows predictions to work when the possible predictions have shared prefixes of either `"`, `'`, or `

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
