### PR TITLE
Decode JSON null as empty tuple

### DIFF
--- a/docs/std-encoding.md
+++ b/docs/std-encoding.md
@@ -16,7 +16,7 @@ maps incoming JSON values as follows:
 | `"abc"` | `(s: "abc")` |
 | `[1, 2, 3]` | `(a: [1, 2, 3])` |
 | `false`/`true` | `(b: false)`/`(b: true)` |
-| `null` | `(null: {})` |
+| `null` | `()` |
 | `{"a": [2, 4, 8]}` | `{"a": (a: [2, 4, 8])}` | Objects are mapped directly to dicts. |
 | `42` | `42` | Numbers, including zero, cannot be confused with other values. |
 

--- a/syntax/std_encoding_json_test.go
+++ b/syntax/std_encoding_json_test.go
@@ -17,8 +17,8 @@ func TestJSONDecode(t *testing.T) {
 			},
 			"h": (a: [])
 		},
-		"i": (null: {}),
-		"j": (a: [(b: {()}), (b: {})]),
+		"i": (),
+		"j": (a: [(b: true), (b: false)]),
 		"k": (s: {})
 	}`
 

--- a/translate/translator.go
+++ b/translate/translator.go
@@ -39,7 +39,7 @@ func ToArrai(data interface{}) (rel.Value, error) {
 	case bool:
 		return rel.NewTuple(rel.NewAttr("b", rel.NewBool(v))), nil
 	case nil:
-		return rel.NewTuple(rel.NewAttr("null", rel.None)), nil
+		return rel.NewTuple(), nil
 	default:
 		t, err := rel.NewValue(v)
 		if err != nil {

--- a/translate/translator_json_test.go
+++ b/translate/translator_json_test.go
@@ -43,7 +43,7 @@ func TestJSONObjectToArrai(t *testing.T) {
 
 	// different value types
 	AssertExpectedJSONTranslation(t, `{"key": 123}           `, `{"key":123}          `)
-	AssertExpectedJSONTranslation(t, `{"key": (null: {})}    `, `{"key":null}         `)
+	AssertExpectedJSONTranslation(t, `{"key": ()}    `, `{"key":null}         `)
 	AssertExpectedJSONTranslation(t, `{"key": (s: "val")}    `, `{"key":"val"}        `)
 	AssertExpectedJSONTranslation(t, `{"key": (a: [1, 2, 3])}`, `{"key":[1, 2, 3]}    `)
 	AssertExpectedJSONTranslation(t, `{"key": {"foo": (s: "bar")}}`, `{"key":{"foo":"bar"}}`)
@@ -60,18 +60,18 @@ func TestJSONArrayToArrai(t *testing.T) {
 
 	// Different value types
 	AssertExpectedJSONTranslation(t, `(a: [1])                  `, `[1]            `)
-	AssertExpectedJSONTranslation(t, `(a: [(null: {})])         `, `[null]         `)
+	AssertExpectedJSONTranslation(t, `(a: [()])         `, `[null]         `)
 	AssertExpectedJSONTranslation(t, `(a: [(s: "hello")])       `, `["hello"]      `)
 	AssertExpectedJSONTranslation(t, `(a: [(a: [1, 2, 3])])     `, `[[1, 2, 3]]    `)
 	AssertExpectedJSONTranslation(t, `(a: [{"foo": (s: "bar")}])`, `[{"foo":"bar"}]`)
 
 	// Multiple values with different types
-	AssertExpectedJSONTranslation(t, `(a: [1, (s: "Hello"), (null: {})])`, `[1, "Hello", null]`)
+	AssertExpectedJSONTranslation(t, `(a: [1, (s: "Hello"), ()])`, `[1, "Hello", null]`)
 }
 
 func TestJSONNullToNone(t *testing.T) {
 	t.Parallel()
-	AssertExpectedJSONTranslation(t, `(null: {})`, `null`)
+	AssertExpectedJSONTranslation(t, `()`, `null`)
 }
 
 func TestJSONStringToArrai(t *testing.T) {

--- a/translate/translator_yaml_test.go
+++ b/translate/translator_yaml_test.go
@@ -25,7 +25,7 @@ func TestYAMLObjectToArrai(t *testing.T) {
 
 	// different value types
 	AssertExpectedYAMLTranslation(t, `{"key": (123)}              `, `key: 123       `)
-	AssertExpectedYAMLTranslation(t, `{"key": (null: {})}         `, `key:           `)
+	AssertExpectedYAMLTranslation(t, `{"key": ()}         `, `key:           `)
 	AssertExpectedYAMLTranslation(t, `{"key": (s: "val")}         `, `key: val       `)
 	AssertExpectedYAMLTranslation(t, `{"key": (a: [1, 2, 3])}     `, `key: [1,2,3]   `)
 	AssertExpectedYAMLTranslation(t, `{"key": {"foo": (s: "bar")}}`, `key: {foo: bar}`)
@@ -42,18 +42,18 @@ func TestYAMLArrayToArrai(t *testing.T) {
 
 	// Different value types
 	AssertExpectedYAMLTranslation(t, `(a: [1])                            `, `[1]            `)
-	AssertExpectedYAMLTranslation(t, `(a: [(null: {})])                   `, `[null]         `)
+	AssertExpectedYAMLTranslation(t, `(a: [()])                   `, `[null]         `)
 	AssertExpectedYAMLTranslation(t, `(a: [(s: "hello")])                 `, `["hello"]      `)
 	AssertExpectedYAMLTranslation(t, `(a: [(a: [1, 2, 3])])               `, `[[1, 2, 3]]    `)
 	AssertExpectedYAMLTranslation(t, `(a: [{"foo": (s: "bar")}])          `, `[{"foo":"bar"}]`)
 
 	// Multiple values with different types
-	AssertExpectedYAMLTranslation(t, `(a: [1, (s: 'Hello'), (null: {})])`, `[1, "Hello", null]`)
+	AssertExpectedYAMLTranslation(t, `(a: [1, (s: 'Hello'), ()])`, `[1, "Hello", null]`)
 }
 
 func TestYAMLNullToNone(t *testing.T) {
 	t.Parallel()
-	AssertExpectedYAMLTranslation(t, `(null: {})`, `null`)
+	AssertExpectedYAMLTranslation(t, `()`, `null`)
 }
 
 func TestYAMLStringToArrai(t *testing.T) {


### PR DESCRIPTION
Currently, `null` encodes to `(null: {})`. But, since nothing else currently encode to the empty tuple, this change uses

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
