### PR TITLE
error report now has filepath relative to current directory

### DIFF
--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -44,17 +45,24 @@ func Compile(filepath, source string) (_ rel.Expr, err error) {
 	return MustCompile(filepath, source), nil
 }
 
-func MustCompile(filepath, source string) rel.Expr {
+func MustCompile(filePath, source string) rel.Expr {
 	dirpath := "."
-	if filepath != "" {
-		if filepath == NoPath {
+	if filePath != "" {
+		if filePath == NoPath {
 			dirpath = NoPath
 		} else {
-			dirpath = path.Dir(filepath)
+			dirpath = path.Dir(filePath)
 		}
 	}
 	pc := ParseContext{SourceDir: dirpath}
-	ast, err := pc.Parse(parser.NewScannerWithFilename(source, dirpath))
+	if !filepath.IsAbs(filePath) {
+		var err error
+		filePath, err = filepath.Rel(".", filePath)
+		if err != nil {
+			panic(err)
+		}
+	}
+	ast, err := pc.Parse(parser.NewScannerWithFilename(source, filePath))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
now error message will have filename in it, relative to current directory. For example:

```
arrai/examples/grpc/grpc-proto.arrai:2:16:
\app
let grpc = //{./grp}; [recovered]
	panic: open arrai/examples/grpc/grp.arrai: no such file or directory
```

Checklist:
- [ ] Added related tests (no way to tests, it depends on wbnf error)
- [ ] Made corresponding changes to the documentation
