### PR TITLE
Cond change to `cond x {...}`

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -119,47 +119,47 @@ $ arrai eval 'cond {cond {1 > 2 : 1, _ : 11} < 2 : 1, 2 < 3: 2, _:1 + 2}'
 
 #### Control Var Cases
 ```bash
-$ arrai eval 'let a = 1; a cond {1 :1, 2 :2, _:1 + 2}'
+$ arrai eval 'let a = 1; cond a {1 :1, 2 :2, _:1 + 2}'
 1
 ```
 
 ```bash
-$ arrai eval 'let a = 1; a cond {1 :1 + 10, 2 : 2, _:1 + 2}'
+$ arrai eval 'let a = 1; cond a {1 :1 + 10, 2 : 2, _:1 + 2}'
 11
 ```
 
 ```bash
-$ arrai eval 'let a = 1; a cond {2 :2, _:1 + 2}'
+$ arrai eval 'let a = 1; cond a {2 :2, _:1 + 2}'
 3
 ```
 
 ```bash
-$ arrai eval 'let a = 1; let b = a cond {1 :1, 2 :2, _:1 + 2}; b * 100'
+$ arrai eval 'let a = 1; let b = cond a {1 :1, 2 :2, _:1 + 2}; b * 100'
 100
 ```
 
 ```bash
-$ arrai eval 'let a = 1; a + 1 cond {1 :1, 2 :2, _:1 + 2}'
+$ arrai eval 'let a = 1; cond a + 1 {1 :1, 2 :2, _:1 + 2}'
 2
 ```
 
 ```bash
-$ arrai eval 'let a = 2; a cond { 1: "A", (2, 3): "B", _: "C"}'
+$ arrai eval 'let a = 2; cond a { 1: "A", (2, 3): "B", _: "C"}'
 B
 ```
 
 ```bash
-$ arrai eval 'let a = 2; a cond { (a cond {(1,2) : 1}): "A", (2, 3): "B", _: "C"}'
+$ arrai eval 'let a = 2; cond a { (cond a {(1,2) : 1}): "A", (2, 3): "B", _: "C"}'
 B
 ```
 
 ```bash
-$ arrai eval 'let a = 1; a cond { (cond {2 > 1 : 1}): "A", (2, 3): "B", _: "C"}'
+$ arrai eval 'let a = 1; cond a { (cond {2 > 1 : 1}): "A", (2, 3): "B", _: "C"}'
 A
 ```
 
 ```bash
-$ arrai eval 'let a = 1; cond { a cond {1 : 1} : "A", 2: "B", _: "C"}'
+$ arrai eval 'let a = 1; cond { cond a {1 : 1} : "A", 2: "B", _: "C"}'
 A
 ```
 

