### PR TITLE
fix #350, run and eval drops into shell with the last scope

### DIFF
--- a/cmd/arrai/main.go
+++ b/cmd/arrai/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/arr-ai/arrai/rel"
 	"github.com/arr-ai/arrai/syntax"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -77,6 +78,9 @@ VERSION:
 
 	err := app.Run(args)
 	if err != nil {
-		logrus.Fatal(err)
+		logrus.Info(err)
+		if _, isContextErr := err.(rel.ContextErr); isContextErr {
+			logrus.Info(createDebuggerShell(err))
+		}
 	}
 }

--- a/cmd/arrai/main.go
+++ b/cmd/arrai/main.go
@@ -80,7 +80,9 @@ VERSION:
 	if err != nil {
 		logrus.Info(err)
 		if _, isContextErr := err.(rel.ContextErr); isContextErr {
-			logrus.Info(createDebuggerShell(err))
+			if err = createDebuggerShell(err); err != nil {
+				logrus.Info(err)
+			}
 		}
 	}
 }

--- a/cmd/arrai/run.go
+++ b/cmd/arrai/run.go
@@ -32,5 +32,5 @@ func evalFile(path string, w io.Writer) error {
 	if _, err := f.Read(buf); err != nil {
 		return err
 	}
-	return evalExpr(path, string(buf), w)
+	return createDebuggerShell(evalExpr(path, string(buf), w))
 }

--- a/cmd/arrai/shell.go
+++ b/cmd/arrai/shell.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/arr-ai/arrai/internal/shell"
+	"github.com/arr-ai/arrai/rel"
 	"github.com/urfave/cli/v2"
 )
 
@@ -13,5 +14,15 @@ var shellCommand = &cli.Command{
 }
 
 func iShell(_ *cli.Context) error {
-	return shell.Shell()
+	return shell.Shell(rel.EmptyScope)
+}
+
+func createDebuggerShell(err error) error {
+	if err != nil {
+		if ctxErr, isContextError := err.(rel.ContextErr); isContextError {
+			return shell.Shell(ctxErr.GetLastScope())
+		}
+		return err
+	}
+	return nil
 }

--- a/docs/tutorial/shell.md
+++ b/docs/tutorial/shell.md
@@ -35,6 +35,32 @@ $ _
 
 In Windows, TODO.
 
+## Shell as debugger
+
+When you evaluate an arrai script by using and the script fails, the `arrai`
+program will drop into the `arrai` interactive shell with the scope near the
+point of failure available to the interactive shell as a tuple.
+
+This can be accessed through the `@locals` variable.
+
+```bash
+❯ arrai e 'let x = 1; (\a a + b)(x)'
+INFO[0000] Name "b" not found in {a, x}
+
+.:1:20:
+let x = 1; (\a a + b)(x)
+
+.:1:16:
+let x = 1; (\a a + b)(x)
+
+.:1:22:
+let x = 1; (\a a + b)(x)
+@> @locals.x
+1
+@> @locals.
+.a .x
+```
+
 ## Evaluating expressions
 
 To evaluate an expression in the shell, simply type it in and press enter.

--- a/docs/tutorial/shell.md
+++ b/docs/tutorial/shell.md
@@ -37,14 +37,14 @@ In Windows, TODO.
 
 ## Shell as debugger
 
-When you evaluate an arrai script by using and the script fails, the `arrai`
-program will drop into the `arrai` interactive shell with the scope near the
-point of failure available to the interactive shell as a tuple.
+When you evaluate an arrai script and the script fails, the `arrai` program will
+drop into the `arrai` interactive shell with the scope near the point of failure
+available to the interactive shell as a tuple.
 
