### PR TITLE
Support arbitrary expressions in pattern matching

### DIFF
--- a/docs/tutorial/binding.md
+++ b/docs/tutorial/binding.md
@@ -181,13 +181,12 @@ Both let-bindings and function parameters support pattern matching. This is a
 very powerful mechanism to extract elements from a complex structure and also
 restrict what values may be used as input.
 
-The bare literals are supported:
+Bare literals are supported and will simply match their own value:
 
 ```arrai
 @> let 42 = 42; 1
 @> let "hello" = "hello"; 1
 @> let 3 = 1 + 2; 5
-@> let (1 + 2) = 3; 5
 @> let true = true; 3
 @> let true = {()}; 3
 ```
@@ -255,6 +254,11 @@ A name within parentheses like `(x)` refers to the value bound to the name `x`.
 but `let a = 56; let {"x": a, "y": (a)} = {"x": 42, "y": 42}; a` should fail. 
 Using the same name in an expression, `(a)`, and a newly bound name, `a`, is
 confusing and should be avoided.
+
+Complex expressions are supported and will also match their own value. However, they must be enclosed in parentheses, `(...)`:
+```arrai
+@> let (1 + 2) = 3; 5
+```
 
 What's more, arr.ai allows extra elements `...` or `...x` in addition to 
 the explicitly bound ones and binds name `x` to any additional elements 

--- a/docs/tutorial/binding.md
+++ b/docs/tutorial/binding.md
@@ -181,7 +181,7 @@ Both let-bindings and function parameters support pattern matching. This is a
 very powerful mechanism to extract elements from a complex structure and also
 restrict what values may be used as input.
 
-The bare literals are obviously allowed:
+The bare literals are supported:
 
 ```arrai
 @> let 42 = 42; 1

--- a/docs/tutorial/binding.md
+++ b/docs/tutorial/binding.md
@@ -181,6 +181,17 @@ Both let-bindings and function parameters support pattern matching. This is a
 very powerful mechanism to extract elements from a complex structure and also
 restrict what values may be used as input.
 
+The bare literals are obviously allowed:
+
+```arrai
+@> let 42 = 42; 1
+@> let "hello" = "hello"; 1
+@> let 3 = 1 + 2; 5
+@> let (1 + 2) = 3; 5
+@> let true = true; 3
+@> let true = {()}; 3
+```
+
 Try out the following examples to use pattern with arrays:
 
 ```arrai
@@ -211,6 +222,7 @@ and with sets:
 ```arrai
 @> let {} = {}; 1
 @> let {a, 42} = {3, 42}; a
+@> let {a, b} = {3, 42}; [a, b]        # should fail because it is a non-deterministic situation
 ```
 
 Also, nested patterns are supported as:

--- a/rel/pattern_expr.go
+++ b/rel/pattern_expr.go
@@ -3,6 +3,7 @@ package rel
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 
 	"github.com/go-errors/errors"
 )
