### PR TITLE
fix nested empty array pattern value

### DIFF
--- a/rel/pattern.go
+++ b/rel/pattern.go
@@ -74,10 +74,14 @@ func NewArrayPattern(elements ...Pattern) ArrayPattern {
 func (p ArrayPattern) Bind(scope Scope, value Value) Scope {
 	if s, is := value.(GenericSet); is {
 		if s.set.IsEmpty() {
-			return EmptyScope
+			if len(p.items) == 0 {
+				return EmptyScope
+			}
+			panic(fmt.Sprintf("value [] is empty but pattern %s is not", p))
 		}
 		panic(fmt.Sprintf("value %s is not an array", value))
 	}
+
 	array, is := value.(Array)
 	if !is {
 		panic(fmt.Sprintf("value %s is not an array", value))

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -116,3 +116,7 @@ func TestExprLetExtraElementsInPattern(t *testing.T) {
 	AssertCodeErrors(t, `let [x, y, ...y] = [1, 2, 4]; x`, "")
 	AssertCodeErrors(t, `let [..., y, ...] = [1, 2, 4]; x`, "")
 }
+
+func TestExprLetNestedPattern(t *testing.T) {
+	AssertCodeErrors(t, `let [[x]] = []; 42`, "")
+}


### PR DESCRIPTION
Fixes #324 .

Changes proposed in this pull request:
- `let [[x]] = []` fails

Checklist:
- [x] Added related tests
