### PR TITLE
allows `//eval.value` to take in an array of bytes

### DIFF
--- a/docs/std-eval.md
+++ b/docs/std-eval.md
@@ -2,7 +2,7 @@
 
 The `eval` contains functions which converts raw string into a built-in arrai values.
 
-## `//eval.value(s <: string) <: any`
+## `//eval.value(s <: string|array_of_bytes) <: any`
 
 `value` takes in a string `s` which represents an arrai value and converts them to
 arrai values.

--- a/docs/std-eval.md
+++ b/docs/std-eval.md
@@ -4,7 +4,7 @@ The `eval` contains functions which converts raw string into a built-in arrai va
 
 ## `//eval.value(s <: string|array_of_bytes) <: any`
 
-`value` takes in a string `s` which represents an arrai value and converts them to
+`value` takes in a string or byte array `s` which represents an arrai value and converts them to
 arrai values.
 
 However, `eval` is only supported to evaluate simple values e.g. numbers,

--- a/syntax/std_eval.go
+++ b/syntax/std_eval.go
@@ -1,6 +1,10 @@
 package syntax
 
-import "github.com/arr-ai/arrai/rel"
+import (
+	"fmt"
+
+	"github.com/arr-ai/arrai/rel"
+)
 
 func stdEval() rel.Attr {
 	return rel.NewTupleAttr("eval",
@@ -13,9 +17,13 @@ func stdEval() rel.Attr {
 }
 
 func evalExpr(v rel.Value) rel.Value {
-	evaluated, err := EvaluateExpr(".", v.(rel.String).String())
-	if err != nil {
-		panic(err)
+	switch val := v.(type) {
+	case rel.String, rel.Bytes:
+		evaluated, err := EvaluateExpr(".", val.String())
+		if err != nil {
+			panic(err)
+		}
+		return evaluated
 	}
-	return evaluated
+	panic(fmt.Sprintf("eval.value only takes byte array or string: %T", v))
 }

--- a/syntax/std_eval.go
+++ b/syntax/std_eval.go
@@ -25,5 +25,5 @@ func evalExpr(v rel.Value) rel.Value {
 		}
 		return evaluated
 	}
-	panic(fmt.Sprintf("eval.value only takes byte array or string: %T", v))
+	panic(fmt.Sprintf("eval.value only takes byte array or string, received %T", v))
 }

--- a/syntax/std_eval_test.go
+++ b/syntax/std_eval_test.go
@@ -11,5 +11,12 @@ func TestEvalValue(t *testing.T) {
 	AssertCodesEvalToSameValue(t,
 		`(str: "stuff", num:123, array: [1,2,3])`,
 		`//eval.value("(str: 'stuff', num:123, array: [1,2,3])")`)
+	AssertCodesEvalToSameValue(t, `123             `, `//eval.value(<<"123">>)             `)
+	AssertCodesEvalToSameValue(t, `true            `, `//eval.value(<<"true">>)            `)
+	AssertCodesEvalToSameValue(t, `123.321         `, `//eval.value(<<"123.321">>)         `)
+	AssertCodesEvalToSameValue(t, `"this is a test"`, `//eval.value(<<"'this is a test'">>)`)
+	AssertCodesEvalToSameValue(t,
+		`(str: "stuff", num:123, array: [1,2,3])`,
+		`//eval.value(<<"(str: 'stuff', num:123, array: [1,2,3])">>)`)
 	AssertCodeErrors(t, `//eval.value(123)`, "")
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- allows `//eval.value` to take in string and an array of bytes

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
