### PR TITLE
support tuple construction shortcut in pattern matching

### DIFF
--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -165,6 +165,8 @@ func (pc ParseContext) compileTuplePattern(b ast.Branch) rel.Pattern {
 			v := pc.compilePattern(pair.One("v").(ast.Branch))
 			if name := pair.One("name"); name != nil {
 				k = parseName(name.(ast.Branch))
+			} else {
+				k = v.String()
 			}
 			attr := rel.NewAttrPattern(k, v)
 			attrs = append(attrs, attr)

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -2,11 +2,14 @@ package syntax
 
 import "testing"
 
-func TestExprLetIdentPattern(t *testing.T) {
+func TestExprLet(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `7`, `let x = 6; 7`)
 	AssertCodesEvalToSameValue(t, `42`, `let x = 6; x * 7`)
 	AssertCodesEvalToSameValue(t, `[1, 2]`, `let x = 1; [x, 2]`)
 	AssertCodesEvalToSameValue(t, `2`, `let x = 1; let x = x + 1; x`)
+	AssertCodesEvalToSameValue(t, `(x: 1)`, `let x = 1; (:x)`)
+	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; let y = 2; (:x, :y)`)
+	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; (:x, y: 2)`)
 }
 
 func TestExprLetValuePattern(t *testing.T) {
@@ -50,6 +53,8 @@ func TestExprLetTuplePattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `4`, `let (a:x, b:x) = (a:4, b:4); x`)
 	AssertCodesEvalToSameValue(t, `4`, `let x = 4; let (a:x) = (a:4); x`)
 	AssertCodesEvalToSameValue(t, `4`, `let x = 5; let (a:x) = (a:4); x`)
+	AssertCodesEvalToSameValue(t, `1`, `let (:x) = (x: 1); x`)
+	AssertCodesEvalToSameValue(t, `2`, `let (:x, :y) = (x: 1, y: 2); y`)
 	AssertCodePanics(t, `let (a:x) = (b:7, a:4); x`)
 	AssertCodePanics(t, `let (a:x, a:x) = (a:4, a:4); x`)
 	AssertCodePanics(t, `let (a:x, a:x) = (a:4); x`)


### PR DESCRIPTION
Changes proposed in this pull request:
- support tuple construction shortcut in pattern matching


Checklist:
- [x] Added related tests
