### PR TITLE
Report arr.ai stack traces when pattern matching fails

### DIFF
--- a/rel/expr.go
+++ b/rel/expr.go
@@ -37,14 +37,16 @@ func wrapContext(err error, expr Expr) error {
 }
 
 func EvalExpr(expr Expr, local Scope) (_ Value, err error) {
-	defer func() {
-		switch r := recover().(type) {
-		case nil:
-		case error:
-			err = wrapContext(r, expr)
-		default:
-			err = wrapContext(fmt.Errorf("unexpected panic: %v", r), expr)
-		}
-	}()
+	defer wrapPanic(expr, &err)
 	return expr.Eval(local)
+}
+
+func wrapPanic(expr Expr, err *error) {
+	switch r := recover().(type) {
+	case nil:
+	case error:
+		*err = wrapContext(r, expr)
+	default:
+		*err = wrapContext(fmt.Errorf("unexpected panic: %v", r), expr)
+	}
 }

--- a/rel/expr_arrow.go
+++ b/rel/expr_arrow.go
@@ -37,7 +37,8 @@ func (e *ArrowExpr) String() string {
 }
 
 // Eval returns the lhs
-func (e *ArrowExpr) Eval(local Scope) (Value, error) {
+func (e *ArrowExpr) Eval(local Scope) (_ Value, err error) {
+	defer wrapPanic(e, &err)
 	value, err := e.lhs.Eval(local)
 	if err != nil {
 		return nil, wrapContext(err, e)

--- a/rel/expr_darrow.go
+++ b/rel/expr_darrow.go
@@ -35,7 +35,8 @@ func (e *DArrowExpr) String() string {
 }
 
 // Eval returns the lhs transformed elementwise by fn.
-func (e *DArrowExpr) Eval(local Scope) (Value, error) {
+func (e *DArrowExpr) Eval(local Scope) (_ Value, err error) {
+	defer wrapPanic(e, &err)
 	value, err := e.lhs.Eval(local)
 	if err != nil {
 		return nil, wrapContext(err, e)

--- a/rel/expr_seqmap.go
+++ b/rel/expr_seqmap.go
@@ -35,7 +35,8 @@ func (e *SequenceMapExpr) String() string {
 }
 
 // Eval returns the lhs
-func (e *SequenceMapExpr) Eval(local Scope) (Value, error) {
+func (e *SequenceMapExpr) Eval(local Scope) (_ Value, err error) {
+	defer wrapPanic(e, &err)
 	value, err := e.lhs.Eval(local)
 	if err != nil {
 		return nil, wrapContext(err, e)

--- a/rel/expr_tuplemap.go
+++ b/rel/expr_tuplemap.go
@@ -35,6 +35,7 @@ func (e *TupleMapExpr) String() string {
 
 // Eval returns the lhs
 func (e *TupleMapExpr) Eval(local Scope) (_ Value, err error) {
+	defer wrapPanic(e, &err)
 	value, err := e.lhs.Eval(local)
 	if err != nil {
 		return nil, wrapContext(err, e)

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -15,8 +15,8 @@ func TestExprLet(t *testing.T) {
 func TestExprLetValuePattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `42`, `let 42 = 42; 42`)
 	AssertCodesEvalToSameValue(t, `1`, `let 42 = 42; 1`)
-	AssertCodePanics(t, `let 42 = 1; 42`)
-	AssertCodePanics(t, `let 42 = 1; 1`)
+	AssertCodeErrors(t, `let 42 = 1; 42`, "")
+	AssertCodeErrors(t, `let 42 = 1; 1`, "")
 }
 
 func TestExprLetArrayPattern(t *testing.T) {
@@ -36,15 +36,15 @@ func TestExprLetArrayPattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `2`, `let x = 3; let [_, b, (x)] = [1, 2, 3]; b`)
 	AssertCodesEvalToSameValue(t, `2`, `let x = 3; let [x] = [2]; x`)
 
-	AssertCodePanics(t, `let [(x)] = [2]; x`)
-	AssertCodePanics(t, `let x = 3; let [(x)] = [2]; x`)
-	AssertCodePanics(t, `let [x, y] = 1; x`)
-	AssertCodePanics(t, `let [x, x] = [1]; x`)
-	AssertCodePanics(t, `let [x, y] = [1]; x`)
-	AssertCodePanics(t, `let [x, x] = [1, 2]; x`)
+	AssertCodeErrors(t, `let [(x)] = [2]; x`, "")
+	AssertCodeErrors(t, `let x = 3; let [(x)] = [2]; x`, "")
+	AssertCodeErrors(t, `let [x, y] = 1; x`, "")
+	AssertCodeErrors(t, `let [x, x] = [1]; x`, "")
+	AssertCodeErrors(t, `let [x, y] = [1]; x`, "")
+	AssertCodeErrors(t, `let [x, x] = [1, 2]; x`, "")
 	AssertCodeErrors(t, `let [_] = [1]; _`,
 		"Name \"_\" not found in {} \n\n\x1b[1;37m:1:16:\x1b[0m\nlet [_]")
-	AssertCodePanics(t, `let x = 3; let [b, (x)] = [2, 1]; b`)
+	AssertCodeErrors(t, `let x = 3; let [b, (x)] = [2, 1]; b`, "")
 }
 
 func TestExprLetTuplePattern(t *testing.T) {
@@ -56,21 +56,21 @@ func TestExprLetTuplePattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `4`, `let (a:[x]) = (a:[4]); x`)
 	AssertCodesEvalToSameValue(t, `1`, `let (:x) = (x: 1); x`)
 	AssertCodesEvalToSameValue(t, `2`, `let (:x, :y) = (x: 1, y: 2); y`)
-	AssertCodePanics(t, `let (a:x) = (b:7, a:4); x`)
-	AssertCodePanics(t, `let (a:x, a:x) = (a:4, a:4); x`)
-	AssertCodePanics(t, `let (a:x, a:x) = (a:4); x`)
-	AssertCodePanics(t, `let x = 5; let (a:(x)) = (a:4); x`)
-	AssertCodePanics(t, `let (a:x, b:x) = (a:4, b:7); x`)
-	AssertCodePanics(t, `let x = 5; let (a:[(x)]) = (a:[4]); x`)
+	AssertCodeErrors(t, `let (a:x) = (b:7, a:4); x`, "")
+	AssertCodeErrors(t, `let (a:x, a:x) = (a:4, a:4); x`, "")
+	AssertCodeErrors(t, `let (a:x, a:x) = (a:4); x`, "")
+	AssertCodeErrors(t, `let x = 5; let (a:(x)) = (a:4); x`, "")
+	AssertCodeErrors(t, `let (a:x, b:x) = (a:4, b:7); x`, "")
+	AssertCodeErrors(t, `let x = 5; let (a:[(x)]) = (a:[4]); x`, "")
 }
 
 func TestExprLetDictPattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `[4, 5]`, `let d = {"x": 4, "y": 5}; let {"x": a, "y": b} = d; [a, b]`)
 	AssertCodesEvalToSameValue(t, `[4, 5]`, `let {"x": a, "y": b} = {"x": 4, "y": 5}; [a, b]`)
 	AssertCodesEvalToSameValue(t, `4`, `let a = 4; let {"x": (a)} = {"x": 4}; a`)
-	AssertCodePanics(t, `let {"x": a, "y": b} = {"x": 4}; a`)
-	AssertCodePanics(t, `let {"x": a, "y": b} = {"x": 4, "y": 5, "z": 6}; a`)
-	AssertCodePanics(t, `let {"x": a, "x": a} = {"x": 4}; a`)
+	AssertCodeErrors(t, `let {"x": a, "y": b} = {"x": 4}; a`, "")
+	AssertCodeErrors(t, `let {"x": a, "y": b} = {"x": 4, "y": 5, "z": 6}; a`, "")
+	AssertCodeErrors(t, `let {"x": a, "x": a} = {"x": 4}; a`, "")
+	AssertCodeErrors(t, `let a = 4; let {"x": (a)} = {"x": 5}; a`, "")
 	AssertCodePanics(t, `let {"x": a, "x": a} = {"x": 4, "x": 4}; a`)
-	AssertCodePanics(t, `let a = 4; let {"x": (a)} = {"x": 5}; a`)
 }


### PR DESCRIPTION
Panics from pattern matching failures weren't being trapped and turned into arr.ai stack frames.