-This can be accessed through the `@locals` variable.
+The values in the scope can be accessed through the `@locals` variable.
 
 ```bash
-❯ arrai e 'let x = 1; (\a a + b)(x)'
+$ arrai e 'let x = 1; (\a a + b)(x)'
 INFO[0000] Name "b" not found in {a, x}
 
 .:1:20:

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -43,9 +43,24 @@ func shellFilterInputRune(r rune) (rune, bool) {
 	return r, true
 }
 
-func Shell() error {
+func addLocalScope(initialScope rel.Scope) rel.Scope {
+	scope := syntax.StdScope()
+	attrs := make([]rel.Attr, 0)
+	for e := initialScope.Enumerator(); e.MoveNext(); {
+		name, val := e.Current()
+		if v, isValue := val.(rel.Value); isValue {
+			attrs = append(attrs, rel.NewAttr(name, v))
+		}
+	}
+	if len(attrs) > 0 {
+		scope = syntax.StdScope().With("@locals", rel.NewTuple(attrs...))
+	}
+	return scope
+}
+
+func Shell(local rel.Scope) error {
 	ctx := log.WithConfigs(log.SetVerboseMode(true)).Onto(context.Background())
-	sh := newShellInstance(newLineCollector(), syntax.StdScope())
+	sh := newShellInstance(newLineCollector(), addLocalScope(local))
 	l, err := readline.NewEx(&readline.Config{
 		Prompt:              shellPrompt,
 		HistoryFile:         os.ExpandEnv("${HOME}/.arrai_history"),

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -324,3 +324,24 @@ func assertTabCompletion(t *testing.T,
 	assert.Equal(t, expectedPredictions, strPredictions)
 	assert.Equal(t, expectedLength, length)
 }
+
+func TestAddLocalScope(t *testing.T) {
+	t.Parallel()
+
+	scope := rel.EmptyScope.
+		With("random", rel.NewString([]rune("scope"))).
+		With("more", rel.NewNumber(1))
+	resultScope := addLocalScope(scope)
+
+	locals, hasLocals := resultScope.Get("@locals")
+	assert.True(t, hasLocals)
+
+	expectedTuple := rel.EmptyTuple.
+		With("random", rel.NewString([]rune("scope"))).
+		With("more", rel.NewNumber(1))
+	assert.True(t, locals.(rel.Tuple).Equal(expectedTuple))
+
+	resultScope = addLocalScope(rel.EmptyScope)
+	_, hasLocals = resultScope.Get("@locals")
+	assert.False(t, hasLocals)
+}

--- a/internal/shell/shell_wasm.go
+++ b/internal/shell/shell_wasm.go
@@ -2,6 +2,8 @@
 
 package shell
 
-func Shell() error {
+import "github.com/arr-ai/arrai/rel"
+
+func Shell(_ rel.Scope) error {
 	panic("not implemented")
 }

--- a/rel/expr.go
+++ b/rel/expr.go
@@ -32,21 +32,50 @@ func (e ExprScanner) Source() parser.Scanner {
 	return e.Src
 }
 
-func wrapContext(err error, expr Expr) error {
-	return fmt.Errorf("%s\n%s", err.Error(), expr.Source().Context(parser.DefaultLimit))
+type ContextErr struct {
+	err    error
+	source parser.Scanner
+	scope  Scope
+}
+
+func (c ContextErr) Error() string {
+	return fmt.Sprintf("%s\n%s", c.err.Error(), c.source.Context(parser.DefaultLimit))
+}
+
+// GetLastScope gets the scope nearest to the error
+func (c ContextErr) GetLastScope() Scope {
+	ctxErr := c
+	for {
+		var isContextErr bool
+		var currentErr ContextErr
+		if currentErr, isContextErr = ctxErr.err.(ContextErr); !isContextErr {
+			return ctxErr.scope
+		}
+		ctxErr = currentErr
+	}
+}
+
+func wrapContext(err error, expr Expr, scope Scope) error {
+	// removes stdlib
+	scope = scope.Without(".")
+	if _, isContextErr := err.(ContextErr); isContextErr {
+		return ContextErr{err, expr.Source(), EmptyScope}
+	}
+	return ContextErr{err, expr.Source(), scope}
 }
 
 func EvalExpr(expr Expr, local Scope) (_ Value, err error) {
-	defer wrapPanic(expr, &err)
+	//TODO: this is only the initial scope, how to get the last scope?
+	defer wrapPanic(expr, &err, local)
 	return expr.Eval(local)
 }
 
-func wrapPanic(expr Expr, err *error) {
+func wrapPanic(expr Expr, err *error, scope Scope) {
 	switch r := recover().(type) {
 	case nil:
 	case error:
-		*err = wrapContext(r, expr)
+		*err = wrapContext(r, expr, scope)
 	default:
-		*err = wrapContext(fmt.Errorf("unexpected panic: %v", r), expr)
+		*err = wrapContext(fmt.Errorf("unexpected panic: %v", r), expr, scope)
 	}
 }

--- a/rel/expr.go
+++ b/rel/expr.go
@@ -56,11 +56,6 @@ func (c ContextErr) GetLastScope() Scope {
 }
 
 func wrapContext(err error, expr Expr, scope Scope) error {
-	// removes stdlib
-	scope = scope.Without(".")
-	if _, isContextErr := err.(ContextErr); isContextErr {
-		return ContextErr{err, expr.Source(), EmptyScope}
-	}
 	return ContextErr{err, expr.Source(), scope}
 }
 

--- a/rel/expr_array.go
+++ b/rel/expr_array.go
@@ -57,7 +57,7 @@ func (e ArrayExpr) Eval(local Scope) (Value, error) {
 			var err error
 			value, err = expr.Eval(local)
 			if err != nil {
-				return nil, wrapContext(err, e)
+				return nil, wrapContext(err, e, local)
 			}
 		}
 		values = append(values, value)

--- a/rel/expr_array_item_entry.go
+++ b/rel/expr_array_item_entry.go
@@ -30,14 +30,14 @@ func (e ArrayItemTupleExpr) String() string {
 
 // Eval returns the subject.
 func (e ArrayItemTupleExpr) Eval(local Scope) (_ Value, err error) {
-	defer wrapPanic(e, &err)
+	defer wrapPanic(e, &err, local)
 	at, err := e.at.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	value, err := e.item.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	return NewArrayItemTuple(int(at.(Number).Float64()), value), nil
 }

--- a/rel/expr_arrow.go
+++ b/rel/expr_arrow.go
@@ -38,14 +38,14 @@ func (e *ArrowExpr) String() string {
 
 // Eval returns the lhs
 func (e *ArrowExpr) Eval(local Scope) (_ Value, err error) {
-	defer wrapPanic(e, &err)
+	defer wrapPanic(e, &err, local)
 	value, err := e.lhs.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	scope, err := e.fn.arg.Bind(local, value)
 	if err != nil {
-		return nil, err
+		return nil, wrapContext(err, e, local)
 	}
 	return e.fn.body.Eval(local.Update(scope))
 }

--- a/rel/expr_binary.go
+++ b/rel/expr_binary.go
@@ -266,16 +266,19 @@ func (e *BinExpr) String() string {
 
 // Eval returns the subject
 func (e *BinExpr) Eval(local Scope) (_ Value, err error) {
-	defer wrapPanic(e, &err)
+	defer wrapPanic(e, &err, local)
 	a, err := e.a.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 
 	b, err := e.b.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
-
-	return e.eval(a, b, local)
+	val, err := e.eval(a, b, local)
+	if err != nil {
+		return nil, wrapContext(err, e, local)
+	}
+	return val, nil
 }

--- a/rel/expr_bytes.go
+++ b/rel/expr_bytes.go
@@ -30,30 +30,30 @@ func (b BytesExpr) Eval(local Scope) (Value, error) {
 	for _, expr := range b.elements {
 		value, err := expr.Eval(local)
 		if err != nil {
-			return nil, wrapContext(err, b)
+			return nil, wrapContext(err, b, local)
 		}
 		switch v := value.(type) {
 		case Number:
 			if !isByteNumber(v) {
-				return nil, wrapContext(errors.Errorf("BytesExpr.Eval: Number does not represent a byte: %v", v), b)
+				return nil, wrapContext(errors.Errorf("BytesExpr.Eval: Number does not represent a byte: %v", v), b, local)
 			}
 			bytes = append(bytes, byte(v))
 		case String:
 			if err := b.handleOffset(v); err != nil {
-				return nil, err
+				return nil, wrapContext(err, b, local)
 			}
 			bytes = append(bytes, []byte(string(v.s))...)
 		case GenericSet:
 			if s, isString := AsString(v); isString {
 				if err := b.handleOffset(s); err != nil {
-					return nil, err
+					return nil, wrapContext(err, b, local)
 				}
 				bytes = append(bytes, []byte(string(s.s))...)
 				continue
 			}
-			return nil, wrapContext(errors.Errorf("BytesExpr.Eval: Set %v is not supported", expr), b)
+			return nil, wrapContext(errors.Errorf("BytesExpr.Eval: Set %v is not supported", expr), b, local)
 		default:
-			return nil, wrapContext(errors.Errorf("BytesExpr.Eval: %T is not supported", v), b)
+			return nil, wrapContext(errors.Errorf("BytesExpr.Eval: %T is not supported", v), b, local)
 		}
 	}
 	return NewBytes(bytes), nil
@@ -61,7 +61,7 @@ func (b BytesExpr) Eval(local Scope) (Value, error) {
 
 func (b BytesExpr) handleOffset(s String) error {
 	if s.offset != 0 {
-		return wrapContext(errors.Errorf("BytesExpr.Eval: offsetted String is not supported: %v", s), b)
+		return errors.Errorf("BytesExpr.Eval: offsetted String is not supported: %v", s)
 	}
 	return nil
 }

--- a/rel/expr_cond.go
+++ b/rel/expr_cond.go
@@ -58,12 +58,12 @@ func (e CondExpr) Eval(local Scope) (Value, error) {
 
 			cond, err := tempExpr.at.Eval(local)
 			if err != nil {
-				return nil, wrapContext(err, e)
+				return nil, wrapContext(err, e, local)
 			}
 
 			valid, err := e.validValidation(cond, local)
 			if err != nil {
-				return nil, wrapContext(err, e)
+				return nil, wrapContext(err, e, local)
 			}
 			if cond != nil && valid {
 				trueCond = &tempExpr
@@ -81,7 +81,7 @@ func (e CondExpr) Eval(local Scope) (Value, error) {
 
 	value, err := finalCond.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	return value, nil
 }

--- a/rel/expr_cond_control_var.go
+++ b/rel/expr_cond_control_var.go
@@ -34,7 +34,7 @@ func NewCondControlVarExpr(scanner parser.Scanner, controlVar Expr, dictExpr Exp
 					if !has {
 						return false, fmt.Errorf("%s", err.Error())
 					}
-					return false, wrapContext(err, currentExpr)
+					return false, wrapContext(err, currentExpr, local)
 				}
 				for _, exprVal := range condition.Values() {
 					if exprVal.Equal(varVal) {
@@ -66,7 +66,7 @@ func (e CondControlVarExpr) String() string {
 func (e CondControlVarExpr) Eval(local Scope) (Value, error) {
 	controlVarVal, err := e.controlVarExpr.Eval(local)
 	if err != nil {
-		return nil, err
+		return nil, wrapContext(err, e, local)
 	}
 
 	local = local.With("controlVarVal", controlVarVal).With("currentExpr", e)

--- a/rel/expr_cond_pattern_control_var.go
+++ b/rel/expr_cond_pattern_control_var.go
@@ -45,15 +45,16 @@ func (expr CondPatternControlVarExpr) String() string {
 func (expr CondPatternControlVarExpr) Eval(local Scope) (Value, error) {
 	varVal, err := expr.controlVarExpr.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, expr.controlVarExpr)
+		return nil, wrapContext(err, expr.controlVarExpr, local)
 	}
 
 	for _, conditionPair := range expr.conditionPairs {
 		bindings, err := conditionPair.Bind(local, varVal)
 		if err == nil {
-			val, err := conditionPair.Eval(local.MatchedUpdate(bindings))
+			l := local.MatchedUpdate(bindings)
+			val, err := conditionPair.Eval(l)
 			if err != nil {
-				return nil, err
+				return nil, wrapContext(err, expr.controlVarExpr, l)
 			}
 			return val, nil
 		}

--- a/rel/expr_darrow.go
+++ b/rel/expr_darrow.go
@@ -36,25 +36,25 @@ func (e *DArrowExpr) String() string {
 
 // Eval returns the lhs transformed elementwise by fn.
 func (e *DArrowExpr) Eval(local Scope) (_ Value, err error) {
-	defer wrapPanic(e, &err)
+	defer wrapPanic(e, &err, local)
 	value, err := e.lhs.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	if set, ok := value.(Set); ok {
 		values := []Value{}
 		for i := set.Enumerator(); i.MoveNext(); {
 			scope, err := e.fn.arg.Bind(local, i.Current())
 			if err != nil {
-				return nil, err
+				return nil, wrapContext(err, e, local)
 			}
 			v, err := e.fn.body.Eval(local.Update(scope))
 			if err != nil {
-				return nil, wrapContext(err, e)
+				return nil, wrapContext(err, e, local)
 			}
 			values = append(values, v)
 		}
 		return NewSet(values...), nil
 	}
-	return nil, wrapContext(errors.Errorf("=> not applicable to %T: %[1]v", value), e)
+	return nil, wrapContext(errors.Errorf("=> not applicable to %T: %[1]v", value), e, local)
 }

--- a/rel/expr_dict.go
+++ b/rel/expr_dict.go
@@ -52,11 +52,11 @@ func (e DictExpr) Eval(local Scope) (Value, error) {
 	for _, expr := range e.entryExprs {
 		at, err := expr.at.Eval(local)
 		if err != nil {
-			return nil, wrapContext(err, e)
+			return nil, wrapContext(err, e, local)
 		}
 		value, err := expr.value.Eval(local)
 		if err != nil {
-			return nil, wrapContext(err, e)
+			return nil, wrapContext(err, e, local)
 		}
 		entryExprs = append(entryExprs, NewDictEntryTuple(at, value))
 	}

--- a/rel/expr_dot.go
+++ b/rel/expr_dot.go
@@ -46,13 +46,13 @@ func (x *DotExpr) String() string {
 
 // Eval returns the lhs
 func (x *DotExpr) Eval(local Scope) (_ Value, err error) {
-	defer wrapPanic(x, &err)
+	defer wrapPanic(x, &err, local)
 	if x.attr == "*" {
-		return nil, errors.Errorf("expr.* not allowed outside tuple attr")
+		return nil, wrapContext(errors.Errorf("expr.* not allowed outside tuple attr"), x, local)
 	}
 	a, err := x.lhs.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, x)
+		return nil, wrapContext(err, x, local)
 	}
 	get := func(t Tuple) (Value, error) {
 		if value, found := t.Get(x.attr); found {
@@ -72,7 +72,7 @@ func (x *DotExpr) Eval(local Scope) (_ Value, err error) {
 			}
 		}
 		return nil, MissingAttrError{
-			wrapContext(errors.Errorf("Missing attr %q (available: %v)", x.attr, t.Names()), x),
+			wrapContext(errors.Errorf("Missing attr %q (available: %v)", x.attr, t.Names()), x, local),
 		}
 	}
 
@@ -81,20 +81,20 @@ func (x *DotExpr) Eval(local Scope) (_ Value, err error) {
 		return get(t)
 	case Set:
 		if !t.IsTrue() {
-			return nil, wrapContext(errors.Errorf("Cannot get attr %q from empty set", x.attr), x)
+			return nil, wrapContext(errors.Errorf("Cannot get attr %q from empty set", x.attr), x, local)
 		}
 		e := t.Enumerator()
 		e.MoveNext()
 		v := e.Current()
 		if e.MoveNext() {
-			return nil, wrapContext(errors.Errorf("Too many elts to get attr %q from set", x.attr), x)
+			return nil, wrapContext(errors.Errorf("Too many elts to get attr %q from set", x.attr), x, local)
 		}
 		if t, ok := v.(Tuple); ok {
 			return get(t)
 		}
-		return nil, wrapContext(errors.Errorf("Cannot get attr %q from non-tuple set elt", x.attr), x)
+		return nil, wrapContext(errors.Errorf("Cannot get attr %q from non-tuple set elt", x.attr), x, local)
 	default:
 		return nil, wrapContext(errors.Errorf(
-			"(%s).%s: lhs must be a Tuple, not %T", x.lhs, x.attr, a), x)
+			"(%s).%s: lhs must be a Tuple, not %T", x.lhs, x.attr, a), x, local)
 	}
 }

--- a/rel/expr_if_else.go
+++ b/rel/expr_if_else.go
@@ -43,7 +43,7 @@ func (e *IfElseExpr) String() string {
 func (e *IfElseExpr) Eval(local Scope) (Value, error) {
 	cond, err := e.cond.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	if cond.IsTrue() {
 		return e.ifTrue.Eval(local)

--- a/rel/expr_logical.go
+++ b/rel/expr_logical.go
@@ -22,7 +22,7 @@ func (e AndExpr) String() string {
 func (e AndExpr) Eval(local Scope) (Value, error) {
 	a, err := e.a.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	if !a.IsTrue() {
 		return a, nil
@@ -30,7 +30,7 @@ func (e AndExpr) Eval(local Scope) (Value, error) {
 
 	b, err := e.b.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 
 	return b, nil
@@ -52,7 +52,7 @@ func (e OrExpr) String() string {
 func (e OrExpr) Eval(local Scope) (Value, error) {
 	a, err := e.a.Eval(local)
 	if err != nil {
-		return nil, err
+		return nil, wrapContext(err, e, local)
 	}
 	if a.IsTrue() {
 		return a, nil
@@ -60,7 +60,7 @@ func (e OrExpr) Eval(local Scope) (Value, error) {
 
 	b, err := e.b.Eval(local)
 	if err != nil {
-		return nil, err
+		return nil, wrapContext(err, e, local)
 	}
 
 	return b, nil

--- a/rel/expr_nary.go
+++ b/rel/expr_nary.go
@@ -36,12 +36,12 @@ func (e CompareExpr) String() string {
 func (e CompareExpr) Eval(local Scope) (Value, error) {
 	lhs, err := e.args[0].Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	for i, arg := range e.args[1:] {
 		rhs, err := arg.Eval(local)
 		if err != nil {
-			return nil, wrapContext(err, e)
+			return nil, wrapContext(err, e, local)
 		}
 		if !e.comps[i](lhs, rhs) {
 			return False, nil

--- a/rel/expr_nest.go
+++ b/rel/expr_nest.go
@@ -44,10 +44,10 @@ func (e *NestExpr) String() string {
 func (e *NestExpr) Eval(local Scope) (Value, error) {
 	value, err := e.lhs.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	if set, ok := value.(Set); ok {
 		return Nest(set, e.attrs, e.attr), nil
 	}
-	return nil, wrapContext(errors.Errorf("nest not applicable to %T", value), e)
+	return nil, wrapContext(errors.Errorf("nest not applicable to %T", value), e, local)
 }

--- a/rel/expr_offset.go
+++ b/rel/expr_offset.go
@@ -20,19 +20,19 @@ func NewOffsetExpr(scanner parser.Scanner, n, s Expr) Expr {
 }
 
 func (o *OffsetExpr) Eval(local Scope) (_ Value, err error) {
-	defer wrapPanic(o, &err)
+	defer wrapPanic(o, &err, local)
 	offset, err := o.offset.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, o)
+		return nil, wrapContext(err, o, local)
 	}
 	_, isNumber := offset.(Number)
 	if !isNumber {
-		return nil, wrapContext(errors.Errorf("\\ not applicable to %T", offset), o)
+		return nil, wrapContext(errors.Errorf("\\ not applicable to %T", offset), o, local)
 	}
 
 	array, err := o.array.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, o)
+		return nil, wrapContext(err, o, local)
 	}
 	switch a := array.(type) {
 	case Array:
@@ -42,7 +42,7 @@ func (o *OffsetExpr) Eval(local Scope) (_ Value, err error) {
 	case String:
 		return NewOffsetString(a.s, a.offset+int(offset.(Number))), nil
 	}
-	return nil, wrapContext(errors.Errorf("\\ not applicable to %T", array), o)
+	return nil, wrapContext(errors.Errorf("\\ not applicable to %T", array), o, local)
 }
 
 func (o *OffsetExpr) String() string {

--- a/rel/expr_recursion.go
+++ b/rel/expr_recursion.go
@@ -24,12 +24,12 @@ func (r RecursionExpr) Eval(local Scope) (Value, error) {
 	var name IdentExpr
 	var isIdent bool
 	if name, isIdent = exprs[0].(IdentExpr); !isIdent || len(exprs) != 1 {
-		return nil, errors.Errorf("Does not evaluate to a variable name: %v", r.name)
+		return nil, wrapContext(errors.Errorf("Does not evaluate to a variable name: %v", r.name), r, local)
 	}
 
 	val, err := r.fn.Eval(local)
 	if err != nil {
-		return nil, err
+		return nil, wrapContext(err, r, local)
 	}
 
 	argName := NewIdentExpr(name.Source(), name.String())
@@ -44,13 +44,13 @@ func (r RecursionExpr) Eval(local Scope) (Value, error) {
 				f = f.With(attr, NewClosure(local, NewFunction(fn.Source(), argName, fn.f).(*Function)))
 				continue
 			}
-			return nil, errors.Errorf("Recursion requires a tuple of functions: %v", t.String())
+			return nil, wrapContext(errors.Errorf("Recursion requires a tuple of functions: %v", t.String()), r, local)
 		}
 		return Call(r.fixt, f, local)
 	case Closure:
 		return Call(r.fix, NewClosure(local, NewFunction(f.Source(), argName, f.f).(*Function)), local)
 	}
-	return nil, errors.Errorf("Recursion does not support %T", val)
+	return nil, wrapContext(errors.Errorf("Recursion does not support %T", val), r, local)
 }
 
 func (r RecursionExpr) String() string {

--- a/rel/expr_reduce.go
+++ b/rel/expr_reduce.go
@@ -138,24 +138,24 @@ func (e *ReduceExpr) String() string {
 
 // Eval returns the subject
 func (e *ReduceExpr) Eval(local Scope) (_ Value, err error) {
-	defer wrapPanic(e, &err)
+	defer wrapPanic(e, &err, local)
 	a, err := e.a.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	if s, ok := a.(Set); ok {
 		acc, err := e.init(s)
 		if err != nil {
-			return nil, wrapContext(err, e)
+			return nil, wrapContext(err, e, local)
 		}
 		for i := s.Enumerator(); i.MoveNext(); {
 			f, err := e.f.Eval(local)
 			if err != nil {
-				return nil, wrapContext(err, e)
+				return nil, wrapContext(err, e, local)
 			}
 			acc, err = e.reduce(acc, SetCall(f.(Closure), i.Current()))
 			if err != nil {
-				return nil, wrapContext(err, e)
+				return nil, wrapContext(err, e, local)
 			}
 		}
 		return e.output(acc)

--- a/rel/expr_safe_tail.go
+++ b/rel/expr_safe_tail.go
@@ -24,12 +24,12 @@ func NewSafeTailExpr(scanner parser.Scanner, fallback, base Expr, tailExprs []Sa
 func (s *SafeTailExpr) Eval(local Scope) (value Value, err error) {
 	value, err = s.base.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, s)
+		return nil, wrapContext(err, s, local)
 	}
 	for _, t := range s.tailExprs {
 		value, err = t(value, local)
 		if err != nil {
-			return nil, err
+			return nil, wrapContext(err, s, local)
 		}
 		if value == nil {
 			return s.fallbackValue.Eval(local)

--- a/rel/expr_seqmap.go
+++ b/rel/expr_seqmap.go
@@ -36,10 +36,10 @@ func (e *SequenceMapExpr) String() string {
 
 // Eval returns the lhs
 func (e *SequenceMapExpr) Eval(local Scope) (_ Value, err error) {
-	defer wrapPanic(e, &err)
+	defer wrapPanic(e, &err, local)
 	value, err := e.lhs.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	// TODO: implement directly for String, Array and Dict.
 	if set, ok := value.(Set); ok {
@@ -51,15 +51,15 @@ func (e *SequenceMapExpr) Eval(local Scope) (_ Value, err error) {
 			item, _ := t.Get(attr)
 			scope, err := e.fn.arg.Bind(local, item)
 			if err != nil {
-				return nil, err
+				return nil, wrapContext(err, e, local)
 			}
 			v, err := e.fn.body.Eval(local.Update(scope))
 			if err != nil {
-				return nil, wrapContext(err, e)
+				return nil, wrapContext(err, e, local)
 			}
 			values = append(values, NewTuple(Attr{"@", pos}, Attr{attr, v}))
 		}
 		return NewSet(values...), nil
 	}
-	return nil, wrapContext(errors.Errorf(">> not applicable to %T", value), e)
+	return nil, wrapContext(errors.Errorf(">> not applicable to %T", value), e, local)
 }

--- a/rel/expr_set.go
+++ b/rel/expr_set.go
@@ -54,7 +54,7 @@ func (e *SetExpr) Eval(local Scope) (Value, error) {
 	for _, expr := range e.elements {
 		value, err := EvalExpr(expr, local)
 		if err != nil {
-			return nil, wrapContext(err, e)
+			return nil, wrapContext(err, e, local)
 		}
 		values = append(values, value)
 	}

--- a/rel/expr_string_char_entry.go
+++ b/rel/expr_string_char_entry.go
@@ -30,14 +30,14 @@ func (e StringCharTupleExpr) String() string {
 
 // Eval returns the subject
 func (e StringCharTupleExpr) Eval(local Scope) (_ Value, err error) {
-	defer wrapPanic(e, &err)
+	defer wrapPanic(e, &err, local)
 	at, err := e.at.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	char, err := e.char.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	return NewStringCharTuple(int(at.(Number).Float64()), rune(char.(Number).Float64())), nil
 }

--- a/rel/expr_test.go
+++ b/rel/expr_test.go
@@ -1,0 +1,30 @@
+package rel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLastScope(t *testing.T) {
+	t.Parallel()
+
+	scope := EmptyScope.With("stuff", NewNumber(1)).With("random", NewNumber(2))
+	err := wrapContext(
+		wrapContext(
+			wrapContext(fmt.Errorf("random"), EmptyTuple, scope),
+			EmptyTuple,
+			scope,
+		),
+		EmptyTuple,
+		scope,
+	)
+	assert.True(t, err.(ContextErr).GetLastScope().m.Equal(scope.m))
+
+	err = wrapContext(fmt.Errorf("random"), EmptyTuple, scope)
+	assert.True(t, err.(ContextErr).GetLastScope().m.Equal(scope.m))
+
+	err = wrapContext(fmt.Errorf("random"), EmptyTuple, EmptyScope)
+	assert.True(t, err.(ContextErr).GetLastScope().m.Equal(EmptyScope.m))
+}

--- a/rel/expr_tuple.go
+++ b/rel/expr_tuple.go
@@ -159,7 +159,7 @@ func (e *TupleExpr) Eval(local Scope) (Value, error) {
 	for _, attr := range e.attrs {
 		tuple, err = attr.Apply(local, tuple)
 		if err != nil {
-			return nil, wrapContext(err, e)
+			return nil, wrapContext(err, e, local)
 		}
 	}
 	// TODO: Construct new tuple directly

--- a/rel/expr_tuple_dict_entry.go
+++ b/rel/expr_tuple_dict_entry.go
@@ -32,11 +32,11 @@ func (e DictEntryTupleExpr) String() string {
 func (e DictEntryTupleExpr) Eval(local Scope) (Value, error) {
 	at, err := e.at.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	value, err := e.value.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	return NewDictEntryTuple(at, value), nil
 }

--- a/rel/expr_tuplemap.go
+++ b/rel/expr_tuplemap.go
@@ -35,10 +35,10 @@ func (e *TupleMapExpr) String() string {
 
 // Eval returns the lhs
 func (e *TupleMapExpr) Eval(local Scope) (_ Value, err error) {
-	defer wrapPanic(e, &err)
+	defer wrapPanic(e, &err, local)
 	value, err := e.lhs.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	defer func() {
 		if r := recover(); r != nil {

--- a/rel/expr_unary.go
+++ b/rel/expr_unary.go
@@ -111,7 +111,11 @@ func (e *UnaryExpr) String() string {
 func (e *UnaryExpr) Eval(local Scope) (Value, error) {
 	a, err := e.a.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
-	return e.eval(a, local)
+	val, err := e.eval(a, local)
+	if err != nil {
+		return nil, wrapContext(err, e, local)
+	}
+	return val, nil
 }

--- a/rel/expr_unnest.go
+++ b/rel/expr_unnest.go
@@ -38,10 +38,10 @@ func (e *UnnestExpr) String() string {
 func (e *UnnestExpr) Eval(local Scope) (Value, error) {
 	value, err := e.lhs.Eval(local)
 	if err != nil {
-		return nil, wrapContext(err, e)
+		return nil, wrapContext(err, e, local)
 	}
 	if set, ok := value.(Set); ok {
 		return Unnest(set, e.attr), nil
 	}
-	return nil, wrapContext(errors.Errorf("unnest not applicable to %T", value), e)
+	return nil, wrapContext(errors.Errorf("unnest not applicable to %T", value), e, local)
 }

--- a/rel/scope.go
+++ b/rel/scope.go
@@ -47,7 +47,7 @@ func (s Scope) Eval(local Scope) (Value, error) {
 		name, expr := e.Current()
 		value, err := expr.Eval(local)
 		if err != nil {
-			return nil, err
+			return nil, wrapContext(err, expr, local)
 		}
 		tuple = tuple.With(name, value)
 	}


### PR DESCRIPTION
Fixes #350 .

Changes proposed in this pull request:
- `arrai run` and `arrai eval` will drop into the interactive shell with the last scope available to it

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
