### PR TITLE
support dict pattern

### DIFF
--- a/rel/value_number.go
+++ b/rel/value_number.go
@@ -113,7 +113,7 @@ func (n Number) Export() interface{} {
 
 func (n Number) Bind(scope Scope, value Value) Scope {
 	if !n.Equal(value) {
-		panic(fmt.Sprintf("%s doesn't equal to %s", n, value))
+		panic(fmt.Sprintf("%s doesn't equal to %s, cannot bind these two numbers", n, value))
 	}
 
 	return EmptyScope

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -149,6 +149,7 @@ func (pc ParseContext) compilePattern(b ast.Branch) rel.Pattern {
 	if ident := b.One("identpattern"); ident != nil {
 		return rel.NewIdentPattern(ident.Scanner().String())
 	}
+
 	expr := pc.CompileExpr(b)
 	return rel.ExprAsPattern(expr)
 }
@@ -192,12 +193,12 @@ func (pc ParseContext) compileDictPattern(b ast.Branch) rel.Pattern {
 	values := b["value"]
 	if (keys != nil) || (values != nil) {
 		if (keys != nil) && (values != nil) {
-			keyPtns := pc.compileExprs(keys.(ast.Many)...)
+			keyExprs := pc.compileExprs(keys.(ast.Many)...)
 			valuePtns := pc.compilePatterns(values.(ast.Many)...)
-			if len(keyPtns) == len(valuePtns) {
-				entryPtns := make([]rel.DictPatternEntry, 0, len(keyPtns))
-				for i, keyPtn := range keyPtns {
-					entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyPtn, valuePtns[i]))
+			if len(keyExprs) == len(valuePtns) {
+				entryPtns := make([]rel.DictPatternEntry, 0, len(keyExprs))
+				for i, keyExpr := range keyExprs {
+					entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyExpr, valuePtns[i]))
 				}
 				return rel.NewDictPattern(entryPtns...)
 			}

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -143,6 +143,9 @@ func (pc ParseContext) compilePattern(b ast.Branch) rel.Pattern {
 	if tuple := b.One("tuple"); tuple != nil {
 		return pc.compileTuplePattern(tuple.(ast.Branch))
 	}
+	if dict := b.One("dict"); dict != nil {
+		return pc.compileDictPattern(dict.(ast.Branch))
+	}
 	if ident := b.One("identpattern"); ident != nil {
 		return rel.NewIdentPattern(ident.Scanner().String())
 	}
@@ -167,7 +170,7 @@ func (pc ParseContext) compileArrayPattern(b ast.Branch) rel.Pattern {
 
 func (pc ParseContext) compileTuplePattern(b ast.Branch) rel.Pattern {
 	if pairs := b.Many("pairs"); pairs != nil {
-		attrs := make([]rel.AttrPattern, 0, len(pairs))
+		attrs := make([]rel.TuplePatternAttr, 0, len(pairs))
 		for _, pair := range pairs {
 			var k string
 			v := pc.compilePattern(pair.One("v").(ast.Branch))
@@ -176,12 +179,32 @@ func (pc ParseContext) compileTuplePattern(b ast.Branch) rel.Pattern {
 			} else {
 				k = v.String()
 			}
-			attr := rel.NewAttrPattern(k, v)
+			attr := rel.NewTuplePatternAttr(k, v)
 			attrs = append(attrs, attr)
 		}
 		return rel.NewTuplePattern(attrs...)
 	}
 	return rel.NewTuplePattern()
+}
+
+func (pc ParseContext) compileDictPattern(b ast.Branch) rel.Pattern {
+	keys := b["key"]
+	values := b["value"]
+	if (keys != nil) || (values != nil) {
+		if (keys != nil) && (values != nil) {
+			keyPtns := pc.compileExprs(keys.(ast.Many)...)
+			valuePtns := pc.compilePatterns(values.(ast.Many)...)
+			if len(keyPtns) == len(valuePtns) {
+				entryPtns := make([]rel.DictPatternEntry, 0, len(keyPtns))
+				for i, keyPtn := range keyPtns {
+					entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyPtn, valuePtns[i]))
+				}
+				return rel.NewDictPattern(entryPtns...)
+			}
+		}
+		panic("mismatch between dict keys and values")
+	}
+	return rel.NewDictPattern()
 }
 
 func (pc ParseContext) compileArrow(b ast.Branch, name string, c ast.Children) rel.Expr {

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -191,17 +191,18 @@ func (pc ParseContext) compileTuplePattern(b ast.Branch) rel.Pattern {
 func (pc ParseContext) compileDictPattern(b ast.Branch) rel.Pattern {
 	keys := b["key"]
 	values := b["value"]
-	if (keys != nil) || (values != nil) {
-		if (keys != nil) && (values != nil) {
-			keyExprs := pc.compileExprs(keys.(ast.Many)...)
-			valuePtns := pc.compilePatterns(values.(ast.Many)...)
-			if len(keyExprs) == len(valuePtns) {
-				entryPtns := make([]rel.DictPatternEntry, 0, len(keyExprs))
-				for i, keyExpr := range keyExprs {
-					entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyExpr, valuePtns[i]))
-				}
-				return rel.NewDictPattern(entryPtns...)
+	if (keys != nil) != (values != nil) {
+		panic("mismatch between dict keys and values")
+	}
+	if (keys != nil) && (values != nil) {
+		keyExprs := pc.compileExprs(keys.(ast.Many)...)
+		valuePtns := pc.compilePatterns(values.(ast.Many)...)
+		if len(keyExprs) == len(valuePtns) {
+			entryPtns := make([]rel.DictPatternEntry, 0, len(keyExprs))
+			for i, keyExpr := range keyExprs {
+				entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyExpr, valuePtns[i]))
 			}
+			return rel.NewDictPattern(entryPtns...)
 		}
 		panic("mismatch between dict keys and values")
 	}

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -65,9 +65,12 @@ func TestExprLetTuplePattern(t *testing.T) {
 }
 
 func TestExprLetDictPattern(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `[4, 5]`, `let d = {"x": 4, "y": 5}; let {"x": a, "y": b} = d; [a, b]`)
 	AssertCodesEvalToSameValue(t, `[4, 5]`, `let {"x": a, "y": b} = {"x": 4, "y": 5}; [a, b]`)
+	AssertCodesEvalToSameValue(t, `4`, `let a = 4; let {"x": (a)} = {"x": 4}; a`)
 	AssertCodePanics(t, `let {"x": a, "y": b} = {"x": 4}; a`)
 	AssertCodePanics(t, `let {"x": a, "y": b} = {"x": 4, "y": 5, "z": 6}; a`)
 	AssertCodePanics(t, `let {"x": a, "x": a} = {"x": 4}; a`)
 	AssertCodePanics(t, `let {"x": a, "x": a} = {"x": 4, "x": 4}; a`)
+	AssertCodePanics(t, `let a = 4; let {"x": (a)} = {"x": 5}; a`)
 }

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -53,6 +53,7 @@ func TestExprLetTuplePattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `4`, `let (a:x, b:x) = (a:4, b:4); x`)
 	AssertCodesEvalToSameValue(t, `4`, `let x = 4; let (a:x) = (a:4); x`)
 	AssertCodesEvalToSameValue(t, `4`, `let x = 5; let (a:x) = (a:4); x`)
+	AssertCodesEvalToSameValue(t, `4`, `let (a:[x]) = (a:[4]); x`)
 	AssertCodesEvalToSameValue(t, `1`, `let (:x) = (x: 1); x`)
 	AssertCodesEvalToSameValue(t, `2`, `let (:x, :y) = (x: 1, y: 2); y`)
 	AssertCodePanics(t, `let (a:x) = (b:7, a:4); x`)
@@ -60,4 +61,13 @@ func TestExprLetTuplePattern(t *testing.T) {
 	AssertCodePanics(t, `let (a:x, a:x) = (a:4); x`)
 	AssertCodePanics(t, `let x = 5; let (a:(x)) = (a:4); x`)
 	AssertCodePanics(t, `let (a:x, b:x) = (a:4, b:7); x`)
+	AssertCodePanics(t, `let x = 5; let (a:[(x)]) = (a:[4]); x`)
+}
+
+func TestExprLetDictPattern(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `[4, 5]`, `let {"x": a, "y": b} = {"x": 4, "y": 5}; [a, b]`)
+	AssertCodePanics(t, `let {"x": a, "y": b} = {"x": 4}; a`)
+	AssertCodePanics(t, `let {"x": a, "y": b} = {"x": 4, "y": 5, "z": 6}; a`)
+	AssertCodePanics(t, `let {"x": a, "x": a} = {"x": 4}; a`)
+	AssertCodePanics(t, `let {"x": a, "x": a} = {"x": 4, "x": 4}; a`)
 }


### PR DESCRIPTION
Fixes #237.

Changes proposed in this pull request:
- support dict pattern `let {"x": a, "y": b} = {"x": 4, "y": 5}; [a, b]`

Checklist:
- [x] Added related tests
