### PR TITLE
Fix #356: set to array with holes

### DIFF
--- a/rel/expr_array.go
+++ b/rel/expr_array.go
@@ -42,7 +42,9 @@ func (e ArrayExpr) String() string {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(expr.String())
+		if expr != nil {
+			b.WriteString(expr.String())
+		}
 	}
 	b.WriteByte(']')
 	return b.String()

--- a/rel/value_set_array_test.go
+++ b/rel/value_set_array_test.go
@@ -12,6 +12,16 @@ func TestAsArray(t *testing.T) {
 	)
 }
 
+func TestAsArrayHoles(t *testing.T) {
+	AssertEqualValues(t,
+		NewArray(NewNumber(1), nil, nil, NewNumber(2)),
+		NewSet(
+			NewArrayItemTuple(0, NewNumber(1)),
+			NewArrayItemTuple(3, NewNumber(2)),
+		),
+	)
+}
+
 func TestArrayWithout(t *testing.T) {
 	three := NewArray(NewNumber(10), NewNumber(11), NewNumber(12))
 

--- a/syntax/expr_array_test.go
+++ b/syntax/expr_array_test.go
@@ -1,0 +1,13 @@
+package syntax
+
+import "testing"
+
+func TestArrayExprStringEmpty(t *testing.T) {
+	AssertEvalExprString(t, `{}`, `[]`)
+}
+
+func TestArrayExprStringHoles(t *testing.T) {
+	AssertEvalExprString(t, `[1,,]`, `[1,,]`)
+	AssertEvalExprString(t, `[1,,2]`, `[1,,2]`)
+	AssertEvalExprString(t, `[1,,,2]`, `[1,,,2]`)
+}

--- a/syntax/expr_seqmap_test.go
+++ b/syntax/expr_seqmap_test.go
@@ -1,0 +1,27 @@
+package syntax
+
+import "testing"
+
+func TestExprSequenceMapEmpty(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `[]`, `[] >> .`)
+}
+
+func TestExprSequenceMapIdent(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `[1,2,3] >> .`)
+}
+
+func TestExprSequenceMapDouble(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `[2, 4, 6]`, `[1,2,3] >> \i i * 2`)
+}
+
+func TestExprSequenceMapIdentHoles(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `[1, , , 2]`, `[1,,,2] >> .`)
+}


### PR DESCRIPTION
Fixes #356 .

Changes proposed in this pull request:
- Simplify creating array from set to account for holes, which were not accounted for.
- Fix an incidental panic when trying to stringify an array with holes.

New algorithm needs to loop through the set twice, once to get the index bounds of its elements, then again to populate the []Value array.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
