### PR TITLE
handle duplicated tuple pattern name

### DIFF
--- a/rel/pattern.go
+++ b/rel/pattern.go
@@ -116,6 +116,12 @@ type TuplePattern struct {
 }
 
 func NewTuplePattern(attrs ...AttrPattern) TuplePattern {
+	names := make(map[string]bool)
+	for _, attr := range attrs {
+		if names[attr.name] {
+			panic(fmt.Sprintf("name %s is duplicated in tuple", attr.name))
+		}
+	}
 	return TuplePattern{attrs}
 }
 
@@ -123,6 +129,10 @@ func (p TuplePattern) Bind(scope Scope, value Value) Scope {
 	tuple, is := value.(Tuple)
 	if !is {
 		panic(fmt.Sprintf("%s is not a tuple", value))
+	}
+
+	if len(p.attrs) != tuple.Count() {
+		panic(fmt.Sprintf("tuples %s and %s cannot match", p, tuple))
 	}
 
 	result := EmptyScope

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -47,11 +47,12 @@ func TestExprLetArrayPattern(t *testing.T) {
 func TestExprLetTuplePattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `4`, `let () = (); 4`)
 	AssertCodesEvalToSameValue(t, `4`, `let (a:x, b:y) = (a:4, b:7); x`)
-	AssertCodesEvalToSameValue(t, `4`, `let (a:x) = (b:7, a:4); x`)
 	AssertCodesEvalToSameValue(t, `4`, `let (a:x, b:x) = (a:4, b:4); x`)
-	AssertCodesEvalToSameValue(t, `4`, `let (a:x, a:x) = (a:4, a:4); x`)
 	AssertCodesEvalToSameValue(t, `4`, `let x = 4; let (a:x) = (a:4); x`)
 	AssertCodesEvalToSameValue(t, `4`, `let x = 5; let (a:x) = (a:4); x`)
+	AssertCodePanics(t, `let (a:x) = (b:7, a:4); x`)
+	AssertCodePanics(t, `let (a:x, a:x) = (a:4, a:4); x`)
+	AssertCodePanics(t, `let (a:x, a:x) = (a:4); x`)
 	AssertCodePanics(t, `let x = 5; let (a:(x)) = (a:4); x`)
 	AssertCodePanics(t, `let (a:x, b:x) = (a:4, b:7); x`)
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- handle duplicated tuple pattern name
- two sides of tuples in let statement must be the same name:expr