### PR TITLE
Fixes #290, add go mod tidy after a test in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ install: parser
 test:
 	go test $(GOTESTFLAGS) -tags timingsensitive ./...
 	GOARCH=386 go build ./...
+	go mod tidy
 
 lint:
 	golangci-lint run


### PR DESCRIPTION
Some package tests in package_test.go seems to run a go get a command
which pollutes the go.mod and go.sum for every make test. This commit
fixes it by adding a go mod tidy command in the make test script.
