### PR TITLE
enclosed expr in byte expr with parentheses in the grammar

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -260,6 +260,8 @@ Array of Bytes can be expressed in arr.ai. The syntactic sugar is in the form of
 `<< expr1, expr2, expr3, ... >>`.
 It only accepts expressions that are evaluated to either a `Number` whose values
 range from 0-255 inclusive or a `String` with `0` offset.
+Any complicated expressions need to be surrounded by parentheses `(expr)`,
+except literal values such as `Number`, `String`, `Char`, and variables.
 Any other values and the expression will fail.
 A `Number` is appended to the array while each characters of a `String` is
 appended to the array.
@@ -268,8 +270,9 @@ The result is an array of Bytes and each Byte is represented as a `Number`.
 Example of usages:
 
 ```arrai
-<<"hello", 10>> = <<"hello\n">>
-<<97, 98, 99>>  = <<"abc">>
+<<"hello", 10>>      = <<"hello\n">>
+<<97, 98, 99>>       = <<"abc">>
+<<("abc" >> . + 1)>> = <<"bcd">>
 ```
 
 ##### Expression string syntax

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -78,7 +78,7 @@ SEQ_COMMENT -> "," C*;
   | C* "{" C* set=(elt=top:SEQ_COMMENT,?) "}" C*
   | C* "{" C* dict=((ext=extra|key=expr ":" value=top):SEQ_COMMENT,?) "}" C*
   | C* "[" C* array=(%!sparse_sequence(top)?) C* "]" C*
-  | C* "<<" C* bytes=(item=top:SEQ_COMMENT,?) C* ">>" C*
+  | C* "<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* ">>" C*
   | C* "(" tuple=(pairs=(extra|name? ":" v=top):SEQ_COMMENT,?) ")" C*
   | C* "(" identpattern=IDENT ")" C*
 };

--- a/syntax/expr_bytes_test.go
+++ b/syntax/expr_bytes_test.go
@@ -8,31 +8,34 @@ import (
 func TestBytesExpr(t *testing.T) {
 	t.Parallel()
 
-	AssertCodesEvalToSameValue(t, toBytes(`"hello\n"`), `<<"hello", 10>>                           `)
-	AssertCodesEvalToSameValue(t, toBytes(`"abc"    `), `<<97, 98, 99>>                            `)
-	AssertCodesEvalToSameValue(t, toBytes(`"hello"  `), `<<"hello">>                               `)
-	AssertCodesEvalToSameValue(t, toBytes(`""       `), `<<>>                                      `)
-	AssertCodesEvalToSameValue(t, toBytes(`""       `), `<<''>>                                    `)
-	AssertCodesEvalToSameValue(t, toBytes(`"a"      `), `<<'', 97>>                                `)
-	AssertCodesEvalToSameValue(t, toBytes(`"abc"    `), `<<{|@, @char| (0, 97), (1, 98), (2, 99)}>>`)
+	AssertCodesEvalToSameValue(t, toBytes(`"hello\n"`), `<<"hello", 10>>                             `)
+	AssertCodesEvalToSameValue(t, toBytes(`"abc"    `), `<<97, 98, 99>>                              `)
+	AssertCodesEvalToSameValue(t, toBytes(`"ABC"    `), `<<%A, %B, %C>>                              `)
+	AssertCodesEvalToSameValue(t, toBytes(`"hello"  `), `<<"hello">>                                 `)
+	AssertCodesEvalToSameValue(t, toBytes(`""       `), `<<>>                                        `)
+	AssertCodesEvalToSameValue(t, toBytes(`""       `), `<<''>>                                      `)
+	AssertCodesEvalToSameValue(t, toBytes(`"a"      `), `<<'', 97>>                                  `)
+	AssertCodesEvalToSameValue(t, toBytes(`"aa"     `), `let x = 97; <<x, x>>                        `)
+	AssertCodesEvalToSameValue(t, toBytes(`"bcd"    `), `<<("abc" >> . + 1)>>                        `)
+	AssertCodesEvalToSameValue(t, toBytes(`"abc"    `), `<<({|@, @char| (0, 97), (1, 98), (2, 99)})>>`)
 
 	AssertCodeErrors(t,
 		`<<256>>`,
 		"BytesExpr.Eval: Number does not represent a byte: 256")
 	AssertCodeErrors(t,
-		`<<-2>>`,
+		`<<(-2)>>`,
 		"BytesExpr.Eval: Number does not represent a byte: -2")
 	AssertCodeErrors(t,
-		`<<2\"offset">>`,
+		`<<(2\"offset")>>`,
 		"BytesExpr.Eval: offsetted String is not supported: offset")
 	AssertCodeErrors(t,
-		`<<{1, 2, 3}>>`,
+		`<<({1, 2, 3})>>`,
 		"BytesExpr.Eval: Set {1, 2, 3} is not supported")
 	AssertCodeErrors(t,
-		`<<(a: 1)>>`,
+		`<<((a: 1))>>`,
 		"BytesExpr.Eval: *rel.GenericTuple is not supported")
 	AssertCodeErrors(t,
-		`<<[1, 2, 3]>>`,
+		`<<([1, 2, 3])>>`,
 		"BytesExpr.Eval: rel.Array is not supported")
 }
 

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -92,7 +92,7 @@ SEQ_COMMENT -> "," C*;
   | C* "{" C* set=(elt=top:SEQ_COMMENT,?) "}" C*
   | C* "{" C* dict=((ext=extra|key=expr ":" value=top):SEQ_COMMENT,?) "}" C*
   | C* "[" C* array=(%!sparse_sequence(top)?) C* "]" C*
-  | C* "<<" C* bytes=(item=top:SEQ_COMMENT,?) C* ">>" C*
+  | C* "<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* ">>" C*
   | C* "(" tuple=(pairs=(extra|name? ":" v=top):SEQ_COMMENT,?) ")" C*
   | C* "(" identpattern=IDENT ")" C*
 };


### PR DESCRIPTION
Changes proposed in this pull request:
- The more complicated expressions in byte expr will now have to enclosed in parentheses to avoid parsing error

Initially, this was parsed wrongly
```
<< expr >> => transform(.)
```

This commit will require it to be
```
<< (expr) >> => transform(.)
```

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
