### PR TITLE
fix #417, adds recursion syntax in tuple

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -471,6 +471,16 @@ let rec oe = (
 oe.even(6)
 ```
 
+It is also possible to use the same syntax in a tuple.
+
+```arrai
+let t = (
+   rec fact: \n cond n ((0, 1): 1, n: n * fact(n - 1)),
+   n       : 5
+);
+t.rec(t.n)
+```
+
 This syntactic sugar only works with expression that evaluates to either a
 function or a tuple of functions. Anything else and the expression will fail.
 

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -79,7 +79,7 @@ SEQ_COMMENT -> "," C*;
   | C* "{" C* dict=((ext=extra|key=expr ":" value=top):SEQ_COMMENT,?) "}" C*
   | C* "[" C* array=(%!sparse_sequence(top)?) C* "]" C*
   | C* "<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* ">>" C*
-  | C* "(" tuple=(pairs=(extra|name? ":" v=top):SEQ_COMMENT,?) ")" C*
+  | C* "(" tuple=(pairs=((extra|rec="rec"? name| name?) ":" v=top):SEQ_COMMENT,?) ")" C*
   | C* "(" identpattern=IDENT ")" C*
 };
 

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -79,7 +79,7 @@ SEQ_COMMENT -> "," C*;
   | C* "{" C* dict=((ext=extra|key=expr ":" value=top):SEQ_COMMENT,?) "}" C*
   | C* "[" C* array=(%!sparse_sequence(top)?) C* "]" C*
   | C* "<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* ">>" C*
-  | C* "(" tuple=(pairs=((extra|rec="rec"? name| name?) ":" v=top):SEQ_COMMENT,?) ")" C*
+  | C* "(" tuple=(pairs=(extra | ((rec="rec"? name| name?) ":" v=top)):SEQ_COMMENT,?) ")" C*
   | C* "(" identpattern=IDENT ")" C*
 };
 

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -843,7 +843,16 @@ func (pc ParseContext) compileTuple(c ast.Children) rel.Expr {
 					panic(fmt.Errorf("unnamed attr expression must be name or end in .name: %T(%[1]v)", v))
 				}
 			}
-			attr, err := rel.NewAttrExpr(pair.One("v").(ast.Branch).Scanner(), k, v)
+			scanner := pair.One("v").(ast.Branch).Scanner()
+			if pair.One("rec") != nil {
+				fix, fixt := FixFuncs()
+				v = rel.NewRecursionExpr(
+					scanner,
+					rel.NewExprPattern(rel.NewIdentExpr(pair.One("name").Scanner(), k)),
+					v, fix, fixt,
+				)
+			}
+			attr, err := rel.NewAttrExpr(scanner, k, v)
 			if err != nil {
 				panic(err)
 			}

--- a/syntax/expr_tuple_test.go
+++ b/syntax/expr_tuple_test.go
@@ -42,3 +42,40 @@ func TestTupleLiteral(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let t = (x: 1, y: 2); (:t.x, :t.y)`)
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `(x: 1, y: 2) -> (:.x, :.y)`)
 }
+
+func TestTupleRec(t *testing.T) {
+	t.Parallel()
+	AssertCodesEvalToSameValue(t,
+		`120`,
+		`
+		let t = (
+			rec fact: \n cond n {(0, 1): 1, n: n * fact(n - 1)},
+			n       : 5,
+		);
+		t.fact(t.n)
+		`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`false`,
+		`
+		let t = (
+			rec eo: (
+				even: \n n = 0 || eo.odd(n - 1),
+				odd:  \n n != 0 && eo.even(n - 1),
+			),
+			n     : 5,
+		);
+		t.eo.even(t.n)
+		`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`120`,
+		`
+		let t = (
+			rec fact: \n cond n {(0, 1): 1, n: n * fact(n - 1)},
+			rec     : 5,
+		);
+		t.fact(t.rec)
+		`,
+	)
+}

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -93,7 +93,7 @@ SEQ_COMMENT -> "," C*;
   | C* "{" C* dict=((ext=extra|key=expr ":" value=top):SEQ_COMMENT,?) "}" C*
   | C* "[" C* array=(%!sparse_sequence(top)?) C* "]" C*
   | C* "<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* ">>" C*
-  | C* "(" tuple=(pairs=(extra|name? ":" v=top):SEQ_COMMENT,?) ")" C*
+  | C* "(" tuple=(pairs=((extra|rec="rec"? name| name?) ":" v=top):SEQ_COMMENT,?) ")" C*
   | C* "(" identpattern=IDENT ")" C*
 };
 

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -93,7 +93,7 @@ SEQ_COMMENT -> "," C*;
   | C* "{" C* dict=((ext=extra|key=expr ":" value=top):SEQ_COMMENT,?) "}" C*
   | C* "[" C* array=(%!sparse_sequence(top)?) C* "]" C*
   | C* "<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* ">>" C*
-  | C* "(" tuple=(pairs=((extra|rec="rec"? name| name?) ":" v=top):SEQ_COMMENT,?) ")" C*
+  | C* "(" tuple=(pairs=(extra | ((rec="rec"? name| name?) ":" v=top)):SEQ_COMMENT,?) ")" C*
   | C* "(" identpattern=IDENT ")" C*
 };
 


### PR DESCRIPTION
Fixes #417.

Changes proposed in this pull request:
- allows syntactic sugar for recursive functions in a tuple.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