--- a/examples/grpc/grpc.arrai
+++ b/examples/grpc/grpc.arrai
@@ -1,7 +1,7 @@
 (
     type: //fn.fix(\type \t
-        t.type cond {
-            'primitive': t.primitive cond {
+        cond t.type {
+            'primitive': cond t.primitive {
                 'DECIMAL':  'double',
                 'INT':      'int64',
                 'FLOAT':    'double',

--- a/rel/expr_cond_pattern_control_var.go
+++ b/rel/expr_cond_pattern_control_var.go
@@ -11,11 +11,11 @@ import (
 type CondPatternControlVarExpr struct {
 	ExprScanner
 	controlVarExpr Expr
-	conditionPairs []PatternExpr
+	conditionPairs []PatternExprPair
 }
 
 // NewCondPatternControlVarExpr returns a new CondPatternControlVarExpr.
-func NewCondPatternControlVarExpr(scanner parser.Scanner, controlVar Expr, patternExprs ...PatternExpr) Expr {
+func NewCondPatternControlVarExpr(scanner parser.Scanner, controlVar Expr, patternExprs ...PatternExprPair) Expr {
 	return CondPatternControlVarExpr{ExprScanner{scanner}, controlVar, patternExprs}
 }
 

--- a/rel/expr_pattern.go
+++ b/rel/expr_pattern.go
@@ -2,25 +2,26 @@ package rel
 
 import "fmt"
 
-type PatternExpr struct {
+// PatternExprPair a Pattern/Expr pair
+type PatternExprPair struct {
 	pattern Pattern
 	expr    Expr
 }
 
-// NewPatternExpr returns a new PatternExpr.
-func NewPatternExpr(pattern Pattern, expr Expr) PatternExpr {
-	return PatternExpr{pattern, expr}
+// NewPatternExprPair returns a new PatternExprPair.
+func NewPatternExprPair(pattern Pattern, expr Expr) PatternExprPair {
+	return PatternExprPair{pattern, expr}
 }
 
 // String returns a string representation of a PatternPair.
-func (pt PatternExpr) String() string {
+func (pt PatternExprPair) String() string {
 	return fmt.Sprintf("%s:%s", pt.pattern, pt.expr)
 }
 
-func (pt PatternExpr) Bind(local Scope, value Value) (Scope, error) {
+func (pt PatternExprPair) Bind(local Scope, value Value) (Scope, error) {
 	return pt.pattern.Bind(local, value)
 }
 
-func (pt PatternExpr) Eval(local Scope) (Value, error) {
+func (pt PatternExprPair) Eval(local Scope) (Value, error) {
 	return pt.expr.Eval(local)
 }

--- a/rel/pattern.go
+++ b/rel/pattern.go
@@ -346,6 +346,7 @@ func (p DictPattern) String() string {
 	return b.String()
 }
 
+// ExprsPattern a wrapper represents Expr as Pattern, then Expr can be compiled to Pattern too.
 type ExprsPattern struct {
 	exprs []Expr
 }

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -10,7 +10,6 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* @:binop="&&" C*
         > C* @:compare=/{!?(?:<:|=|<=?|>=?|\((?:<=?|>=?|<>=?)\))} C*
         > C* @ if=("if" t=expr ("else" f=expr)?)* C*
-        > C* @ cond=("cond" "{" (condition=pattern ":" value=expr):",",? "}")? C*
         > C* @:binop=/{\+\+|[+|]|-%?} C*
         > C* @:binop=/{&~|&|~~?|[-<][-&][->]} C*
         > C* @:binop=/{//|[*/%]|\\} C*
@@ -21,6 +20,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* (get | @) tail_op=(safe_tail | tail)* C*
         > %!patternterms(expr)
         | C* cond=("cond" "{" (key=@ ":" value=@):",",? "}") C*
+        | C* cond=("cond" controlVar=expr "{" (condition=pattern ":" value=@):",",? "}") C*
         | C* "{:" C* embed=(grammar=@ ":" subgrammar=%%ast) ":}" C*
         | C* op="\\\\" @ C*
         | C* fn="\\" IDENT @ C*

--- a/syntax/expr_cond_test.go
+++ b/syntax/expr_cond_test.go
@@ -68,49 +68,49 @@ func TestEvalCondStr(t *testing.T) {
 func TestEvalCondWithControlVar(t *testing.T) {
 	t.Parallel()
 
-	AssertCodesEvalToSameValue(t, `{}`, `let a = 1; a cond {(1 + 2) :1, 2 :2}`)
+	AssertCodesEvalToSameValue(t, `{}`, `let a = 1; cond a {(1 + 2) :1, 2 :2}`)
 	// // Control var conditions
-	AssertCodesEvalToSameValue(t, `1`, `let a = 1; a cond {1 :1}`)
-	AssertCodesEvalToSameValue(t, `1`, `let a = 1; a cond {1 :1, 2:2}`)
-	AssertCodesEvalToSameValue(t, `1`, `let a = 1; a cond {1 :1, 2 :2, _:1 + 2}`)
-	AssertCodesEvalToSameValue(t, `11`, `let a = 1; a cond {(1) :1 + 10, (2) : 2, _:1 + 2}`)
-	AssertCodesEvalToSameValue(t, `3`, `let a = 1; a cond {234 :2, _:1 + 2}`)
-	AssertCodesEvalToSameValue(t, `3`, `let a = 1; a cond {(234) :2, _:1 + 2}`)
-	AssertCodesEvalToSameValue(t, `2`, `let a = 234; a cond {234 :2, _:11 + 2}`)
-	AssertCodesEvalToSameValue(t, `5`, `let a = 3; a cond {_:5}`)
-	AssertCodesEvalToSameValue(t, `3`, `let a = 3; a cond {_:1 + 2}`)
+	AssertCodesEvalToSameValue(t, `1`, `let a = 1; cond a {1 :1}`)
+	AssertCodesEvalToSameValue(t, `1`, `let a = 1; cond a {1 :1, 2:2}`)
+	AssertCodesEvalToSameValue(t, `1`, `let a = 1; cond a {1 :1, 2 :2, _:1 + 2}`)
+	AssertCodesEvalToSameValue(t, `11`, `let a = 1; cond a {(1) :1 + 10, (2) : 2, _:1 + 2}`)
+	AssertCodesEvalToSameValue(t, `3`, `let a = 1; cond a {234 :2, _:1 + 2}`)
+	AssertCodesEvalToSameValue(t, `3`, `let a = 1; cond a {(234) :2, _:1 + 2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = 234; cond a {234 :2, _:11 + 2}`)
+	AssertCodesEvalToSameValue(t, `5`, `let a = 3; cond a {_:5}`)
+	AssertCodesEvalToSameValue(t, `3`, `let a = 3; cond a {_:1 + 2}`)
 
-	AssertCodesEvalToSameValue(t, `1`, `let a = 1; let b = a cond {1 :1, 2 :2, _:1 + 2}; b`)
-	AssertCodesEvalToSameValue(t, `100`, `let a = 1; let b = a cond {1 :1, 2 :2, _:1 + 2}; b * 100`)
+	AssertCodesEvalToSameValue(t, `1`, `let a = 1; let b = cond a {1 :1, 2 :2, _:1 + 2}; b`)
+	AssertCodesEvalToSameValue(t, `100`, `let a = 1; let b = cond a {1 :1, 2 :2, _:1 + 2}; b * 100`)
 	// // //
-	AssertCodesEvalToSameValue(t, `2`, `let a = 1; (a + 100) cond {1 :1, 101 :2, _:1 + 2}`)
-	AssertCodesEvalToSameValue(t, `3`, `let a = 1; a + 10 cond {1 :1, 2 :2, _:1 + 2}`)
-	AssertCodesEvalToSameValue(t, `2`, `let a = 1; let b = a + 1 cond {1 :1, 2 :2, _:1 + 2}; b`)
-	AssertCodesEvalToSameValue(t, `300`, `let a = 1; let b = a + 10 cond {1 :1, 2 :2, _:1 + 2}; b * 100`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = 1; cond (a + 100) {1 :1, 101 :2, _:1 + 2}`)
+	AssertCodesEvalToSameValue(t, `3`, `let a = 1; cond a + 10 {1 :1, 2 :2, _:1 + 2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = 1; let b = cond a + 1 {1 :1, 2 :2, _:1 + 2}; b`)
+	AssertCodesEvalToSameValue(t, `300`, `let a = 1; let b = cond a + 10 {1 :1, 2 :2, _:1 + 2}; b * 100`)
 	// Nested call
-	AssertCodesEvalToSameValue(t, `"B"`, `let a = 2; a cond {(a cond {(1,2) : 1}): "A", (2, 3): "B", _: "C"}`)
-	AssertCodesEvalToSameValue(t, `"A"`, `let a = 1; a cond { (cond {(2 > 1) : 1}): "A", (2, 3): "B", _: "C"}`)
-	AssertCodesEvalToSameValue(t, `"A"`, `let a = 1; cond { (a cond {(1) : 1}) : "A", (2): "B", _: "C"}`)
+	AssertCodesEvalToSameValue(t, `"B"`, `let a = 2; cond a {(cond a {(1,2) : 1}): "A", (2, 3): "B", _: "C"}`)
+	AssertCodesEvalToSameValue(t, `"A"`, `let a = 1; cond a {(cond {(2 > 1) : 1}): "A", (2, 3): "B", _: "C"}`)
+	AssertCodesEvalToSameValue(t, `"A"`, `let a = 1; cond {(cond a {(1) : 1}) : "A", (2): "B", _: "C"}`)
 
-	AssertCodesEvalToSameValue(t, `{}`, `let a = 3; a cond {1 :1, 2 :2 + 1}`)
-	AssertCodesEvalToSameValue(t, `{}`, `let a = 3; let b = a cond {1 :1, 2 :2 + 1}; b`)
-	AssertCodesEvalToSameValue(t, `{}`, `let a = 3; let b = a + 10 cond {1 :1, 2 :2 + 1}; b`)
+	AssertCodesEvalToSameValue(t, `{}`, `let a = 3; cond a {1 :1, 2 :2 + 1}`)
+	AssertCodesEvalToSameValue(t, `{}`, `let a = 3; let b = cond a {1 :1, 2 :2 + 1}; b`)
+	AssertCodesEvalToSameValue(t, `{}`, `let a = 3; let b = cond a + 10 {1 :1, 2 :2 + 1}; b`)
 
-	AssertCodesEvalToSameValue(t, `1`, `let x = 1; 2 cond { 2: x }`)
+	AssertCodesEvalToSameValue(t, `1`, `let x = 1; cond 2 { 2: x }`)
 }
 
 func TestEvalCondWithControlVarMulti(t *testing.T) {
-	AssertCodesEvalToSameValue(t, `1`, `let a = 1; a cond {(1 + 0,2 + 0) :1}`)
-	AssertCodesEvalToSameValue(t, `1`, `let a = 2; a cond {(1 + 0,2 + 0,3 + 0) :1, (2 + 0):2}`)
-	AssertCodesEvalToSameValue(t, `2`, `let a = 2; a cond {(1 + 0,2 + 4,3 + 5) :1, (2 + 0):2}`)
-	AssertCodesEvalToSameValue(t, `11`, `let [a,b] = [2,4]; a cond {(1 + 0,b -2,3 + 5) :11, (2):2}`)
-	AssertCodesEvalToSameValue(t, `1`, `let a = 3; a cond {(1 + 0,2 + 0,3 + 0) :1, (2 + 0) :2, _:1 + 2}`)
+	AssertCodesEvalToSameValue(t, `1`, `let a = 1; cond a {(1 + 0,2 + 0) :1}`)
+	AssertCodesEvalToSameValue(t, `1`, `let a = 2; cond a {(1 + 0,2 + 0,3 + 0) :1, (2 + 0):2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = 2; cond a {(1 + 0,2 + 4,3 + 5) :1, (2 + 0):2}`)
+	AssertCodesEvalToSameValue(t, `11`, `let [a,b] = [2,4]; cond a {(1 + 0,b -2,3 + 5) :11, (2):2}`)
+	AssertCodesEvalToSameValue(t, `1`, `let a = 3; cond a {(1 + 0,2 + 0,3 + 0) :1, (2 + 0) :2, _:1 + 2}`)
 
-	AssertCodesEvalToSameValue(t, `2`, `let a = 2; a cond {(1) :1 + 10, (2,3) : 2, _:1 + 2}`)
-	AssertCodesEvalToSameValue(t, `2`, `let a = 2; a cond {(1) :1 + 10, (3,2) : 2, _:1 + 2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = 2; cond a {(1) :1 + 10, (2,3) : 2, _:1 + 2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = 2; cond a {(1) :1 + 10, (3,2) : 2, _:1 + 2}`)
 
 	AssertCodesEvalToSameValue(t, `"med"`, `let a = 2;
-	a cond {
+	cond a {
 		(1):"lo",
 		(2,3): "med",
 		_: "hi"}`)
@@ -119,62 +119,63 @@ func TestEvalCondWithControlVarMulti(t *testing.T) {
 // TestEvalCondMultiStr executes the cases whose condition has multiple expressions.
 func TestEvalCondMultiStr(t *testing.T) {
 	t.Parallel()
-	AssertEvalExprString(t, "((control_var:1),{((1>0))&&((2>1)):1})", "(1) cond {(1 > 0 && 2 > 1) : 1}")
-	AssertEvalExprString(t, "((control_var:1),{((1>0))||((2>1)):1})", "(1) cond {(1 > 0 || 2 > 1) : 1}")
-	AssertEvalExprString(t, "((control_var:1),{((1>0))||((2>1)):1,_:11})", "(1) cond {(1 > 0 || 2 > 1) : 1, _ : 11}")
+	AssertEvalExprString(t, "((control_var:1),{((1>0))&&((2>1)):1})", "cond (1) {(1 > 0 && 2 > 1) : 1}")
+	AssertEvalExprString(t, "((control_var:1),{((1>0))||((2>1)):1})", "cond (1) {(1 > 0 || 2 > 1) : 1}")
+	AssertEvalExprString(t, "((control_var:1),{((1>0))||((2>1)):1,_:11})", "cond (1) {(1 > 0 || 2 > 1) : 1, _ : 11}")
 }
 
 func TestEvalCondWithControlVarStr(t *testing.T) {
 	t.Parallel()
-	AssertEvalExprString(t, "((control_var:1),{1:1})", "(1) cond {1 : 1}")
-	AssertEvalExprString(t, "((control_var:1),{1:1})", "(1) cond {1 : 1,}")
-	AssertEvalExprString(t, "((control_var:1),{1:1,(2+1):3})", "(1) cond {1 : 1, (2 + 1) : 3}")
-	AssertEvalExprString(t, "((control_var:1),{1:1,(2+1):3})", "(1) cond {(1) : 1, (2 + 1) : 3,}")
-	AssertEvalExprString(t, "((control_var:1),{1:1,(2+1):3,_:4})", "(1) cond {1 : 1, (2 + 1) : 3, _ : 4}")
-	AssertEvalExprString(t, "((control_var:1),{1:1,(2+1):3,_:4})", "(1) cond {(1) : 1, (2 + 1) : 3, _ : 4,}")
+	AssertEvalExprString(t, "((control_var:1),{1:1})", "cond (1) {1 : 1}")
+	AssertEvalExprString(t, "((control_var:1),{1:1})", "cond (1) {1 : 1,}")
+	AssertEvalExprString(t, "((control_var:1),{1:1,(2+1):3})", "cond (1) {1 : 1, (2 + 1) : 3}")
+	AssertEvalExprString(t, "((control_var:1),{1:1,(2+1):3})", "cond (1) {(1) : 1, (2 + 1) : 3,}")
+	AssertEvalExprString(t, "((control_var:1),{1:1,(2+1):3,_:4})", "cond (1) {1 : 1, (2 + 1) : 3, _ : 4}")
+	AssertEvalExprString(t, "((control_var:1),{1:1,(2+1):3,_:4})", "cond (1) {(1) : 1, (2 + 1) : 3, _ : 4,}")
 
 	AssertEvalExprString(t, "(1->(\\a((control_var:a),{1:1})))",
-		"let a = 1; a cond {(1) : 1}")
+		"let a = 1; cond a {(1) : 1}")
 	AssertEvalExprString(t, "(1->(\\a((control_var:a),{(1+2):1,_:(1+2)})))",
-		"let a = 1; a cond {(1 + 2): 1, _ : 1 + 2}")
+		"let a = 1; cond a {(1 + 2): 1, _ : 1 + 2}")
 	AssertEvalExprString(t, "(2->(\\a(((control_var:a),{(1+2):1,_:(1+2)})->(\\b(b*1)))))",
-		"let a = 2; let b = a cond {(1 + 2): 1, _ : 1 + 2}; b * 1")
+		"let a = 2; let b = cond a {(1 + 2): 1, _ : 1 + 2}; b * 1")
 	AssertEvalExprString(t, "(3->(\\a((control_var:(a+2)),{(1+2):1,_:(1+2)})))",
-		"let a = 3; (a + 2) cond {(1 + 2): 1, _ : 1 + 2}")
+		"let a = 3; cond (a + 2) {(1 + 2): 1, _ : 1 + 2}")
 }
 
 func TestEvalCondWithControlVarMultiStr(t *testing.T) {
 	t.Parallel()
-	AssertEvalExprString(t, "((control_var:1),{[1,2]:1})", "(1) cond {(1,2) :1}")
-	AssertEvalExprString(t, "((control_var:2),{1:(1+10),[2,3]:2,_:(1+2)})", "(2) cond {(1) :1 + 10, (2,3) : 2, _:1 + 2}")
+	AssertEvalExprString(t, "((control_var:1),{[1,2]:1})", "cond (1) {(1,2) :1}")
+	AssertEvalExprString(t, "((control_var:2),{1:(1+10),[2,3]:2,_:(1+2)})", "cond (2) {(1) :1 + 10, (2,3) : 2, _:1 + 2}")
 }
 
 func TestEvalCondPatternMatchingWithControlVar(t *testing.T) {
 	t.Parallel()
-	AssertCodesEvalToSameValue(t, `2`, `let a = 'A' ; a cond {'A':2}`)
-	AssertCodesEvalToSameValue(t, `2`, `let a = 'ABC' ; a cond {'ABC':2}`)
-	AssertCodesEvalToSameValue(t, `2`, `let a = "A" ; a cond {"A":2}`)
-	AssertCodesEvalToSameValue(t, `2`, `let a = "ABC" ; a cond {"ABC":2}`)
-	AssertCodesEvalToSameValue(t, `2`, `let [a,b,c] = [10,100,1000]; 1100 cond {(b + c):2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = 'A' ; cond a {'A':2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = 'ABC' ; cond a {'ABC':2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = "A" ; cond a {"A":2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = "ABC" ; cond a {"ABC":2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let [a,b,c] = [10,100,1000]; cond 1100 {(b + c):2}`)
 
-	AssertCodesEvalToSameValue(t, `2`, `let a = [1, 2]; a cond {[1, 2]: 2}`)
-	AssertCodesEvalToSameValue(t, `2`, `let a = ['a', 'b']; a cond {['a', 'b']: 2}`)
-	AssertCodesEvalToSameValue(t, `6`, `let a = (x:4); a cond {(x:x): x + 2}`)
-	AssertCodesEvalToSameValue(t, `6`, `(x:4) cond {(x:x): x + 2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = [1, 2]; cond a {[1, 2]: 2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = ['a', 'b']; cond a {['a', 'b']: 2}`)
+	AssertCodesEvalToSameValue(t, `6`, `let a = (x:4); cond a {(x:x): x + 2}`)
+	AssertCodesEvalToSameValue(t, `6`, `cond (x:4) {(x:x): x + 2}`)
 
-	AssertCodesEvalToSameValue(t, `8`, `let a = (a:3); a cond {(a:x): x + 5,_:2}`)
-	AssertCodesEvalToSameValue(t, `8`, `let a = {"a":3}; a cond {{"a":x}: x + 5,_:2}`)
-	AssertCodesEvalToSameValue(t, `2`, `let a = {"a":3}; a cond {1 : x + 5,_:2}`)
+	AssertCodesEvalToSameValue(t, `8`, `let a = (a:3); cond a {(a:x): x + 5,_:2}`)
+	AssertCodesEvalToSameValue(t, `8`, `let a = {"a":3}; cond a {{"a":x}: x + 5,_:2}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = {"a":3}; cond a {1 : x + 5,_:2}`)
 
-	AssertCodesEvalToSameValue(t, `10`, `{'a': {'b': 10}} cond {{'a': {'b': b}}: b, _:42}`)
-	AssertCodesEvalToSameValue(t, `42`, `{'a': {'z': 10}} cond {{'a': {'b': b}}: b, _:42}`)
-	AssertCodesEvalToSameValue(t, `10`, `(a: (b: 10)) cond {(a: (:b)): b, _:42}`)
-	AssertCodesEvalToSameValue(t, `42`, `(a: (z: 10)) cond {(a: (:b)): b, _:42}`)
+	AssertCodesEvalToSameValue(t, `10`, `cond ({'a': {'b': 10}}) {{'a': {'b': b}}: b, _:42}`)
+	AssertCodesEvalToSameValue(t, `42`, `cond ({'a': {'z': 10}}) {{'a': {'b': b}}: b, _:42}`)
 
-	AssertCodesEvalToSameValue(t, `42`, `[] cond {[b]: b, _:42}`)
-	AssertCodesEvalToSameValue(t, `42`, `(a: []) cond {(a: [b]): b, _:42}`)
-	AssertCodesEvalToSameValue(t, `43`, `() cond {{1:2}: 42, _: 43}`)
+	AssertCodesEvalToSameValue(t, `10`, `cond (a: (b: 10)) {(a: (:b)): b, _:42}`)
+	AssertCodesEvalToSameValue(t, `42`, `cond (a: (z: 10)) {(a: (:b)): b, _:42}`)
 
-	AssertCodesEvalToSameValue(t, `{}`, `let a = 2; a cond {[1,2,3]: 6}`)
-	AssertCodesEvalToSameValue(t, `2`, `let a = {"a":3}; a cond {(a:x): x + 5,_:2}`)
+	AssertCodesEvalToSameValue(t, `42`, `cond [] {[b]: b, _:42}`)
+	AssertCodesEvalToSameValue(t, `42`, `cond (a: []) {(a: [b]): b, _:42}`)
+	AssertCodesEvalToSameValue(t, `43`, `cond () {{1:2}: 42, _: 43}`)
+
+	AssertCodesEvalToSameValue(t, `{}`, `let a = 2; cond a {[1,2,3]: 6}`)
+	AssertCodesEvalToSameValue(t, `2`, `let a = {"a":3}; cond a {(a:x): x + 5,_:2}`)
 }

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -24,7 +24,6 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* @:binop="&&" C*
         > C* @:compare=/{!?(?:<:|=|<=?|>=?|\((?:<=?|>=?|<>=?)\))} C*
         > C* @ if=("if" t=expr ("else" f=expr)?)* C*
-        > C* @ cond=("cond" "{" (condition=pattern ":" value=expr):",",? "}")? C*
         > C* @:binop=/{\+\+|[+|]|-%?} C*
         > C* @:binop=/{&~|&|~~?|[-<][-&][->]} C*
         > C* @:binop=/{//|[*/%]|\\} C*
@@ -35,6 +34,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* (get | @) tail_op=(safe_tail | tail)* C*
         > %!patternterms(expr)
         | C* cond=("cond" "{" (key=@ ":" value=@):",",? "}") C*
+        | C* cond=("cond" controlVar=expr "{" (condition=pattern ":" value=@):",",? "}") C*
         | C* "{:" C* embed=(grammar=@ ":" subgrammar=%%ast) ":}" C*
         | C* op="\\\\" @ C*
         | C* fn="\\" IDENT @ C*


### PR DESCRIPTION
Fixes #371 .

Changes proposed in this pull request:
- Changed cond syntax to `cond x {...}`

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
