### PR TITLE
Change optional fallback from expr to atom

### DIFF
--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -18,7 +18,10 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* unop=/{[-+!*^]}* @ C*
         > C* @:binop=">>>" C*
         > C* @ postfix=/{count|single}? C* touch? C*
-        > C* (get | @) tail_op=(safe_tail | tail)* C*
+        > C* (get | @) tail_op=(
+            safe_tail=(first_safe=(tail "?") ops=(safe=(tail "?") | tail)* ":" fall=@)
+            | tail
+          )* C*
         > %!patternterms(expr)
         | C* cond=("cond" "{" (key=@ ":" value=@):SEQ_COMMENT,? "}") C*
         | C* cond=("cond" controlVar=expr "{" (condition=pattern ":" value=@):SEQ_COMMENT,? "}") C*
@@ -53,7 +56,6 @@ tail   -> get
                     |     ":" end=expr  (":" step=expr)?
                 ):SEQ_COMMENT,
             ")");
-safe_tail -> first_safe=(tail "?") ops=(safe=(tail "?") | tail)* ":" fall=expr;
 pattern -> extra | %!patternterms(pattern|expr) | IDENT | NUM | C* "(" exprpattern=expr:SEQ_COMMENT,? ")" C* | C* exprpattern=STR C*;
 extra -> ("..." ident=IDENT?);
 

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -32,7 +32,10 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* unop=/{[-+!*^]}* @ C*
         > C* @:binop=">>>" C*
         > C* @ postfix=/{count|single}? C* touch? C*
-        > C* (get | @) tail_op=(safe_tail | tail)* C*
+        > C* (get | @) tail_op=(
+            safe_tail=(first_safe=(tail "?") ops=(safe=(tail "?") | tail)* ":" fall=@)
+            | tail
+          )* C*
         > %!patternterms(expr)
         | C* cond=("cond" "{" (key=@ ":" value=@):SEQ_COMMENT,? "}") C*
         | C* cond=("cond" controlVar=expr "{" (condition=pattern ":" value=@):SEQ_COMMENT,? "}") C*
@@ -67,7 +70,6 @@ tail   -> get
                     |     ":" end=expr  (":" step=expr)?
                 ):SEQ_COMMENT,
             ")");
-safe_tail -> first_safe=(tail "?") ops=(safe=(tail "?") | tail)* ":" fall=expr;
 pattern -> extra | %!patternterms(pattern|expr) | IDENT | NUM | C* "(" exprpattern=expr:SEQ_COMMENT,? ")" C* | C* exprpattern=STR C*;
 extra -> ("..." ident=IDENT?);
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Currently, `a.b?:{} => ... >> ...` parses as `a.b?:({} => ... >> ...)`, which is counterintuitive.

The expectation is that `?:` bind quite tightly, so only the `{}` is picked up as the fallback value. This is because the most common case for the `?:` fallback value is a simple "zero"-value like `0`, `[]`, `""`, etc.

Checklist:
- [ ] Added related tests
- [ ] Made corresponding changes to the documentation