@@ -16,11 +17,21 @@ func NewExprPattern(expr Expr) ExprPattern {
 }
 
 func (p ExprPattern) Bind(scope Scope, value Value) (Scope, error) {
-	switch p.expr.(type) {
+	switch t := p.expr.(type) {
 	case IdentExpr, Number:
-		return p.expr.(Pattern).Bind(EmptyScope, value)
+		return t.(Pattern).Bind(EmptyScope, value)
+	case GenericSet:
+		if t == True || t == False {
+			if t.IsTrue() == value.IsTrue() {
+				return EmptyScope, nil
+			}
+			fmt.Println(reflect.TypeOf(p.expr))
+			fmt.Println(reflect.TypeOf(value))
+			return EmptyScope, errors.Errorf("%s doesn't equal to %s", t, value)
+		}
+		return EmptyScope, fmt.Errorf("%s is not a Pattern", t)
 	default:
-		return EmptyScope, fmt.Errorf("%s is not a Pattern", p.expr)
+		return EmptyScope, fmt.Errorf("%s is not a Pattern", t)
 	}
 }
 

--- a/rel/pattern_expr.go
+++ b/rel/pattern_expr.go
@@ -16,7 +16,7 @@ func NewExprPattern(expr Expr) ExprPattern {
 }
 
 func (p ExprPattern) Bind(scope Scope, value Value) (Scope, error) {
-	switch t := p.expr.(type) {
+	switch t := p.Expr.(type) {
 	case IdentExpr, Number, GenericSet:
 		return t.(Pattern).Bind(EmptyScope, value)
 	default:

--- a/rel/pattern_expr.go
+++ b/rel/pattern_expr.go
@@ -17,16 +17,8 @@ func NewExprPattern(expr Expr) ExprPattern {
 
 func (p ExprPattern) Bind(scope Scope, value Value) (Scope, error) {
 	switch t := p.expr.(type) {
-	case IdentExpr, Number:
+	case IdentExpr, Number, GenericSet:
 		return t.(Pattern).Bind(EmptyScope, value)
-	case GenericSet:
-		if t == True || t == False {
-			if t.IsTrue() == value.IsTrue() {
-				return EmptyScope, nil
-			}
-			return EmptyScope, errors.Errorf("%s doesn't equal to %s", t, value)
-		}
-		return EmptyScope, fmt.Errorf("%s is not a Pattern", t)
 	default:
 		return EmptyScope, fmt.Errorf("%s is not a Pattern", t)
 	}

--- a/rel/pattern_expr.go
+++ b/rel/pattern_expr.go
@@ -3,7 +3,6 @@ package rel
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 
 	"github.com/go-errors/errors"
 )
@@ -25,8 +24,6 @@ func (p ExprPattern) Bind(scope Scope, value Value) (Scope, error) {
 			if t.IsTrue() == value.IsTrue() {
 				return EmptyScope, nil
 			}
-			fmt.Println(reflect.TypeOf(p.expr))
-			fmt.Println(reflect.TypeOf(value))
 			return EmptyScope, errors.Errorf("%s doesn't equal to %s", t, value)
 		}
 		return EmptyScope, fmt.Errorf("%s is not a Pattern", t)

--- a/rel/value_set_generic.go
+++ b/rel/value_set_generic.go
@@ -2,11 +2,13 @@ package rel
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"sort"
 
 	"github.com/arr-ai/frozen"
 	"github.com/arr-ai/wbnf/parser"
+	"github.com/go-errors/errors"
 )
 
 // GenericSet is a set of Values.
@@ -358,4 +360,14 @@ func (s GenericSet) OrderedValues() []Value {
 	}
 	sort.Sort(ValueList(a))
 	return a
+}
+
+func (s GenericSet) Bind(scope Scope, value Value) (Scope, error) {
+	if s == True || s == False {
+		if s.IsTrue() == value.IsTrue() {
+			return EmptyScope, nil
+		}
+		return EmptyScope, errors.Errorf("%s doesn't equal to %s", s, value)
+	}
+	return EmptyScope, fmt.Errorf("%s is not a Pattern", s)
 }

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -13,12 +13,30 @@ func TestExprLet(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; (:x, y: 2)`)
 }
 
-func TestExprLetValuePattern(t *testing.T) {
+func TestExprLetExprPattern(t *testing.T) {
 	t.Parallel()
 	AssertCodesEvalToSameValue(t, `42`, `let 42 = 42; 42`)
+	AssertCodesEvalToSameValue(t, `42`, `let (42) = 42; 42`)
 	AssertCodesEvalToSameValue(t, `1`, `let 42 = 42; 1`)
+	AssertCodesEvalToSameValue(t, `1`, `let "hello" = "hello"; 1`)
+	AssertCodesEvalToSameValue(t, `5`, `let 3 = 1 + 2; 5`)
+	AssertCodesEvalToSameValue(t, `5`, `let (1 + 2) = 3; 5`)
+	AssertCodesEvalToSameValue(t, `3`, `let a = 1 + 2; a`)
+	AssertCodesEvalToSameValue(t, `3`, `let a = 3; let a = 1 + 2; a`)
+	AssertCodesEvalToSameValue(t, `3`, `let true = true; 3`)
+	AssertCodesEvalToSameValue(t, `3`, `let false = false; 3`)
+	AssertCodesEvalToSameValue(t, `3`, `let true = {()}; 3`)
+	AssertCodesEvalToSameValue(t, `3`, `let false = {}; 3`)
+	AssertCodesEvalToSameValue(t, `3`, `let true = {()}; 3`)
+
 	AssertCodeErrors(t, `let 42 = 1; 42`, "")
 	AssertCodeErrors(t, `let 42 = 1; 1`, "")
+	AssertCodeErrors(t, `let "hello" = "hi"; 1`, "")
+	AssertCodeErrors(t, `let 1 = 1 + 2; 5`, "")
+	AssertCodeErrors(t, `let (1 + 2) = 6; 5`, "")
+	AssertCodeErrors(t, `let a = 5; let (a) = 1 + 2; a`, "")
+	AssertCodeErrors(t, `let true = false; 3`, "")
+	AssertCodeErrors(t, `let true = {}; 3`, "")
 }
 
 func TestExprLetArrayPattern(t *testing.T) { //nolint:dupl

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -13,7 +13,7 @@ func TestExprLet(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; (:x, y: 2)`)
 }
 
-func TestExprLetExprPattern(t *testing.T) {
+func TestExprLetExprPattern(t *testing.T) { //nolint:dupl
 	t.Parallel()
 	AssertCodesEvalToSameValue(t, `42`, `let 42 = 42; 42`)
 	AssertCodesEvalToSameValue(t, `42`, `let (42) = 42; 42`)


### PR DESCRIPTION
Fixes #325 .
Fixes #254 .

Changes proposed in this pull request:
- Support `True` and `False` in pattern matching
- Support arbitrary expressions e.g. `(1+2)`, `"hello"`

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
