### PR TITLE
Fixes #338, add syntax for sparse array

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -319,6 +319,16 @@ Expression strings are fully described in [Expression strings](expr-str.md).
 Arrays may be expressed using the conventional `[...]` notation, e.g.:
 `[1, 2, [3, 4]]`. They represent relations of the form `{|@, @item| ...}`.
 
+Sparse arrays or arrays with holes can also be defined. For example,
+`[1, 2, , 3]`. This is equivalent to `{|@, @item| (0, 1), (1, 2), (3, 3)}`.
+
+However, holes must be defined in the middle of the elements, which means you
+can not defined `[, , 1, 2]`. Should you want to define that, you can use the
+offset syntax `2\[1, 2]`.
+
+Any empty elements at the end will be trimmed which means
+`[1, 2, 3, ] = [1, 2, 3]`
+
 ### Logic expressions
 
 Arr.ai supports operations on "true" and "false" values. The values `0`, `()`

--- a/rel/expr_array.go
+++ b/rel/expr_array.go
@@ -16,9 +16,11 @@ type ArrayExpr struct {
 func NewArrayExpr(scanner parser.Scanner, elements ...Expr) Expr {
 	values := make([]Value, 0, len(elements))
 	for _, expr := range elements {
-		if value, ok := expr.(Value); ok {
-			values = append(values, value)
-			continue
+		if expr != nil {
+			if value, ok := expr.(Value); ok {
+				values = append(values, value)
+				continue
+			}
 		}
 		return ArrayExpr{ExprScanner{scanner}, elements}
 	}
@@ -50,9 +52,13 @@ func (e ArrayExpr) String() string {
 func (e ArrayExpr) Eval(local Scope) (Value, error) {
 	values := make([]Value, 0, len(e.elements))
 	for _, expr := range e.elements {
-		value, err := expr.Eval(local)
-		if err != nil {
-			return nil, wrapContext(err, e)
+		var value Value
+		if expr != nil {
+			var err error
+			value, err = expr.Eval(local)
+			if err != nil {
+				return nil, wrapContext(err, e)
+			}
 		}
 		values = append(values, value)
 	}

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -73,8 +73,12 @@ C      -> /{ # .* $ };
     C* "{" C* rel=(names tuple=("(" v=top:",", ")"):",",?) "}" C*
   | C* "{" C* set=(elt=top:",",?) "}" C*
   | C* "{" C* dict=((ext=extra|key=expr ":" value=top):",",?) "}" C*
-  | C* "[" C* array=(item=top:",",?) C* "]" C*
+  | C* "[" C* array=(%!sparse_sequence(top)?) C* "]" C*
   | C* "<<" C* bytes=(item=top:",",?) C* ">>" C*
   | C* "(" tuple=(pairs=(extra|name? ":" v=top):",",?) ")" C*
   | C* "(" identpattern=IDENT ")" C*
 };
+
+.macro sparse_sequence(top) {
+  first_item=(top) (",":(item=(top|empty=\s*)),)?
+}

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -177,11 +177,29 @@ func (pc ParseContext) compilePatterns(exprs ...ast.Node) []rel.Pattern {
 	return result
 }
 
-func (pc ParseContext) compileArrayPattern(b ast.Branch) rel.Pattern {
-	if items := b["item"]; items != nil {
-		return rel.NewArrayPattern(pc.compilePatterns(items.(ast.Many)...)...)
+func (pc ParseContext) compileSparsePatterns(b ast.Branch) []rel.Pattern {
+	var nodes []ast.Node
+	if firstItem, exists := b["first_item"]; exists {
+		nodes = []ast.Node{firstItem.(ast.One).Node}
+		if items, exists := b["item"]; exists {
+			for _, i := range items.(ast.Many) {
+				nodes = append(nodes, i)
+			}
+		}
 	}
-	return rel.NewArrayPattern()
+	result := make([]rel.Pattern, 0, len(nodes))
+	for _, expr := range nodes {
+		if expr.One("empty") != nil {
+			result = append(result, nil)
+			continue
+		}
+		result = append(result, pc.compilePattern(expr.(ast.Branch)))
+	}
+	return result
+}
+
+func (pc ParseContext) compileArrayPattern(b ast.Branch) rel.Pattern {
+	return rel.NewArrayPattern(pc.compileSparsePatterns(b)...)
 }
 
 func (pc ParseContext) compileTuplePattern(b ast.Branch) rel.Pattern {
@@ -623,14 +641,15 @@ func (pc ParseContext) compileDictEntryExprs(c ast.Children, keyExprs []rel.Expr
 }
 
 func (pc ParseContext) compileArray(c ast.Children) rel.Expr {
-	if items := c.(ast.One).Node.(ast.Branch)["item"]; items != nil {
-		return rel.NewArrayExpr(items.Scanner(), pc.compileExprs(items.(ast.Many)...)...)
+	if exprs := pc.compileSparseItems(c); len(exprs) > 0 {
+		return rel.NewArrayExpr(c.Scanner(), exprs...)
 	}
 	return rel.NewArray()
 }
 
 func (pc ParseContext) compileBytes(c ast.Children) rel.Expr {
 	if items := c.(ast.One).Node.(ast.Branch)["item"]; items != nil {
+		//TODO: support sparse bytes
 		return rel.NewBytesExpr(items.Scanner(), pc.compileExprs(items.(ast.Many)...)...)
 	}
 	return rel.NewBytes([]byte{})
@@ -639,6 +658,25 @@ func (pc ParseContext) compileBytes(c ast.Children) rel.Expr {
 func (pc ParseContext) compileExprs(exprs ...ast.Node) []rel.Expr {
 	result := make([]rel.Expr, 0, len(exprs))
 	for _, expr := range exprs {
+		result = append(result, pc.CompileExpr(expr.(ast.Branch)))
+	}
+	return result
+}
+
+func (pc ParseContext) compileSparseItems(c ast.Children) []rel.Expr {
+	var nodes []ast.Node
+	if firstItem := c.(ast.One).Node.One("first_item"); firstItem != nil {
+		nodes = []ast.Node{firstItem}
+		if items := c.(ast.One).Node.Many("item"); items != nil {
+			nodes = append(nodes, items...)
+		}
+	}
+	result := make([]rel.Expr, 0, len(nodes))
+	for _, expr := range nodes {
+		if expr.One("empty") != nil {
+			result = append(result, nil)
+			continue
+		}
 		result = append(result, pc.CompileExpr(expr.(ast.Branch)))
 	}
 	return result

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -22,6 +22,8 @@ func TestExprLetValuePattern(t *testing.T) {
 func TestExprLetArrayPattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `1`, `let [] = []; 1`)
 	AssertCodesEvalToSameValue(t, `9`, `let [a, b, c] = [1, 2, 3]; 9`)
+	//TODO: implement pattern matching for sparse array
+	// AssertCodesEvalToSameValue(t, `9`, `let [a, b, , c] = [1, 2, , 3]; 9`)
 	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [a, b, c] = [1, 2, 3]; [a, b, c]`)
 	AssertCodesEvalToSameValue(t, `2`, `let [a, b, c] = [1, 2, 3]; b`)
 	AssertCodesEvalToSameValue(t, `2`, `let arr = [1, 2]; let [a, b] = arr; b`)

--- a/syntax/expr_set_array_test.go
+++ b/syntax/expr_set_array_test.go
@@ -38,6 +38,7 @@ func TestArrayWhere(t *testing.T) {
 
 func TestArrayWithHoles(t *testing.T) {
 	// TODO: Use holey array syntax when available.
-	AssertCodesEvalToSameValue(t, `[10] | 2\[12]`, `[10, 11, 12] where .@ != 1`)
-	AssertCodesEvalToSameValue(t, `[10, 11, 12]`, `([10, 11, 12] where .@ != 1) with (@: 1, @item: 11)`)
+	AssertCodesEvalToSameValue(t, `[10] | 2\[12]`, `[10, , 12]`)
+	AssertCodesEvalToSameValue(t, `[10, 11, 12]`, `[10, , 12] with (@: 1, @item: 11)`)
+	AssertCodesEvalToSameValue(t, `[10, 11, 12]`, `[10, , 12, , , ] with (@: 1, @item: 11)`)
 }

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -87,10 +87,14 @@ C      -> /{ # .* $ };
     C* "{" C* rel=(names tuple=("(" v=top:",", ")"):",",?) "}" C*
   | C* "{" C* set=(elt=top:",",?) "}" C*
   | C* "{" C* dict=((ext=extra|key=expr ":" value=top):",",?) "}" C*
-  | C* "[" C* array=(item=top:",",?) C* "]" C*
+  | C* "[" C* array=(%!sparse_sequence(top)?) C* "]" C*
   | C* "<<" C* bytes=(item=top:",",?) C* ">>" C*
   | C* "(" tuple=(pairs=(extra|name? ":" v=top):",",?) ")" C*
   | C* "(" identpattern=IDENT ")" C*
 };
+
+.macro sparse_sequence(top) {
+  first_item=(top) (",":(item=(top|empty=\s*)),)?
+}
 
 `), nil)


### PR DESCRIPTION
Fixes #338 .

Changes proposed in this pull request:
- Add syntax for sparse array
```
[1, 2, , 3, , 4]
```

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
