### PR TITLE
Much faster tests

### DIFF
--- a/cmd/arrai/command_util_test.go
+++ b/cmd/arrai/command_util_test.go
@@ -37,6 +37,8 @@ func TestFetchCommand(t *testing.T) {
 }
 
 func TestInsertRunCommand(t *testing.T) {
+	t.Parallel()
+
 	flags := []cli.Flag{
 		&cli.BoolFlag{
 			Name:    "stuff",

--- a/cmd/arrai/eval_test.go
+++ b/cmd/arrai/eval_test.go
@@ -14,16 +14,19 @@ func assertEvalOutputs(t *testing.T, expected, source string) bool { //nolint:un
 }
 
 func TestEvalNumberULP(t *testing.T) {
+	t.Parallel()
 	assertEvalOutputs(t, `0.3`, `0.1 + 0.1 + 0.1`)
 }
 
 func TestEvalString(t *testing.T) {
+	t.Parallel()
 	assertEvalOutputs(t, ``, `""`)
 	assertEvalOutputs(t, ``, `{}`)
 	assertEvalOutputs(t, `abc`, `"abc"`)
 }
 
 func TestEvalComplex(t *testing.T) {
+	t.Parallel()
 	assertEvalOutputs(t, `[42, 'abc']`, `[42, "abc"]`)
 	assertEvalOutputs(t, `{42, 'abc'}`, `{"abc", 42}`)
 }

--- a/cmd/arrai/run_test.go
+++ b/cmd/arrai/run_test.go
@@ -16,6 +16,7 @@ func TestEvalFile(t *testing.T) {
 }
 
 func TestEvalNotExistingFile(t *testing.T) {
+	t.Parallel()
 	require.Equal(t, `"version": not a command and not found as a file in the current directory`,
 		evalFile("version", nil).Error())
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/arr-ai/frozen v0.13.0
 	github.com/arr-ai/hash v0.4.0
 	github.com/arr-ai/proto v0.0.0-20180422074755-2ffbedebee50
-	github.com/arr-ai/wbnf v0.16.0
+	github.com/arr-ai/wbnf v0.18.0
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/arr-ai/proto v0.0.0-20180422074755-2ffbedebee50 h1:IKdl2NU9J9dt4qtet3
 github.com/arr-ai/proto v0.0.0-20180422074755-2ffbedebee50/go.mod h1:zMLnTY/7fre6NJw4N46s23kehuIHx4MdXx1fdaEG9Ss=
 github.com/arr-ai/wbnf v0.16.0 h1:AeUKh5F0LvoBUZq0OpbzxUQ8x4lf/XhUWzD1V0dpKnU=
 github.com/arr-ai/wbnf v0.16.0/go.mod h1:WRCWNNBAGJU3JwitK7FwbOA68f0/yr4m/Iq64/wyqCo=
+github.com/arr-ai/wbnf v0.18.0 h1:JFZ76L0oe20Xtinvq2e4B6G9y3HWf2sjNqljxsjDGmY=
+github.com/arr-ai/wbnf v0.18.0/go.mod h1:WRCWNNBAGJU3JwitK7FwbOA68f0/yr4m/Iq64/wyqCo=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/rel/astnode_value_test.go
+++ b/rel/astnode_value_test.go
@@ -48,16 +48,18 @@ func assertASTNodeToValueToNode(t *testing.T, p parser.Parsers, rule, src string
 }
 
 func TestNodeToValueSimple(t *testing.T) {
+	t.Parallel()
 	assertASTNodeToValueToNode(t, wbnf.Core(), "grammar", `expr -> "+"|"*";`)
 }
 
 func TestGrammarToValueExpr(t *testing.T) {
+	t.Parallel()
 	assertASTNodeToValueToNode(t, wbnf.Core(), "grammar", `x->@:"+" > @:"*" > "1";`)
 }
 
 func TestNodeToValueExpr(t *testing.T) {
+	t.Parallel()
 	grammar := `expr -> @:op="+" > @:op="*" > n=[0-9];`
-
 	exprP, err := wbnf.Compile(grammar, nil)
 	require.NoError(t, err)
 	assertASTNodeToValueToNode(t, exprP, "expr", `1+2*3`)

--- a/rel/value_number_test.go
+++ b/rel/value_number_test.go
@@ -15,5 +15,6 @@ func sum(nums []float64) float64 {
 }
 
 func TestNumberULP(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "0.3", NewNumber(sum([]float64{0.1, 0.1, 0.1})).String())
 }

--- a/rel/value_set_array_test.go
+++ b/rel/value_set_array_test.go
@@ -3,6 +3,7 @@ package rel
 import "testing"
 
 func TestAsArray(t *testing.T) {
+	t.Parallel()
 	AssertEqualValues(t,
 		NewArray(NewNumber(10), NewNumber(11)),
 		NewSet(
@@ -13,6 +14,7 @@ func TestAsArray(t *testing.T) {
 }
 
 func TestAsArrayHoles(t *testing.T) {
+	t.Parallel()
 	AssertEqualValues(t,
 		NewArray(NewNumber(1), nil, nil, NewNumber(2)),
 		NewSet(
@@ -23,6 +25,8 @@ func TestAsArrayHoles(t *testing.T) {
 }
 
 func TestArrayWithout(t *testing.T) {
+	t.Parallel()
+
 	three := NewArray(NewNumber(10), NewNumber(11), NewNumber(12))
 
 	AssertEqualValues(t,

--- a/rel/value_set_dict_test.go
+++ b/rel/value_set_dict_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestDictEntryTupleLess(t *testing.T) {
+	t.Parallel()
 	// Test for a panic when comparing Strings using !=.
 	assert.NotPanics(t, func() {
 		NewDict(false,
@@ -17,6 +18,8 @@ func TestDictEntryTupleLess(t *testing.T) {
 }
 
 func TestDictEntryTupleOrdered(t *testing.T) {
+	t.Parallel()
+
 	entries := NewDict(true,
 		NewDictEntryTuple(NewString([]rune("b")), NewNumber(2)),
 		NewDictEntryTuple(NewString([]rune("a")), NewNumber(2)),
@@ -31,6 +34,8 @@ func TestDictEntryTupleOrdered(t *testing.T) {
 }
 
 func TestDictLess(t *testing.T) {
+	t.Parallel()
+
 	kv := func(k, v float64) DictEntryTuple {
 		return NewDictEntryTuple(NewNumber(k), NewNumber(v))
 	}

--- a/rel/value_set_str_test.go
+++ b/rel/value_set_str_test.go
@@ -10,6 +10,7 @@ import (
 const hello = "hello"
 
 func TestIsStringTuple(t *testing.T) {
+	t.Parallel()
 	for e := NewString([]rune(hello)).Enumerator(); e.MoveNext(); {
 		tuple, is := e.Current().(StringCharTuple)
 		if assert.True(t, is) {

--- a/syntax/expr_array_test.go
+++ b/syntax/expr_array_test.go
@@ -3,10 +3,12 @@ package syntax
 import "testing"
 
 func TestArrayExprStringEmpty(t *testing.T) {
+	t.Parallel()
 	AssertEvalExprString(t, `{}`, `[]`)
 }
 
 func TestArrayExprStringHoles(t *testing.T) {
+	t.Parallel()
 	AssertEvalExprString(t, `[1,,]`, `[1,,]`)
 	AssertEvalExprString(t, `[1,,2]`, `[1,,2]`)
 	AssertEvalExprString(t, `[1,,,2]`, `[1,,,2]`)

--- a/syntax/expr_arrow_test.go
+++ b/syntax/expr_arrow_test.go
@@ -3,11 +3,14 @@ package syntax
 import "testing"
 
 func TestApplyExpr(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `42`, `6 -> 7 * .`)
 	AssertCodesEvalToSameValue(t, `42`, `6 -> \x 7 * x`)
 }
 
 func TestSeqArrow(t *testing.T) {
+	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `'HELLO'`, `'hello' >> . - 32`)
 	AssertCodesEvalToSameValue(t, `10\'HELLO'`, `10\'hello' >> . - 32`)
 
@@ -22,6 +25,8 @@ func TestSeqArrow(t *testing.T) {
 }
 
 func TestISeqArrow(t *testing.T) {
+	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `'ACE'`, `'abc' >>> \i \. . - 32 + i`)
 	AssertCodesEvalToSameValue(t, `2\'CEG'`, `2\'abc' >>> \i \. . - 32 + i`)
 
@@ -49,11 +54,13 @@ func TestISeqArrow(t *testing.T) {
 }
 
 func TestApplyExprInsideMapExpr(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{2, 4, 8}`, `{1, 2, 3} => (2 -> \y y ^ .)`)
 	AssertCodesEvalToSameValue(t, `{2, 4, 8}`, `(\z {1, 2, 3} => (z -> \y y ^ .))(2)`)
 }
 
 func TestApplyExprWithPattern(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `2`, `1 -> \x let [(x), y] = [1, 2]; y`)
 	AssertCodesEvalToSameValue(t, `3`, `[1, 2] -> \[x, y] x + y`)
 	AssertCodesEvalToSameValue(t, `3`, `(m: 1, n: 2) -> \(m: x, n: y) x + y`)
@@ -64,6 +71,8 @@ func TestApplyExprWithPattern(t *testing.T) {
 }
 
 func TestUnaryArrows(t *testing.T) {
+	t.Parallel()
+
 	// This tests an error when stringifying sets of arrays.
 	AssertCodesEvalToSameValue(t, `{{2, 4}, {8, 16}}`, `{{1, 2}, {3, 4}} => => 2 ^ .`)
 	AssertCodesEvalToSameValue(t, `{[2, 4], [8, 16]}`, `{[1, 2], [3, 4]} => >> 2 ^ .`)

--- a/syntax/expr_cond_test.go
+++ b/syntax/expr_cond_test.go
@@ -6,6 +6,7 @@ import (
 
 func TestEvalCond(t *testing.T) {
 	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `1`, `cond {1 > 0 : 1, 2 > 3: 2, _:1 + 2,}`)
 	AssertCodesEvalToSameValue(t, `1`, `cond {1 > 0 : 1, 2 > 3: 2, _:1 + 2}`)
 	AssertCodesEvalToSameValue(t, `2`, `cond {1 > 2 : 1, 2 < 3: 2, _:1 + 2}`)
@@ -40,6 +41,7 @@ func TestEvalCond(t *testing.T) {
 // TestEvalCondMulti executes the cases whose condition has multiple expressions.
 func TestEvalCondMulti(t *testing.T) {
 	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `1`, `cond {1 > 0 || 3 > 2: 1, 2 > 3: 2, _:1 + 2,}`)
 	AssertCodesEvalToSameValue(t, `1`, `cond {0 > 1 || 3 > 2: 1, 2 > 3: 2, _:1 + 2,}`)
 	AssertCodesEvalToSameValue(t, `3`, `cond {0 > 1 || 3 > 4: 1, 2 > 3: 2, _:1 + 2,}`)
@@ -56,7 +58,7 @@ func TestEvalCondMulti(t *testing.T) {
 }
 
 func TestEvalCondStr(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	AssertEvalExprString(t, "{(1>0):1,(2>3):2,_:(1+2)}", "cond {(1 > 0) : 1, (2 > 3): 2, _:1 + 2,}")
 	AssertEvalExprString(t, "{(1>0):1,(2>3):2,_:(1+2)}", "cond {(1 > 0) : 1, (2 > 3): 2, _:1 + 2}")
 	AssertEvalExprString(t, "{(1<2):1}", "cond {(1 < 2) : 1}")
@@ -100,6 +102,8 @@ func TestEvalCondWithControlVar(t *testing.T) {
 }
 
 func TestEvalCondWithControlVarMulti(t *testing.T) {
+	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `1`, `let a = 1; cond a {(1 + 0,2 + 0) :1}`)
 	AssertCodesEvalToSameValue(t, `1`, `let a = 2; cond a {(1 + 0,2 + 0,3 + 0) :1, (2 + 0):2}`)
 	AssertCodesEvalToSameValue(t, `2`, `let a = 2; cond a {(1 + 0,2 + 4,3 + 5) :1, (2 + 0):2}`)
@@ -119,6 +123,7 @@ func TestEvalCondWithControlVarMulti(t *testing.T) {
 // TestEvalCondMultiStr executes the cases whose condition has multiple expressions.
 func TestEvalCondMultiStr(t *testing.T) {
 	t.Parallel()
+
 	AssertEvalExprString(t, "((control_var:1),{((1>0))&&((2>1)):1})", "cond (1) {(1 > 0 && 2 > 1) : 1}")
 	AssertEvalExprString(t, "((control_var:1),{((1>0))||((2>1)):1})", "cond (1) {(1 > 0 || 2 > 1) : 1}")
 	AssertEvalExprString(t, "((control_var:1),{((1>0))||((2>1)):1,_:11})", "cond (1) {(1 > 0 || 2 > 1) : 1, _ : 11}")
@@ -126,6 +131,7 @@ func TestEvalCondMultiStr(t *testing.T) {
 
 func TestEvalCondWithControlVarStr(t *testing.T) {
 	t.Parallel()
+
 	AssertEvalExprString(t, "((control_var:1),{1:1})", "cond (1) {1 : 1}")
 	AssertEvalExprString(t, "((control_var:1),{1:1})", "cond (1) {1 : 1,}")
 	AssertEvalExprString(t, "((control_var:1),{1:1,(2+1):3})", "cond (1) {1 : 1, (2 + 1) : 3}")
@@ -151,6 +157,7 @@ func TestEvalCondWithControlVarMultiStr(t *testing.T) {
 
 func TestEvalCondPatternMatchingWithControlVar(t *testing.T) {
 	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `2`, `let a = 'A' ; cond a {'A':2}`)
 	AssertCodesEvalToSameValue(t, `2`, `let a = 'ABC' ; cond a {'ABC':2}`)
 	AssertCodesEvalToSameValue(t, `2`, `let a = "A" ; cond a {"A":2}`)

--- a/syntax/expr_dot_test.go
+++ b/syntax/expr_dot_test.go
@@ -3,17 +3,21 @@ package syntax
 import "testing"
 
 func TestExprDotOnTupleSet(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{(foo: 42)}.foo`, `42`)
 }
 
 func TestExprDotErrorOnEmptySet(t *testing.T) {
+	t.Parallel()
 	AssertCodeErrors(t, `{}.foo`, `Cannot get attr "foo" from empty set`)
 }
 
 func TestExprDotErrorOnMultipletSet(t *testing.T) {
+	t.Parallel()
 	AssertCodeErrors(t, `{1, 2, 3}.foo`, `Too many elts to get attr "foo" from set`)
 }
 
 func TestExprDotErrorOnNonTupleSet(t *testing.T) {
+	t.Parallel()
 	AssertCodeErrors(t, `{1}.foo`, `Cannot get attr "foo" from non-tuple set elt`)
 }

--- a/syntax/expr_literal_test.go
+++ b/syntax/expr_literal_test.go
@@ -3,5 +3,6 @@ package syntax
 import "testing"
 
 func TestExprRelationLiteral(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{(a: "hello", b:1), (a: "world", b:2)}`, `{|a,b| ("hello",1), ("world",2)}`)
 }

--- a/syntax/expr_member_test.go
+++ b/syntax/expr_member_test.go
@@ -3,11 +3,13 @@ package syntax
 import "testing"
 
 func TestExprMemberOf(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `true`, `2 <: {1, 2, 3}`)
 	AssertCodesEvalToSameValue(t, `false`, `42 <: {1, 2, 3}`)
 }
 
 func TestExprNotMemberOf(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `false`, `2 !<: {1, 2, 3}`)
 	AssertCodesEvalToSameValue(t, `true`, `42 !<: {1, 2, 3}`)
 }

--- a/syntax/expr_order_test.go
+++ b/syntax/expr_order_test.go
@@ -3,11 +3,13 @@ package syntax
 import "testing"
 
 func TestOrder(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `[-3, -2, -1, 0, 1, 2, 3]`, `{3, 2, 1, 0, -1, -2, -3} order \a \b  a < b`)
 	AssertCodesEvalToSameValue(t, `[3, 2, 1, 0, -1, -2, -3]`, `{3, 2, 1, 0, -1, -2, -3} order \a \b  a > b`)
 }
 
 func TestOrderBy(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `[-3, -2, -1, 0, 1, 2, 3, 4]`, `{3, 1, -1, 4, 0, -3, -2, 2} orderby .`)
 	AssertCodesEvalToSameValue(t, `[4, 3, 2, 1, 0, -1, -2, -3]`, `{3, 1, -1, 4, 0, -3, -2, 2} orderby -.`)
 	// TODO: Deal with non-deterministic order.
@@ -15,6 +17,7 @@ func TestOrderBy(t *testing.T) {
 }
 
 func TestRank(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{|x,r| (1,0), (2,1), (3,2)}`, `{|x| (1), (2), (3)} rank (r: .x)`)
 	AssertCodesEvalToSameValue(t, `{|x,r| (1,2), (2,1), (3,0)}`, `{|x| (1), (2), (3)} rank (r: -.x)`)
 	AssertCodesEvalToSameValue(t, `{|x,r,s| (1,0,2), (2,1,1), (3,2,0)}`, `{|x| (1), (2), (3)} rank (r: .x, s: -.x)`)

--- a/syntax/expr_rel_test.go
+++ b/syntax/expr_rel_test.go
@@ -3,6 +3,7 @@ package syntax
 import "testing"
 
 func TestConcat(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `"abcdef"`, `"abc" ++ "def"`)
 	AssertCodesEvalToSameValue(t, `   "def"`, `""    ++ "def"`)
 	AssertCodesEvalToSameValue(t, `"abc"   `, `"abc" ++ ""   `)

--- a/syntax/expr_set_array_test.go
+++ b/syntax/expr_set_array_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestArrayToString(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `"hello"`, `[104, 101, 108, 108, 111] => (@:.@, @char:.@item)`)
 	AssertCodeEvalsToType(t, rel.String{}, `[104, 101, 108, 108, 111] => (@:.@, @char:.@item)`)
 }
@@ -28,6 +29,7 @@ func TestArrayType(t *testing.T) {
 }
 
 func TestArrayWhere(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `[1, 2]`, `[1, 2] where .@ < 10`)
 	AssertCodesEvalToSameValue(t, `[1, 2]`, `[1, 2] where .@item < 10`)
 	AssertCodesEvalToSameValue(t, `[1]`, `[1, 2] where .@ < 1`)
@@ -37,13 +39,15 @@ func TestArrayWhere(t *testing.T) {
 }
 
 func TestArrayWithHoles(t *testing.T) {
-	// TODO: Use holey array syntax when available.
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `[10] | 2\[12]`, `[10, , 12]`)
 	AssertCodesEvalToSameValue(t, `[10, 11, 12]`, `[10, , 12] with (@: 1, @item: 11)`)
 	AssertCodesEvalToSameValue(t, `[10, 11, 12]`, `[10, , 12, , , ] with (@: 1, @item: 11)`)
 }
 
 func TestSetOfArrays(t *testing.T) {
+	t.Parallel()
+
 	// This tests an error when stringifying sets of arrays.
 	AssertCodesEvalToSameValue(t, `'{[1], [1, 1]}'`, `$'${{[1, 1], [1]}}'`)
 }

--- a/syntax/expr_set_compare_test.go
+++ b/syntax/expr_set_compare_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestSetCompare(t *testing.T) {
+	t.Parallel()
+
 	intSet := func(i int) rel.Set {
 		set := rel.None
 		for ; i != 0; i &= i - 1 {
@@ -23,6 +25,8 @@ func TestSetCompare(t *testing.T) {
 			j := j
 			b := intSet(j)
 			t.Run(fmt.Sprintf("%v.%v", a, b), func(t *testing.T) {
+				t.Parallel()
+
 				assertComparison := func(op string, result bool) bool { //nolint:unparam
 					var expected string
 					if result {

--- a/syntax/expr_set_special_test.go
+++ b/syntax/expr_set_special_test.go
@@ -25,6 +25,7 @@ func TestStringType(t *testing.T) {
 }
 
 func TestStringWhere(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `"abc"`, `"abc" where .@ < 10`)
 	AssertCodesEvalToSameValue(t, `"abc"`, `"abc" where .@char < 100`)
 	AssertCodesEvalToSameValue(t, `"ab"`, `"abc" where .@ < 2`)
@@ -33,6 +34,7 @@ func TestStringWhere(t *testing.T) {
 }
 
 func TestStringManipulation(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `"Foo"`, `(\s //str.upper(s where .@=0) | (s where .@>0))("foo")`)
 }
 
@@ -53,17 +55,20 @@ func TestDictType(t *testing.T) {
 }
 
 func TestDictWhere(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{"a": "b"}`, `{"a": "b"} where .@ = "a"`)
 	AssertCodesEvalToSameValue(t, `{}`, `{"a": "b"} where .@ = "b"`)
 }
 
 func TestDictUnion(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t,
 		`{"a": "a",    "b": "a"} | {"a": "b"}`,
 		`{"a": "a"} | {"b": "a",    "a": "b"}`)
 }
 
 func TestDictExpand(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t,
 		`"{'a': 'a', 'a': 'b', 'b': 'a'}"`,
 		`//str.expand("", {"b": "a", "a": "b"} | {"a": "a"}, "", "")`)

--- a/syntax/expr_set_with_without_test.go
+++ b/syntax/expr_set_with_without_test.go
@@ -3,6 +3,7 @@ package syntax
 import "testing"
 
 func TestExprSetWith(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{{}}`, `{} with {}`)
 	AssertCodesEvalToSameValue(t, `{{}}`, `{{}} with {}`)
 	AssertCodesEvalToSameValue(t, `{{}, 1}`, `{1} with {}`)
@@ -14,6 +15,7 @@ func TestExprSetWith(t *testing.T) {
 }
 
 func TestExprSetWithout(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{}`, `{} without {}`)
 	AssertCodesEvalToSameValue(t, `{}`, `{{}} without {}`)
 	AssertCodesEvalToSameValue(t, `{1}`, `{1} without {}`)

--- a/syntax/expr_tuple_test.go
+++ b/syntax/expr_tuple_test.go
@@ -30,11 +30,13 @@ func TestTupleGet(t *testing.T) {
 }
 
 func TestTupleCallGet(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `2`, `(a: \x (b: x)).a(2).b`)
 	AssertCodesEvalToSameValue(t, `2`, `let t = (a: \x (b: x)); t.a(2).b`)
 }
 
 func TestTupleLiteral(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; let y = 2; (x: x, y: y)`)
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; let y = 2; (:x, :y)`)
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let t = (x: 1, y: 2); (:t.x, :t.y)`)

--- a/syntax/grammar_test.go
+++ b/syntax/grammar_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestGrammarToValueExpr(t *testing.T) {
+	t.Parallel()
+
 	expected := `(
 		@rule: "grammar",
 		stmt: [
@@ -42,6 +44,8 @@ func TestGrammarToValueExpr(t *testing.T) {
 }
 
 func TestGrammarParseParseLiteral(t *testing.T) {
+	t.Parallel()
+
 	expected := `(
 		"": ["+"],
 		@rule: "expr",
@@ -75,6 +79,8 @@ func TestGrammarParseParseLiteral(t *testing.T) {
 }
 
 func TestGrammarParseParseScopeVar(t *testing.T) {
+	t.Parallel()
+
 	AssertCodesEvalToSameValue(t,
 		`(
 			@rule: "x",
@@ -121,6 +127,7 @@ func TestGrammarParseParseScopeVar(t *testing.T) {
 }
 
 // func TestGrammarParseWithEscape(t *testing.T) {
+// 	t.Parallel()
 // 	AssertCodesEvalToSameValue(t,
 // 		`(
 // 			"": ["+"],

--- a/syntax/import_cache_test.go
+++ b/syntax/import_cache_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestImportCache(t *testing.T) {
+	t.Parallel()
+
 	msgs := []string{}
 	var m sync.Mutex
 	start := time.Now()

--- a/syntax/package_test.go
+++ b/syntax/package_test.go
@@ -3,10 +3,12 @@ package syntax
 import "testing"
 
 func TestPackageE(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `2.718281828459045`, `//math.e`)
 }
 
 func TestPackagePi(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `3.141592653589793`, `//math.pi`)
 }
 
@@ -23,22 +25,27 @@ func TestPackagePi(t *testing.T) {
 // }
 
 func TestPackageImport(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{1, 4, 9, 16}`, `//{./examples/simple/simple}`)
 }
 
 func TestPackageImportFromRoot(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{1, 4, 9, 16}`, `//{/examples/simple/simple}`)
 }
 
 func TestJsonPackageImportFromModuleRoot(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{'location': (s: 'Melbourne'), 'name': (s: 'foo')}`, `//{/examples/json/foo.json}`)
 }
 
 func TestJsonPackageImport(t *testing.T) {
+	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{'location': (s: 'Melbourne'), 'name': (s: 'foo')}`, `//{./examples/json/foo.json}`)
 }
 
 func TestJsonPackageImportNotExists(t *testing.T) {
+	t.Parallel()
 	AssertCodeErrors(t, `//{./examples/json/fooooo.json}`, "")
 }
 

--- a/syntax/scanners_test.go
+++ b/syntax/scanners_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestHandleAccessScanners(t *testing.T) {
+	t.Parallel()
+
 	base := parser.NewScanner(".")
 	access := parser.NewScannerAt(".a.b", 1, 2)
 

--- a/syntax/std_re_test.go
+++ b/syntax/std_re_test.go
@@ -3,6 +3,8 @@ package syntax
 import "testing"
 
 func TestReMatch(t *testing.T) {
+	t.Parallel()
+
 	AssertCodesEvalToSameValue(t,
 		`[['a1', 1\'1'], [2\'b2', 3\'2'], [4\'c3', 5\'3']]`,
 		"//re.compile(`.(\\d)`).match('a1b2c3')")
@@ -12,12 +14,16 @@ func TestReMatch(t *testing.T) {
 }
 
 func TestReMismatch(t *testing.T) {
+	t.Parallel()
+
 	AssertCodesEvalToSameValue(t,
 		`[['a1'] | 2\[1\'1'], [2\'b~2', 3\'~', 4\'2'], [5\'c3'] | 2\[6\'3']]`,
 		"//re.compile(`[a-z](~)?(\\d)`).match('a1b~2c3')")
 }
 
 func TestReSub(t *testing.T) {
+	t.Parallel()
+
 	AssertCodesEvalToSameValue(t,
 		`'-1-2-3'`,
 		"//re.compile(`.(\\d)`).sub(`-$1`, 'a1b2c3')")
@@ -27,6 +33,8 @@ func TestReSub(t *testing.T) {
 }
 
 func TestReSubf(t *testing.T) {
+	t.Parallel()
+
 	AssertCodesEvalToSameValue(t,
 		`'A1B2C3'`,
 		"//re.compile(`.(\\d)`).subf(//str.upper, 'a1b2c3')")

--- a/syntax/std_seq_sub_test.go
+++ b/syntax/std_seq_sub_test.go
@@ -4,6 +4,7 @@ import "testing"
 
 func TestStrSub(t *testing.T) { //nolint:dupl
 	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `" BC"`, `//seq.sub( "A", " ","ABC")`)
 	AssertCodesEvalToSameValue(t, `"this is not a test"`, `//seq.sub("aaa", "is", "this is not a test")`)
 	AssertCodesEvalToSameValue(t, `"this is a test"`, `//seq.sub("is not", "is", "this is not a test")`)
@@ -25,6 +26,7 @@ func TestStrSub(t *testing.T) { //nolint:dupl
 
 func TestArraySub(t *testing.T) {
 	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `['T', 'B', 'T', 'C', 'D', 'E']`,
 		`//seq.sub(['A'], ['T'], ['A', 'B', 'A', 'C', 'D', 'E'])`)
 	AssertCodesEvalToSameValue(t, `[['A', 'B'], ['T','C'],['A','D']]`,
@@ -37,6 +39,8 @@ func TestArraySub(t *testing.T) {
 }
 
 func TestArraySubEdgeCases(t *testing.T) {
+	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `[]`, `//seq.sub( [],[], [])`)
 	AssertCodesEvalToSameValue(t, `[1]`, `//seq.sub( [],[1], [])`)
 	AssertCodesEvalToSameValue(t, `[1,2]`, `//seq.sub( [],[1,2], [])`)
@@ -52,6 +56,7 @@ func TestArraySubEdgeCases(t *testing.T) {
 
 func TestBytesSub(t *testing.T) {
 	t.Parallel()
+
 	// hello bytes - 104 101 108 108 111
 	AssertCodesEvalToSameValue(t, `<<'oello'>>`, `//seq.sub(<<104>>,<<111>>,<<'hello'>>)`)
 	AssertCodesEvalToSameValue(t, `<<'hehho'>>`, `//seq.sub(<<108>>,<<104>>,<<'hello'>>)`)


### PR DESCRIPTION
Changes proposed in this pull request:
- Parallelise as many tests as possible
- Use wbnf v0.18.0, which is much faster due to greatly reduced malloc overhead.

Checklist:
- [ ] Added related tests
- [ ] Made corresponding changes to the documentation
