### PR TITLE
expands the highlighted source context for access operations

### DIFF
--- a/syntax/scanners_test.go
+++ b/syntax/scanners_test.go
@@ -1,0 +1,17 @@
+package syntax
+
+import (
+	"testing"
+
+	"github.com/arr-ai/wbnf/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleAccessScanners(t *testing.T) {
+	base := parser.NewScanner(".")
+	access := parser.NewScannerAt(".a.b", 1, 2)
+
+	assert.Equal(t, 0, handleAccessScanners(*base, *access).Offset())
+
+	assert.Equal(t, *access, handleAccessScanners(parser.Scanner{}, *access))
+}


### PR DESCRIPTION
Before, when an access operation fails, the stack dump only show its arguments or attribute access is highlighted. This commit extends the highlighting up to the accessed value.

before
```
a.b.<highlighted>c</highlighted>
```

after
```
<highlighted>a.b.c</highlighted>
```


Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
