### PR TITLE
Fixes #14, implement syntactic sugar for recursive functions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -451,20 +451,25 @@ library:
    eo.even(6)
    ```
 
-In future, these functions will be available through syntactic sugar, something
-like:
+However, these functions are also available through the syntactic sugar in the
+following syntax:
 
+1. For regular recursive functions:
 ```arrai
-let rec factorial = \n 1 if n < 2 else n * factorial(n - 1);
+let rec factorial = \n 1 if n < 2 else n * factorial(n - 1); factorial(5)
 ```
 
+2. For mutual recursion:
 ```arrai
-let rec (
-   even = \n n == 0 || odd (n - 1),
-   odd  = \n n != 0 && even(n - 1),
+let rec oe = (
+   even = \n n == 0 || oe.odd (n - 1),
+   odd  = \n n != 0 && oe.even(n - 1),
 );
-even(6)
+oe.even(6)
 ```
+
+This syntactic sugar only works with expression that evaluates to either a
+function or a tuple of functions. Anything else and the expression will fail.
 
 ### Packages
 

--- a/rel/expr_recursion.go
+++ b/rel/expr_recursion.go
@@ -1,0 +1,53 @@
+package rel
+
+import (
+	"fmt"
+
+	"github.com/arr-ai/wbnf/parser"
+	"github.com/go-errors/errors"
+)
+
+type RecursionExpr struct {
+	ExprScanner
+	name          Pattern
+	fn, fix, fixt Expr
+}
+
+func NewRecursionExpr(scanner parser.Scanner, name Pattern, fn, fix, fixt Expr) Expr {
+	return RecursionExpr{ExprScanner{scanner}, name, fn, fix, fixt}
+}
+
+func (r RecursionExpr) Eval(local Scope) (Value, error) {
+	if _, isIdent := r.name.(IdentExpr); !isIdent {
+		return nil, errors.Errorf("Does not evaluate to a variable name: %v", r.name)
+	}
+
+	val, err := r.fn.Eval(local)
+	if err != nil {
+		return nil, err
+	}
+
+	argName := ExprAsPattern(NewIdentExpr(r.Source(), r.name.String()))
+
+	//TODO: optimise, get it to load either fix or fixt not both
+	switch f := val.(type) {
+	case Tuple:
+		valString := f.String()
+		for e := f.Enumerator(); e.MoveNext(); {
+			attr, val := e.Current()
+			if fn, isFunction := val.(Closure); isFunction {
+				f = f.With(attr, NewClosure(local, NewFunction(fn.Source(), argName, fn.f).(*Function)))
+				continue
+			}
+			return nil, errors.Errorf("Recursion requires a tuple of functions: %v", valString)
+		}
+		return NewCallExpr(r.Source(), r.fixt, f).Eval(local)
+	case Closure:
+		return NewCallExpr(r.Source(), r.fix, NewFunction(f.Source(), argName, f.f)).Eval(local)
+	}
+	return nil, errors.Errorf("Recursion does not support %T", val)
+}
+
+func (r RecursionExpr) String() string {
+	return fmt.Sprintf("\\%s %s", r.name, r.fn)
+}

--- a/rel/expr_recursion.go
+++ b/rel/expr_recursion.go
@@ -19,7 +19,11 @@ func NewRecursionExpr(scanner parser.Scanner, name Pattern, fn Expr, fix, fixt V
 }
 
 func (r RecursionExpr) Eval(local Scope) (Value, error) {
-	if _, isIdent := r.name.(IdentExpr); !isIdent {
+	exprs := r.name.(ExprsPattern).exprs
+
+	var name IdentExpr
+	var isIdent bool
+	if name, isIdent = exprs[0].(IdentExpr); !isIdent || len(exprs) != 1 {
 		return nil, errors.Errorf("Does not evaluate to a variable name: %v", r.name)
 	}
 
@@ -28,7 +32,7 @@ func (r RecursionExpr) Eval(local Scope) (Value, error) {
 		return nil, err
 	}
 
-	argName := ExprAsPattern(NewIdentExpr(r.Source(), r.name.String()))
+	argName := NewIdentExpr(name.Source(), name.String())
 
 	//TODO: optimise, get it to load either fix or fixt not both
 	switch f := val.(type) {

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -26,7 +26,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         | C* fn="\\" IDENT @ C*
         | C* "//" pkg=( "{" dot="."? PKGPATH "}" | std=IDENT?)
         | C* "(" @ ")" C*
-        | C* let=("let" C* pattern C* "=" C* @ %%bind C* ";" C* @) C*
+        | C* let=("let" C* rec="rec"? pattern C* "=" C* @ %%bind C* ";" C* @) C*
         | C* xstr C*
         | C* IDENT C*
         | C* STR C*

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -303,6 +303,12 @@ func (pc ParseContext) compileLet(c ast.Children) rel.Expr {
 
 	p := pc.compilePattern(c.(ast.One).Node.(ast.Branch))
 	rhs = rel.NewFunction(source, p, rhs)
+
+	if c.(ast.One).Node.One("rec") != nil {
+		fix, fixt := FixFuncs()
+		expr = rel.NewRecursionExpr(c.Scanner(), p, expr, fix, fixt)
+	}
+
 	expr = binops["->"](source, expr, rhs)
 	return expr
 }

--- a/syntax/expr_recursion_test.go
+++ b/syntax/expr_recursion_test.go
@@ -1,0 +1,41 @@
+package syntax
+
+import (
+	"testing"
+)
+
+func TestRecursionExpr(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t,
+		`55`,
+		`let rec fib = \n cond (n = 0: 0, n = 1: 1, n > 0: fib(n-1) + fib(n-2), *: 0);
+		fib(10)`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`true`,
+		`let rec eo = (
+     		even: \n n = 0 || eo.odd(n - 1),
+      		odd:  \n n != 0 && eo.even(n - 1),
+   		);
+   		eo.even(6)`,
+	)
+	AssertCodeErrors(t,
+		`let rec eo = (
+     		even: \n n = 0 || eo.odd(n - 1),
+			odd:  \n n != 0 && eo.even(n - 1),
+			num: 6
+   		);
+		eo.even(eo.num)`,
+		"Recursion requires a tuple of functions: "+
+			"(even: ⦇(\\n ((n  = 0)) || («(eo.odd)»((n - 1))))⦈, num: 6, odd: ⦇(\\n ((n  != 0)) && («(eo.even)»((n - 1))))⦈)",
+	)
+	AssertCodeErrors(t,
+		`let rec random = 1; random`,
+		`Recursion does not support rel.Number`,
+	)
+	AssertCodeErrors(t,
+		`let rec 1 = 1; 2`,
+		`Does not evaluate to a variable name: 1`,
+	)
+}

--- a/syntax/expr_recursion_test.go
+++ b/syntax/expr_recursion_test.go
@@ -9,7 +9,7 @@ func TestRecursionExpr(t *testing.T) {
 
 	AssertCodesEvalToSameValue(t,
 		`55`,
-		`let rec fib = \n cond (n = 0: 0, n = 1: 1, n > 0: fib(n-1) + fib(n-2), *: 0);
+		`let rec fib = \n cond {(n = 0): 0, (n = 1): 1, (n > 0): fib(n-1) + fib(n-2), _: 0};
 		fib(10)`,
 	)
 	AssertCodesEvalToSameValue(t,

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -40,7 +40,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         | C* fn="\\" IDENT @ C*
         | C* "//" pkg=( "{" dot="."? PKGPATH "}" | std=IDENT?)
         | C* "(" @ ")" C*
-        | C* let=("let" C* pattern C* "=" C* @ %%bind C* ";" C* @) C*
+        | C* let=("let" C* rec="rec"? pattern C* "=" C* @ %%bind C* ";" C* @) C*
         | C* xstr C*
         | C* IDENT C*
         | C* STR C*

--- a/syntax/std.go
+++ b/syntax/std.go
@@ -13,11 +13,23 @@ import (
 	"github.com/arr-ai/wbnf/wbnf"
 )
 
-var stdScopeOnce sync.Once
-var stdScopeVar rel.Scope
+var (
+	stdScopeOnce, fixOnce sync.Once
+	stdScopeVar           rel.Scope
+	fix, fixt             rel.Value
+)
+
+func FixFuncs() (rel.Value, rel.Value) {
+	fixOnce.Do(func() {
+		fix = parseLit(`(\f f(f))(\f \g \n g(f(f)(g))(n))`)
+		fixt = parseLit(`(\f f(f))(\f \t t :> \g \n g(f(f)(t))(n))`)
+	})
+	return fix, fixt
+}
 
 func StdScope() rel.Scope {
 	stdScopeOnce.Do(func() {
+		fixFn, fixtFn := FixFuncs()
 		stdScopeVar = rel.EmptyScope.
 			With(".", rel.NewTuple(
 				rel.NewNativeFunctionAttr("dict", func(value rel.Value) rel.Value {
@@ -64,8 +76,8 @@ func StdScope() rel.Scope {
 					),
 				),
 				rel.NewTupleAttr("fn",
-					rel.NewAttr("fix", parseLit(`(\f f(f))(\f \g \n g(f(f)(g))(n))`)),
-					rel.NewAttr("fixt", parseLit(`(\f f(f))(\f \t t :> \g \n g(f(f)(t))(n))`)),
+					rel.NewAttr("fix", fixFn),
+					rel.NewAttr("fixt", fixtFn),
 				),
 				rel.NewTupleAttr("log",
 					rel.NewNativeFunctionAttr("print", func(value rel.Value) rel.Value {


### PR DESCRIPTION
Fixes #14.

Changes proposed in this pull request:
- Implement syntactic sugar for recursive functions

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
