### PR TITLE
Implement unary =>, >> and :>

### DIFF
--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -5,6 +5,7 @@ expr   -> C* amp="&"* @ C* arrow=(
               binding="->" C* "\\" C* pattern C* %%bind C* @ |
               binding="->" C* %%bind @
           )* C*
+        > C* unop=/{:>|=>|>>}* @ C*
         > C* @:binop=("without" | "with") C*
         > C* @:binop="||" C*
         > C* @:binop="&&" C*
@@ -14,7 +15,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* @:binop=/{&~|&|~~?|[-<][-&][->]} C*
         > C* @:binop=/{//|[*/%]|\\} C*
         > C* @:rbinop="^" C*
-        > C* unop=/{:>|=>|>>|[-+!*^]}* @ C*
+        > C* unop=/{[-+!*^]}* @ C*
         > C* @:binop=">>>" C*
         > C* @ postfix=/{count|single}? C* touch? C*
         > C* (get | @) tail_op=(safe_tail | tail)* C*

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -905,6 +905,12 @@ func which(b ast.Branch, names ...string) (string, ast.Children) {
 	return "", nil
 }
 
+func dotUnary(f binOpFunc) unOpFunc {
+	return func(scanner parser.Scanner, e rel.Expr) rel.Expr {
+		return f(scanner, rel.DotIdent, e)
+	}
+}
+
 type unOpFunc func(scanner parser.Scanner, e rel.Expr) rel.Expr
 
 var unops = map[string]unOpFunc{
@@ -914,6 +920,9 @@ var unops = map[string]unOpFunc{
 	"!":  rel.NewNotExpr,
 	"*":  rel.NewEvalExpr,
 	"//": NewPackageExpr,
+	"=>": dotUnary(rel.NewMapExpr),
+	">>": dotUnary(rel.NewSequenceMapExpr),
+	":>": dotUnary(rel.NewTupleMapExpr),
 }
 
 type binOpFunc func(scanner parser.Scanner, a, b rel.Expr) rel.Expr

--- a/syntax/expr_arrow_test.go
+++ b/syntax/expr_arrow_test.go
@@ -21,3 +21,17 @@ func TestApplyExprWithPattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `[3, [3, 4]]`, `[1, 2, 3, 4] -> \[x, y, ...t] [x + y, t]`)
 	AssertCodeErrors(t, `1 -> \x let [(x), y] = [2, 2]; y`, "")
 }
+
+func TestUnaryArrows(t *testing.T) {
+	// This tests an error when stringifying sets of arrays.
+	AssertCodesEvalToSameValue(t, `{{2, 4}, {8, 16}}`, `{{1, 2}, {3, 4}} => => 2 ^ .`)
+	AssertCodesEvalToSameValue(t, `{[2, 4], [8, 16]}`, `{[1, 2], [3, 4]} => >> 2 ^ .`)
+	AssertCodesEvalToSameValue(t, `{{'a':2, 'b':4}, {'c':8, 'd':16}}`, `{{'a':1, 'b':2}, {'c':3, 'd':4}} => >> 2 ^ .`)
+	AssertCodesEvalToSameValue(t, `{(a:2, b:4), (c:8, d:16)}`, `{(a:1, b:2), (c:3, d:4)} => :> 2 ^ .`)
+
+	AssertCodesEvalToSameValue(t, `[{2, 4}, {8, 16}]`, `[{1, 2}, {3, 4}] >> => 2 ^ .`)
+
+	AssertCodesEvalToSameValue(t,
+		`(a:{[2, 4], [8]}, b:{[16], [32, 64]})`,
+		`(a:{[1, 2], [3]}, b:{[4], [5, 6]}) :> => >> 2 ^ .`)
+}

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -19,6 +19,7 @@ expr   -> C* amp="&"* @ C* arrow=(
               binding="->" C* "\\" C* pattern C* %%bind C* @ |
               binding="->" C* %%bind @
           )* C*
+        > C* unop=/{:>|=>|>>}* @ C*
         > C* @:binop=("without" | "with") C*
         > C* @:binop="||" C*
         > C* @:binop="&&" C*
@@ -28,7 +29,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* @:binop=/{&~|&|~~?|[-<][-&][->]} C*
         > C* @:binop=/{//|[*/%]|\\} C*
         > C* @:rbinop="^" C*
-        > C* unop=/{:>|=>|>>|[-+!*^]}* @ C*
+        > C* unop=/{[-+!*^]}* @ C*
         > C* @:binop=">>>" C*
         > C* @ postfix=/{count|single}? C* touch? C*
         > C* (get | @) tail_op=(safe_tail | tail)* C*


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- When `.` is in scope, `=> expr` is equivalent to `. => expr`. Same for `>>` and `:>`.
- 

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
  - Already documented
