### PR TITLE
allows stdlib completion without "." at the end

### DIFF
--- a/internal/shell/shell_completion.go
+++ b/internal/shell/shell_completion.go
@@ -27,6 +27,16 @@ func (s *shellInstance) Do(line []rune, pos int) (newLine [][]rune, length int) 
 		newLine, length = getScopePredictions(names, lastName, s.scope.MustGet(".").(rel.Tuple))
 		if l == "//" {
 			newLine = append(newLine, []rune("{"))
+		} else if lastName != "" {
+			if len(newLine) == 0 {
+				length = 0
+			}
+			names, lastName = append(names, lastName), ""
+			predictions, _ := getScopePredictions(names, lastName, s.scope.MustGet(".").(rel.Tuple))
+			for i := 0; i < len(predictions); i++ {
+				predictions[i] = append([]rune("."), predictions[i]...)
+			}
+			newLine = append(newLine, predictions...)
 		}
 	default:
 		currentExpr := strings.Join(s.collector.withLine(string(line[:pos])).lines, "\n")
@@ -158,7 +168,7 @@ func getScopePredictions(tuplePath []string, name string, scope rel.Tuple) ([][]
 	}
 
 	for _, attr := range scope.Names().OrderedNames() {
-		if strings.HasPrefix(attr, name) {
+		if strings.HasPrefix(attr, name) && name != attr {
 			newLine = append(newLine, []rune(attr[length:]))
 		}
 	}

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -176,6 +176,10 @@ func TestTabCompletionStdlib(t *testing.T) {
 	lib := "str"
 	strlib := stdlib.MustGet(lib).(rel.Tuple).Names().OrderedNames()
 	assertTabCompletionWithPrefix(t, prefix, strlib, "//"+lib+".%s\t", nil)
+	for i := 0; i < len(strlib); i++ {
+		strlib[i] = "." + strlib[i]
+	}
+	assertTabCompletionWithPrefix(t, "", strlib, "//"+lib+"%s\t", nil)
 }
 
 func TestTrimExpr(t *testing.T) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Allows stdlib completion without `.`
```
@> //str<tab>
contains   expand     has_prefix has_suffix join       lower      repr       split      sub        title      upper
```

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
