### PR TITLE
Support grammars in let-bindings

### DIFF
--- a/rel/expr_recursion.go
+++ b/rel/expr_recursion.go
@@ -19,7 +19,7 @@ func NewRecursionExpr(scanner parser.Scanner, name Pattern, fn Expr, fix, fixt V
 }
 
 func (r RecursionExpr) Eval(local Scope) (Value, error) {
-	name, isIdent := r.name.(ExprPattern).expr.(IdentExpr)
+	name, isIdent := r.name.(ExprPattern).Expr.(IdentExpr)
 	if !isIdent {
 		return nil, wrapContext(errors.Errorf("Does not evaluate to a variable name: %v", r.name), r, local)
 	}

--- a/rel/pattern_expr.go
+++ b/rel/pattern_expr.go
@@ -8,24 +8,24 @@ import (
 )
 
 type ExprPattern struct {
-	expr Expr
+	Expr Expr
 }
 
 func NewExprPattern(expr Expr) ExprPattern {
-	return ExprPattern{expr: expr}
+	return ExprPattern{Expr: expr}
 }
 
 func (p ExprPattern) Bind(scope Scope, value Value) (Scope, error) {
-	switch p.expr.(type) {
+	switch p.Expr.(type) {
 	case IdentExpr, Number:
-		return p.expr.(Pattern).Bind(EmptyScope, value)
+		return p.Expr.(Pattern).Bind(EmptyScope, value)
 	default:
-		return EmptyScope, fmt.Errorf("%s is not a Pattern", p.expr)
+		return EmptyScope, fmt.Errorf("%s is not a Pattern", p.Expr)
 	}
 }
 
 func (p ExprPattern) String() string {
-	return p.expr.String()
+	return p.Expr.String()
 }
 
 type ExprsPattern struct {

--- a/rel/pattern_set.go
+++ b/rel/pattern_set.go
@@ -37,7 +37,7 @@ func (p SetPattern) Bind(local Scope, value Value) (Scope, error) {
 			continue
 		}
 		if t, is := ptn.(ExprPattern); is {
-			if _, is = t.expr.(IdentExpr); is {
+			if _, is = t.Expr.(IdentExpr); is {
 				if len(extraElements) == 1 {
 					return EmptyScope, fmt.Errorf("non-deterministic pattern is not supported yet")
 				}
@@ -61,7 +61,7 @@ func (p SetPattern) Bind(local Scope, value Value) (Scope, error) {
 		}
 		switch t := ptn.(type) {
 		case ExprPattern:
-			v, is := t.expr.(Value)
+			v, is := t.Expr.(Value)
 			if is {
 				if !set.Has(v) {
 					return EmptyScope, fmt.Errorf("item %s is not included in set %s", v, value)
@@ -70,7 +70,7 @@ func (p SetPattern) Bind(local Scope, value Value) (Scope, error) {
 				continue
 			}
 
-			if _, is := t.expr.(IdentExpr); !is {
+			if _, is := t.Expr.(IdentExpr); !is {
 				return EmptyScope, fmt.Errorf("item type %s is not supported yet", t)
 			}
 		case IdentPattern:

--- a/syntax/grammar_test.go
+++ b/syntax/grammar_test.go
@@ -75,41 +75,48 @@ func TestGrammarParseParseLiteral(t *testing.T) {
 }
 
 func TestGrammarParseParseScopeVar(t *testing.T) {
-	AssertCodesEvalToSameValue(t,
-		`(
-			@rule: "x",
-			'': ["1", "2"],
-		)`,
-		`//grammar -> (.parse(.lang.wbnf, "grammar", "x -> '1' '2';") -> \x .parse(x, "x", "12"))`)
+	// AssertCodesEvalToSameValue(t,
+	// 	`(
+	// 		@rule: "x",
+	// 		'': ["1", "2"],
+	// 	)`,
+	// 	`//grammar -> (.parse(.lang.wbnf, "grammar", "x -> '1' '2';") -> \x .parse(x, "x", "12"))`)
 
-	AssertCodesEvalToSameValue(t,
-		`(
-			"": ["+"],
-			@rule: "expr",
-			expr: [
-				(expr: [("": "1")]),
-				(
-					"": ["*"],
-					expr: [("": "2"), ("": "3")]
-				)
-			]
-		)`,
-		`//grammar -> (.parse(.lang.wbnf, "grammar", "expr -> @:'+' > @:'*' > \\d+;") -> \x .parse(x, "expr", "1+2*3"))`)
+	// AssertCodesEvalToSameValue(t,
+	// 	`(
+	// 		"": ["+"],
+	// 		@rule: "expr",
+	// 		expr: [
+	// 			(expr: [("": "1")]),
+	// 			(
+	// 				"": ["*"],
+	// 				expr: [("": "2"), ("": "3")]
+	// 			)
+	// 		]
+	// 	)`,
+	// 	`//grammar -> (.parse(.lang.wbnf, "grammar", "expr -> @:'+' > @:'*' > \\d+;") -> \x .parse(x, "expr", "1+2*3"))`)
 
 	scenarios := []struct{ grammar, rule, text string }{
 		{`a -> "1" "2";`, "a", `12`},
 		{`expr -> @:"+" > @:"*" > \d;`, "expr", `1+2*3`},
 	}
-	for _, s := range scenarios {
+	bindForms := []string{
+		`{://grammar.lang.wbnf.grammar:%s:} -> {:.%s:%s:}`,
+		`let g = {://grammar.lang.wbnf.grammar:%s:}; {:g.%s:%s:}`,
+	}
+	for i, s := range scenarios {
 		s := s
-		t.Run(s.text, func(t *testing.T) {
-			parse := fmt.Sprintf(
-				"//grammar -> (.parse(.lang.wbnf, 'grammar', `%s`) -> \\g .parse(g, '%s', `%s`))",
-				s.grammar, s.rule, s.text)
-			AssertCodesEvalToSameValue(t,
-				parse,
-				fmt.Sprintf(`{://grammar.lang.wbnf.grammar:%s:} -> {:.%s:%s:}`, s.grammar, s.rule, s.text))
-		})
+		for j, form := range bindForms {
+			form := form
+			t.Run(fmt.Sprintf("%d.%d", i, j), func(t *testing.T) {
+				parse := fmt.Sprintf(
+					"//grammar -> (.parse(.lang.wbnf, 'grammar', `%s`) -> \\g .parse(g, '%s', `%s`))",
+					s.grammar, s.rule, s.text)
+				AssertCodesEvalToSameValue(t,
+					parse,
+					fmt.Sprintf(form, s.grammar, s.rule, s.text))
+			})
+		}
 	}
 }
 

--- a/syntax/grammar_test.go
+++ b/syntax/grammar_test.go
@@ -75,26 +75,26 @@ func TestGrammarParseParseLiteral(t *testing.T) {
 }
 
 func TestGrammarParseParseScopeVar(t *testing.T) {
-	// AssertCodesEvalToSameValue(t,
-	// 	`(
-	// 		@rule: "x",
-	// 		'': ["1", "2"],
-	// 	)`,
-	// 	`//grammar -> (.parse(.lang.wbnf, "grammar", "x -> '1' '2';") -> \x .parse(x, "x", "12"))`)
+	AssertCodesEvalToSameValue(t,
+		`(
+			@rule: "x",
+			'': ["1", "2"],
+		)`,
+		`//grammar -> (.parse(.lang.wbnf, "grammar", "x -> '1' '2';") -> \x .parse(x, "x", "12"))`)
 
-	// AssertCodesEvalToSameValue(t,
-	// 	`(
-	// 		"": ["+"],
-	// 		@rule: "expr",
-	// 		expr: [
-	// 			(expr: [("": "1")]),
-	// 			(
-	// 				"": ["*"],
-	// 				expr: [("": "2"), ("": "3")]
-	// 			)
-	// 		]
-	// 	)`,
-	// 	`//grammar -> (.parse(.lang.wbnf, "grammar", "expr -> @:'+' > @:'*' > \\d+;") -> \x .parse(x, "expr", "1+2*3"))`)
+	AssertCodesEvalToSameValue(t,
+		`(
+			"": ["+"],
+			@rule: "expr",
+			expr: [
+				(expr: [("": "1")]),
+				(
+					"": ["*"],
+					expr: [("": "2"), ("": "3")]
+				)
+			]
+		)`,
+		`//grammar -> (.parse(.lang.wbnf, "grammar", "expr -> @:'+' > @:'*' > \\d+;") -> \x .parse(x, "expr", "1+2*3"))`)
 
 	scenarios := []struct{ grammar, rule, text string }{
 		{`a -> "1" "2";`, "a", `12`},

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -74,6 +74,17 @@ func (pc ParseContext) Parse(s *parser.Scanner) (ast.Branch, error) {
 			identStr := "."
 			if _, ident, has := pscope.GetVal("IDENT"); has {
 				identStr = ident.(parser.Scanner).String()
+			} else if _, pattern, has := pscope.GetVal("pattern"); has {
+				patNode := ast.FromParserNode(arraiParsers.Grammar(), pattern)
+				pat := pc.compilePattern(patNode)
+				if epat, is := pat.(rel.ExprPattern); is {
+					if identExpr, is := epat.Expr.(rel.IdentExpr); is {
+						identStr = identExpr.Ident()
+					}
+				}
+				if identStr == "" {
+					return nil, nil
+				}
 			}
 
 			_, exprElt, has := pscope.GetVal("expr@1")


### PR DESCRIPTION
Changes proposed in this pull request:
- This is a quick hack to support the base case of `let g = {:...some grammar...:}` (#398).

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
