### PR TITLE
Fixes #401, allows arrai -d path/to/file.arrai

### DIFF
--- a/cmd/arrai/command_util.go
+++ b/cmd/arrai/command_util.go
@@ -51,7 +51,7 @@ func insertRunCommand(globalFlags []cli.Flag, args []string) []string {
 	for i, a := range args[1:] {
 		if strings.HasPrefix(a, "-") {
 			name := strings.TrimLeft(a, "-")
-			if _, isGlobalFlag := globalFlagsMap[name]; isGlobalFlag {
+			if globalFlagsMap[name] {
 				globalFlagsEndIndex = i + 2
 			} else {
 				break

--- a/cmd/arrai/command_util.go
+++ b/cmd/arrai/command_util.go
@@ -28,3 +28,30 @@ func fetchCommand(args []string) string {
 	}
 	return ""
 }
+
+func insertRunCommand(globalFlags []cli.Flag, args []string) []string {
+	globalFlagsEndIndex := 1
+	globalFlagsMap := make(map[string]struct{})
+
+	for _, f := range globalFlags {
+		for _, n := range f.Names() {
+			globalFlagsMap[n] = struct{}{}
+		}
+	}
+
+	for i, a := range args[1:] {
+		if strings.HasPrefix(a, "-") {
+			name := strings.TrimLeftFunc(a, func(r rune) bool { return r == '-' })
+			if _, isGlobalFlag := globalFlagsMap[name]; isGlobalFlag {
+				globalFlagsEndIndex = i + 2
+			} else {
+				break
+			}
+		}
+	}
+
+	tmpArgs := append(make([]string, 0, globalFlagsEndIndex), args[:globalFlagsEndIndex]...)
+	tmpArgs = append(tmpArgs, "run")
+	args = append(tmpArgs, args[globalFlagsEndIndex:]...)
+	return args
+}

--- a/cmd/arrai/command_util.go
+++ b/cmd/arrai/command_util.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -29,13 +30,21 @@ func fetchCommand(args []string) string {
 	return ""
 }
 
+// insertRunCommand adds a run command on file evaluation commands that does not
+// contain the `run` command by adding the `run` command manually.
+//
+// e.g. `arrai path/to/file.arrai`
 func insertRunCommand(globalFlags []cli.Flag, args []string) []string {
+	if len(args) < 2 {
+		panic(fmt.Errorf("need at least 2 arguments, program and arrai file, received %v", args))
+	}
+
 	globalFlagsEndIndex := 1
-	globalFlagsMap := make(map[string]struct{})
+	globalFlagsMap := make(map[string]bool)
 
 	for _, f := range globalFlags {
 		for _, n := range f.Names() {
-			globalFlagsMap[n] = struct{}{}
+			globalFlagsMap[n] = true
 		}
 	}
 

--- a/cmd/arrai/command_util.go
+++ b/cmd/arrai/command_util.go
@@ -50,7 +50,7 @@ func insertRunCommand(globalFlags []cli.Flag, args []string) []string {
 
 	for i, a := range args[1:] {
 		if strings.HasPrefix(a, "-") {
-			name := strings.TrimLeftFunc(a, func(r rune) bool { return r == '-' })
+			name := strings.TrimLeft(a, "-")
 			if _, isGlobalFlag := globalFlagsMap[name]; isGlobalFlag {
 				globalFlagsEndIndex = i + 2
 			} else {

--- a/cmd/arrai/command_util_test.go
+++ b/cmd/arrai/command_util_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
 )
 
 func TestIsExecCommand(t *testing.T) {
@@ -32,5 +33,35 @@ func TestFetchCommand(t *testing.T) {
 	assert.Equal(t,
 		"",
 		fetchCommand([]string{"-flag", "-flag-again", "--flag"}),
+	)
+}
+
+func TestInsertRunCommand(t *testing.T) {
+	flags := []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "stuff",
+			Aliases: []string{"s", "st"},
+		},
+		&cli.BoolFlag{
+			Name:    "debug",
+			Aliases: []string{"d"},
+		},
+	}
+
+	assert.Equal(t,
+		[]string{"arrai", "-d", "run", "file.arrai"},
+		insertRunCommand(flags, []string{"arrai", "-d", "file.arrai"}),
+	)
+	assert.Equal(t,
+		[]string{"arrai", "--debug", "run", "file.arrai"},
+		insertRunCommand(flags, []string{"arrai", "--debug", "file.arrai"}),
+	)
+	assert.Equal(t,
+		[]string{"arrai", "-d", "--stuff", "run", "file.arrai"},
+		insertRunCommand(flags, []string{"arrai", "-d", "--stuff", "file.arrai"}),
+	)
+	assert.Equal(t,
+		[]string{"arrai", "--debug", "run", "-v", "file.arrai"},
+		insertRunCommand(flags, []string{"arrai", "--debug", "-v", "file.arrai"}),
 	)
 }

--- a/cmd/arrai/command_util_test.go
+++ b/cmd/arrai/command_util_test.go
@@ -60,8 +60,9 @@ func TestInsertRunCommand(t *testing.T) {
 		[]string{"arrai", "-d", "--stuff", "run", "file.arrai"},
 		insertRunCommand(flags, []string{"arrai", "-d", "--stuff", "file.arrai"}),
 	)
+	// separating global flags and subcommand flags
 	assert.Equal(t,
-		[]string{"arrai", "--debug", "run", "-v", "file.arrai"},
-		insertRunCommand(flags, []string{"arrai", "--debug", "-v", "file.arrai"}),
+		[]string{"arrai", "--debug", "run", "--subcommand-flag", "file.arrai"},
+		insertRunCommand(flags, []string{"arrai", "--debug", "--subcommand-flag", "file.arrai"}),
 	)
 }

--- a/cmd/arrai/command_util_test.go
+++ b/cmd/arrai/command_util_test.go
@@ -65,4 +65,10 @@ func TestInsertRunCommand(t *testing.T) {
 		[]string{"arrai", "--debug", "run", "--subcommand-flag", "file.arrai"},
 		insertRunCommand(flags, []string{"arrai", "--debug", "--subcommand-flag", "file.arrai"}),
 	)
+	assert.Equal(t,
+		[]string{"arrai", "run", "file.arrai"},
+		insertRunCommand(flags, []string{"arrai", "file.arrai"}),
+	)
+
+	assert.Panics(t, func() { insertRunCommand(flags, []string{"arrai"}) })
 }

--- a/cmd/arrai/main.go
+++ b/cmd/arrai/main.go
@@ -55,8 +55,7 @@ func main() {
 		}
 		if len(os.Args) > 1 {
 			if execCmd := fetchCommand(args[1:]); execCmd != "" && !isExecCommand(execCmd, app.Commands) {
-				tmpArgs := append(make([]string, 0, 1+len(args)), args[0], "run")
-				args = append(tmpArgs, args[1:]...)
+				args = insertRunCommand(app.Flags, os.Args)
 				syntax.RunOmitted = true
 			}
 		}
@@ -107,7 +106,3 @@ func isTerminal() bool {
 	return (isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())) ||
 		(isatty.IsCygwinTerminal(os.Stdin.Fd()) && isatty.IsCygwinTerminal(os.Stdout.Fd()))
 }
-
-// func dropIntoShell(debugFlag bool) bool {
-// 	os.env
-// }


### PR DESCRIPTION
Fixes #401.

Changes proposed in this pull request:
- Allows the use of global flags in the command `arrai file.arrai` 

For context, I built this feature where user can do the command `arrai file.arrai`. The trick was to transform the command internally to `arrai run file.arrai`. But yesterday's feature, the debug flag, messed that up, this PR will handle any global flags in the future, so user can do `arrai -d --any-other-flag file.arrai` and have it translated to `arrai -d --any-other-flag run file.arrai`

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
