### PR TITLE
fixes #375, handles running arrai script from syntax lib

### DIFF
--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -17,6 +17,9 @@ func stdOsGetArgs() rel.Value {
 	default:
 		if RunOmitted {
 			offset = 1
+		} else if len(os.Args) == 1 {
+			// to handle running script from syntax library
+			return rel.NewArray()
 		} else {
 			offset = 2
 		}


### PR DESCRIPTION
Fixes #375 .

Changes proposed in this pull request:
- `//os.args` doesn't handle running arrai script from syntax library, this PR handles that

Checklist:
- [ ] Added related tests
- [ ] Made corresponding changes to the documentation
