### PR TITLE
reimplement conditional accessor syntax

### DIFF
--- a/rel/expr_binary.go
+++ b/rel/expr_binary.go
@@ -225,18 +225,6 @@ func NewCallExpr(scanner parser.Scanner, a, b Expr) Expr {
 	return newBinExpr(scanner, a, b, "call", "«%s»(%s)", Call)
 }
 
-func SafeCall(a, b Value, local Scope) (Value, error) {
-	if x, ok := a.(Set); ok {
-		return x.CallAll(b), nil
-	}
-	return nil, errors.Errorf(
-		"call lhs must be a function, not %T", a)
-}
-
-func NewSafeCallExpr(scanner parser.Scanner, a, b Expr) Expr {
-	return newBinExpr(scanner, a, b, safeCallOp, "«%s»(%s)?", SafeCall)
-}
-
 func NewCallExprCurry(scanner parser.Scanner, f Expr, args ...Expr) Expr {
 	for _, arg := range args {
 		f = NewCallExpr(scanner, f, arg)

--- a/rel/expr_dot.go
+++ b/rel/expr_dot.go
@@ -7,11 +7,11 @@ import (
 	"github.com/go-errors/errors"
 )
 
-type missingAttrError struct {
+type MissingAttrError struct {
 	ctxErr error
 }
 
-func (m missingAttrError) Error() string {
+func (m MissingAttrError) Error() string {
 	return m.ctxErr.Error()
 }
 
@@ -71,7 +71,7 @@ func (x *DotExpr) Eval(local Scope) (_ Value, err error) {
 				}
 			}
 		}
-		return nil, missingAttrError{
+		return nil, MissingAttrError{
 			wrapContext(errors.Errorf("Missing attr %q (available: %v)", x.attr, t.Names()), x),
 		}
 	}
@@ -97,24 +97,4 @@ func (x *DotExpr) Eval(local Scope) (_ Value, err error) {
 		return nil, wrapContext(errors.Errorf(
 			"(%s).%s: lhs must be a Tuple, not %T", x.lhs, x.attr, a), x)
 	}
-}
-
-type SafeDotExpr struct {
-	d *DotExpr
-}
-
-func NewSafeDotExpr(scanner parser.Scanner, lhs Expr, attr string) Expr {
-	return &SafeDotExpr{NewDotExpr(scanner, lhs, attr).(*DotExpr)}
-}
-
-func (sd *SafeDotExpr) Eval(local Scope) (Value, error) {
-	return sd.d.Eval(local)
-}
-
-func (sd *SafeDotExpr) Source() parser.Scanner {
-	return sd.d.Src
-}
-
-func (sd *SafeDotExpr) String() string {
-	return sd.d.String() + "?"
 }

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -439,23 +439,19 @@ func (pc ParseContext) compileCallGet(b ast.Branch) rel.Expr {
 	if expr := b.One("expr"); expr != nil {
 		result = pc.CompileExpr(expr.(ast.Branch))
 	} else {
-		result = pc.compileGet(rel.DotIdent, b.One("get"), false)
+		result = pc.compileGet(rel.DotIdent, b.One("get"))
 	}
 	for _, part := range b.Many("tail_op") {
 		if safe := part.One("safe_tail"); safe != nil {
 			result = pc.compileSafeTails(result, part.One("safe_tail"))
 		} else {
-			result = pc.compileTail(result, part.One("tail"), false)
+			result = pc.compileTail(result, part.One("tail"))
 		}
 	}
 	return result
 }
 
-func (pc ParseContext) compileTail(base rel.Expr, tail ast.Node, safe bool) rel.Expr {
-	createExpr := rel.NewCallExpr
-	if safe {
-		createExpr = rel.NewSafeCallExpr
-	}
+func (pc ParseContext) compileTail(base rel.Expr, tail ast.Node) rel.Expr {
 	if tail != nil {
 		if call := tail.One("call"); call != nil {
 			args := call.Many("arg")
@@ -464,27 +460,65 @@ func (pc ParseContext) compileTail(base rel.Expr, tail ast.Node, safe bool) rel.
 				exprs = append(exprs, arg.One("expr"))
 			}
 			for _, arg := range pc.compileExprs(exprs...) {
-				base = createExpr(call.Scanner(), base, arg)
+				base = rel.NewCallExpr(call.Scanner(), base, arg)
 			}
 		}
-		base = pc.compileGet(base, tail.One("get"), safe)
+		base = pc.compileGet(base, tail.One("get"))
 	}
 	return base
 }
 
-func (pc ParseContext) compileGet(base rel.Expr, get ast.Node, safe bool) rel.Expr {
-	createExpr := rel.NewDotExpr
-	if safe {
-		createExpr = rel.NewSafeDotExpr
+func (pc ParseContext) compileTailFunc(tail ast.Node) rel.SafeTailCallback {
+	if tail != nil {
+		if call := tail.One("call"); call != nil {
+			args := call.Many("arg")
+			exprs := make([]ast.Node, 0, len(args))
+			for _, arg := range args {
+				exprs = append(exprs, arg.One("expr"))
+			}
+			compiledExprs := pc.compileExprs(exprs...)
+			return func(v rel.Value, local rel.Scope) (rel.Value, error) {
+				for _, arg := range compiledExprs {
+					a, err := arg.Eval(local)
+					if err != nil {
+						return nil, err
+					}
+					v, err = rel.SafeSetCall(v.(rel.Set), a)
+					if err != nil {
+						return nil, err
+					}
+				}
+				return v, nil
+			}
+		}
+		if get := tail.One("get"); get != nil {
+			var scanner parser.Scanner
+			var attr string
+			if ident := get.One("IDENT"); ident != nil {
+				scanner = ident.One("").(ast.Leaf).Scanner()
+				attr = scanner.String()
+			}
+			if str := get.One("STR"); str != nil {
+				scanner = str.One("").Scanner()
+				attr = parseArraiString(scanner.String())
+			}
+			return func(v rel.Value, local rel.Scope) (rel.Value, error) {
+				return rel.NewDotExpr(scanner, v, attr).Eval(local)
+			}
+		}
 	}
+	panic("no tail")
+}
+
+func (pc ParseContext) compileGet(base rel.Expr, get ast.Node) rel.Expr {
 	if get != nil {
 		if ident := get.One("IDENT"); ident != nil {
 			scanner := ident.One("").(ast.Leaf).Scanner()
-			base = createExpr(scanner, base, scanner.String())
+			base = rel.NewDotExpr(scanner, base, scanner.String())
 		}
 		if str := get.One("STR"); str != nil {
 			s := str.One("").Scanner()
-			base = createExpr(s, base, parseArraiString(s.String()))
+			base = rel.NewDotExpr(s, base, parseArraiString(s.String()))
 		}
 	}
 	return base
@@ -493,31 +527,29 @@ func (pc ParseContext) compileGet(base rel.Expr, get ast.Node, safe bool) rel.Ex
 func (pc ParseContext) compileSafeTails(base rel.Expr, tail ast.Node) rel.Expr {
 	if tail != nil {
 		firstSafe := tail.One("first_safe").One("tail")
-		exprStates := []func(rel.Expr) rel.Expr{
-			func(expr rel.Expr) rel.Expr {
-				return pc.compileTail(base, firstSafe, true)
-			},
+		safeCallback := func(tailNode ast.Node) rel.SafeTailCallback {
+			return func(v rel.Value, local rel.Scope) (rel.Value, error) {
+				val, err := pc.compileTailFunc(tailNode)(v, local)
+				if err != nil {
+					switch err.(type) {
+					case rel.MissingAttrError, rel.NoReturnError:
+						return nil, nil
+					default:
+						return nil, err
+					}
+				}
+				return val, nil
+			}
 		}
+		exprStates := []rel.SafeTailCallback{safeCallback(firstSafe)}
 
 		fallback := pc.CompileExpr(tail.One("fall").(ast.Branch))
 
 		for _, o := range tail.Many("ops") {
 			if safeTail := o.One("safe"); safeTail != nil {
-				exprStates = append(exprStates,
-					func(expr rel.Expr) rel.Expr {
-						pctx := pc
-						safe := safeTail.One("tail")
-						return pctx.compileTail(expr, safe, true)
-					},
-				)
+				exprStates = append(exprStates, safeCallback(safeTail.One("tail")))
 			} else if tail := o.One("tail"); tail != nil {
-				exprStates = append(exprStates,
-					func(expr rel.Expr) rel.Expr {
-						pctx := pc
-						unsafeTail := tail
-						return pctx.compileTail(expr, unsafeTail, false)
-					},
-				)
+				exprStates = append(exprStates, pc.compileTailFunc(tail))
 			} else {
 				panic("wat")
 			}

--- a/syntax/expr_safe_tail_test.go
+++ b/syntax/expr_safe_tail_test.go
@@ -5,46 +5,26 @@ import "testing"
 func TestSafeTail(t *testing.T) {
 	t.Parallel()
 
-	AssertCodesEvalToSameValue(t, `1 `, `(a: 1).a?:42                                 `)
-	AssertCodesEvalToSameValue(t, `42`, `(a: 1).b?:42                                 `)
-	AssertCodesEvalToSameValue(t, `1 `, `{"a": 1}("a")?:42                            `)
-	AssertCodesEvalToSameValue(t, `42`, `{"a": 1}("b")?:42                            `)
-	AssertCodesEvalToSameValue(t, `1 `, `(a: (b: 1)).a?.b:42                          `)
-	AssertCodesEvalToSameValue(t, `1 `, `{"a": {"b": 1}}("a")?("b"):42                `)
-	AssertCodesEvalToSameValue(t, `1 `, `let a = (b: (c: (d: (e: 1)))); a.b.c?.d.e?:42`)
-	AssertCodesEvalToSameValue(t, `1 `, `let a = (b: (c: (d: (e: 1)))); a.b.c?.d?.e:42`)
-	AssertCodesEvalToSameValue(t, `42`, `let a = (b: (c: (d: (e: 1)))); a.b.c?.d.f?:42`)
-	AssertCodesEvalToSameValue(t, `42`, `let a = (b: (c: (d: (e: 1)))); a.b.c?.f?.e:42`)
-	AssertCodesEvalToSameValue(t,
-		`1`,
-		`let a = {"b": {"c": {"d": {"e": 1}}}}; a("b", "c", "d", "e")?:42            `)
-	AssertCodesEvalToSameValue(t,
-		`42`,
-		`let a = {"b": {"c": {"d": {"e": 1}}}}; a("b", "c", "x", "e")?:42            `)
-	AssertCodesEvalToSameValue(t,
-		`42`,
-		`let a = {"b": {"c": {"d": {"e": 1}}}}; a("b", "c", "x")?("e"):42            `)
-	AssertCodesEvalToSameValue(t,
-		`1`,
-		`let a = {"b": {"c": {"d": {"e": 1}}}}; a("b")("c")?("d")("e")?:42            `)
-	AssertCodesEvalToSameValue(t,
-		`1`,
-		`let a = {"b": {"c": {"d": {"e": 1}}}}; a("b")("c")?("d")?("e"):42            `)
-	AssertCodesEvalToSameValue(t,
-		`42`,
-		`let a = {"b": {"c": {"d": {"e": 1}}}}; a("b")("c")?("d")("f")?:42            `)
-	AssertCodesEvalToSameValue(t,
-		`42`,
-		`let a = {"b": {"c": {"d": {"e": 1}}}}; a("b")("c")?("f")?("e"):42            `)
-	AssertCodesEvalToSameValue(t,
-		`1`,
-		`let a = {"b": (c: (d: {"e": 1}))}; a("b").c?.d("e")?:42                      `)
-	AssertCodesEvalToSameValue(t,
-		`42`,
-		`let a = {"b": (c: (d: {"e": 1}))}; a("b").c?.d("f")?:42                      `)
-	AssertCodesEvalToSameValue(t,
-		`42`,
-		`let a = {"b": (c: (d: {"e": 1}))}; a("b").c?.e?("f")?:42                     `)
+	AssertCodesEvalToSameValue(t, `1 `, `(a: 1).a?:42                                                     `)
+	AssertCodesEvalToSameValue(t, `42`, `(a: 1).b?:42                                                     `)
+	AssertCodesEvalToSameValue(t, `1 `, `{"a": 1}("a")?:42                                                `)
+	AssertCodesEvalToSameValue(t, `42`, `{"a": 1}("b")?:42                                                `)
+	AssertCodesEvalToSameValue(t, `1 `, `(a: (b: 1)).a?.b:42                                              `)
+	AssertCodesEvalToSameValue(t, `1 `, `{"a": {"b": 1}}("a")?("b"):42                                    `)
+	AssertCodesEvalToSameValue(t, `1 `, `let a = (b: (c: (d: (e: 1)))); a.b.c?.d.e?:42                    `)
+	AssertCodesEvalToSameValue(t, `1 `, `let a = (b: (c: (d: (e: 1)))); a.b.c?.d?.e:42                    `)
+	AssertCodesEvalToSameValue(t, `42`, `let a = (b: (c: (d: (e: 1)))); a.b.c?.d.f?:42                    `)
+	AssertCodesEvalToSameValue(t, `42`, `let a = (b: (c: (d: (e: 1)))); a.b.c?.f?.e:42                    `)
+	AssertCodesEvalToSameValue(t, `1 `, `let a = {"b": {"c": {"d": {"e": 1}}}}; a("b", "c", "d", "e")?:42 `)
+	AssertCodesEvalToSameValue(t, `42`, `let a = {"b": {"c": {"d": {"e": 1}}}}; a("b", "c", "x", "e")?:42 `)
+	AssertCodesEvalToSameValue(t, `42`, `let a = {"b": {"c": {"d": {"e": 1}}}}; a("b", "c", "x")?("e"):42 `)
+	AssertCodesEvalToSameValue(t, `1 `, `let a = {"b": {"c": {"d": {"e": 1}}}}; a("b")("c")?("d")("e")?:42`)
+	AssertCodesEvalToSameValue(t, `1 `, `let a = {"b": {"c": {"d": {"e": 1}}}}; a("b")("c")?("d")?("e"):42`)
+	AssertCodesEvalToSameValue(t, `42`, `let a = {"b": {"c": {"d": {"e": 1}}}}; a("b")("c")?("d")("f")?:42`)
+	AssertCodesEvalToSameValue(t, `42`, `let a = {"b": {"c": {"d": {"e": 1}}}}; a("b")("c")?("f")?("e"):42`)
+	AssertCodesEvalToSameValue(t, `1 `, `let a = {"b": (c: (d: {"e": 1}))}; a("b").c?.d("e")?:42          `)
+	AssertCodesEvalToSameValue(t, `42`, `let a = {"b": (c: (d: {"e": 1}))}; a("b").c?.d("f")?:42          `)
+	AssertCodesEvalToSameValue(t, `42`, `let a = {"b": (c: (d: {"e": 1}))}; a("b").c?.e?("f")?:42         `)
 
 	AssertCodeErrors(t, `(a: 1).a?.c:42               `, `(1).c: lhs must be a Tuple, not rel.Number`)
 	AssertCodeErrors(t, `(a: (b: 1)).a?.c:42          `, `Missing attr "c" (available: |b|)`)

--- a/syntax/expr_safe_tail_test.go
+++ b/syntax/expr_safe_tail_test.go
@@ -17,6 +17,15 @@ func TestSafeTail(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `42`, `let a = (b: (c: (d: (e: 1)))); a.b.c?.f?.e:42`)
 	AssertCodesEvalToSameValue(t,
 		`1`,
+		`let a = {"b": {"c": {"d": {"e": 1}}}}; a("b", "c", "d", "e")?:42            `)
+	AssertCodesEvalToSameValue(t,
+		`42`,
+		`let a = {"b": {"c": {"d": {"e": 1}}}}; a("b", "c", "x", "e")?:42            `)
+	AssertCodesEvalToSameValue(t,
+		`42`,
+		`let a = {"b": {"c": {"d": {"e": 1}}}}; a("b", "c", "x")?("e"):42            `)
+	AssertCodesEvalToSameValue(t,
+		`1`,
 		`let a = {"b": {"c": {"d": {"e": 1}}}}; a("b")("c")?("d")("e")?:42            `)
 	AssertCodesEvalToSameValue(t,
 		`1`,
@@ -39,7 +48,5 @@ func TestSafeTail(t *testing.T) {
 
 	AssertCodeErrors(t, `(a: 1).a?.c:42               `, `(1).c: lhs must be a Tuple, not rel.Number`)
 	AssertCodeErrors(t, `(a: (b: 1)).a?.c:42          `, `Missing attr "c" (available: |b|)`)
-	AssertCodeErrors(t,
-		`{"a": {"b": 1}}("a")?("c"):42`,
-		`unexpected panic: Call: no return values from set {b: 1}`)
+	AssertCodeErrors(t, `{"a": {"b": 1}}("a")?("c"):42`, `Call: no return values from set {b: 1}`)
 }


### PR DESCRIPTION
Initial implementation compiles the chain of accessors during evaluation. This makes sure compilation happens before.

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
