### PR TITLE
fix #434, adds stack frame navigation in arrai debug shell

### DIFF
--- a/cmd/arrai/shell.go
+++ b/cmd/arrai/shell.go
@@ -14,13 +14,13 @@ var shellCommand = &cli.Command{
 }
 
 func iShell(_ *cli.Context) error {
-	return shell.Shell(rel.EmptyScope)
+	return shell.Shell([]rel.ContextErr{})
 }
 
 func createDebuggerShell(err error) error {
 	if err != nil {
 		if ctxErr, isContextError := err.(rel.ContextErr); isContextError {
-			return shell.Shell(ctxErr.GetLastScope())
+			return shell.Shell(ctxErr.GetImportantFrames())
 		}
 		return err
 	}

--- a/docs/tutorial/shell.md
+++ b/docs/tutorial/shell.md
@@ -115,6 +115,10 @@ test.arrai:7:5:
 // a  b  x  y  z
 ```
 
+Stack number represents which stack is currently being used. Low stack number
+is closer to the first point of execution. The higher the stack number, the
+closer it is to the point of failure.
+
 ## Evaluating expressions
 
 To evaluate an expression in the shell, simply type it in and press enter.

--- a/docs/tutorial/shell.md
+++ b/docs/tutorial/shell.md
@@ -64,8 +64,8 @@ let x = 1; (\a a + b)(x)
 a x
 ```
 
-It is also possible to navigate through the frames by using the `/up` and
-`/down`, or `/u` and `/d` which are shorthand for the commands.
+It is also possible to navigate through the frames by using the `/up` (or
+`/u`) and `/down` (or `/d`) commands.
 
 Running the following script:
 ```arrai

--- a/docs/tutorial/shell.md
+++ b/docs/tutorial/shell.md
@@ -64,6 +64,57 @@ let x = 1; (\a a + b)(x)
 a x
 ```
 
+It is also possible to navigate through the frames by using the `/up` and
+`/down`, or `/u` and `/d` which are shorthand for the commands.
+
+Running the following script:
+```arrai
+let a = {"a": {"b": {"c": 1}}};
+let x = "b";
+let y = "d";
+let d = (
+    \z
+    let b = a("a");
+    b(z)(y)
+);
+d(x)
+```
+
+Will drop into this shell.
+
+```bash
+INFO[0000] Call: no return values from set {c: 1}
+
+test.arrai:7:5:
+    let b = a("a");
+    b(z)(y)
+
+test.arrai:9:1:
+);
+d(x)
+
+@> <tab>
+// a  b  x  y  z
+@> /u
+2020-06-09T12:50:58.306199+10:00 INFO Stack: 0
+
+test.arrai:9:1:
+);
+d(x)
+
+@> <tab>
+// a  d  x  y
+@> /d
+2020-06-09T12:52:15.393629+10:00 INFO Stack: 1
+
+test.arrai:7:5:
+    let b = a("a");
+    b(z)(y)
+
+@> <tab>
+// a  b  x  y  z
+```
+
 ## Evaluating expressions
 
 To evaluate an expression in the shell, simply type it in and press enter.

--- a/internal/shell/shell_cmd.go
+++ b/internal/shell/shell_cmd.go
@@ -3,9 +3,14 @@
 package shell
 
 import (
+	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/anz-bank/pkg/log"
+	"github.com/arr-ai/arrai/syntax"
+	"github.com/arr-ai/wbnf/parser"
 	"github.com/go-errors/errors"
 )
 
@@ -30,14 +35,14 @@ func tryRunCommand(line string, shellData *shellInstance) error {
 }
 
 type shellCmd interface {
-	name() string
+	names() []string
 	process(line string, shellData *shellInstance) error
 }
 
 type setCmd struct{}
 
-func (sc *setCmd) name() string {
-	return "set"
+func (sc *setCmd) names() []string {
+	return []string{"set"}
 }
 
 func (sc *setCmd) process(line string, shellData *shellInstance) error {
@@ -58,8 +63,8 @@ func (sc *setCmd) process(line string, shellData *shellInstance) error {
 
 type unsetCmd struct{}
 
-func (uc *unsetCmd) name() string {
-	return "unset"
+func (uc *unsetCmd) names() []string {
+	return []string{"unset"}
 }
 
 func (uc *unsetCmd) process(line string, shellData *shellInstance) error {
@@ -79,19 +84,51 @@ func (exitError) Error() string {
 
 type exitCommand struct{}
 
-func (*exitCommand) name() string {
-	return "exit"
+func (*exitCommand) names() []string {
+	return []string{"exit"}
 }
 
 func (ec *exitCommand) process(_ string, _ *shellInstance) error {
 	return exitError{}
 }
 
+type upFrameCmd struct{}
+
+func (*upFrameCmd) names() []string {
+	return []string{"up", "u"}
+}
+
+func (*upFrameCmd) process(_ string, sh *shellInstance) error {
+	return changeFrame(sh.currentFrameIndex-1, sh)
+}
+
+type downFrameCmd struct{}
+
+func (d *downFrameCmd) names() []string {
+	return []string{"down", "d"}
+}
+
+func (*downFrameCmd) process(_ string, sh *shellInstance) error {
+	return changeFrame(sh.currentFrameIndex+1, sh)
+}
+
+func changeFrame(i int, sh *shellInstance) error {
+	if i < 0 || i >= len(sh.frames) {
+		return fmt.Errorf("frame index out of range, frame length: %d", len(sh.frames))
+	}
+	sh.currentFrameIndex = i
+	log.Infof(context.Background(), "Stack: %d\n%s\n", i, sh.frames[i].GetSource().Context(parser.DefaultLimit))
+	sh.scope = syntax.StdScope().Update(sh.frames[i].GetScope())
+	return nil
+}
+
 func initCommands() map[string]shellCmd {
-	cmds := []shellCmd{&setCmd{}, &unsetCmd{}, &exitCommand{}}
+	cmds := []shellCmd{&setCmd{}, &unsetCmd{}, &exitCommand{}, &upFrameCmd{}, &downFrameCmd{}}
 	cmdMap := make(map[string]shellCmd)
 	for _, cmd := range cmds {
-		cmdMap[cmd.name()] = cmd
+		for _, n := range cmd.names() {
+			cmdMap[n] = cmd
+		}
 	}
 	return cmdMap
 }

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -185,7 +185,7 @@ func TestTabCompletionStdlib(t *testing.T) {
 func TestTrimExpr(t *testing.T) {
 	t.Parallel()
 
-	sh := newShellInstance(newLineCollector(), syntax.StdScope())
+	sh := newShellInstance(newLineCollector(), []rel.ContextErr{})
 
 	realExpr, residue := sh.trimExpr(`x.`)
 	assert.Equal(t, "x", realExpr)
@@ -317,7 +317,8 @@ func assertTabCompletion(t *testing.T,
 		require.NoError(t, err)
 		scope = scope.With(name, val)
 	}
-	sh := newShellInstance(newLineCollector(), scope)
+	sh := newShellInstance(newLineCollector(), []rel.ContextErr{})
+	sh.scope = scope
 	predictions, length := sh.Do([]rune(line), strings.Index(line, "\t"))
 	strPredictions := make([]string, 0, len(predictions))
 	for _, p := range predictions {

--- a/internal/shell/shell_wasm.go
+++ b/internal/shell/shell_wasm.go
@@ -4,6 +4,6 @@ package shell
 
 import "github.com/arr-ai/arrai/rel"
 
-func Shell(_ rel.Scope) error {
+func Shell(_ []rel.ContextErr) error {
 	panic("not implemented")
 }

--- a/rel/expr.go
+++ b/rel/expr.go
@@ -15,6 +15,7 @@ func (e ExprScanner) Source() parser.Scanner {
 	return e.Src
 }
 
+// ContextErr represents the whole stack frame of an error from arrai script.
 type ContextErr struct {
 	err    error
 	source parser.Scanner
@@ -54,6 +55,9 @@ func (c ContextErr) GetLastScope() Scope {
 	}
 }
 
+// GetImportantFrames returns an array of important frames whose last element
+// is the last frame near the point of failure.
+// Important frames are frames that don't contain the frame under it.
 func (c ContextErr) GetImportantFrames() []ContextErr {
 	if cerr, is := c.err.(ContextErr); is {
 		currScope := cerr.GetImportantFrames()

--- a/rel/expr.go
+++ b/rel/expr.go
@@ -21,6 +21,10 @@ type ContextErr struct {
 	scope  Scope
 }
 
+func NewContextErr(err error, source parser.Scanner, scope Scope) ContextErr {
+	return ContextErr{err, source, scope}
+}
+
 func (c ContextErr) Error() string {
 	if cerr, is := c.err.(ContextErr); is {
 		errString := cerr.Error()
@@ -48,6 +52,25 @@ func (c ContextErr) GetLastScope() Scope {
 		}
 		ctxErr = currentErr
 	}
+}
+
+func (c ContextErr) GetImportantFrames() []ContextErr {
+	if cerr, is := c.err.(ContextErr); is {
+		currScope := cerr.GetImportantFrames()
+		if c.source.Contains(cerr.source) {
+			return currScope
+		}
+		return append([]ContextErr{c}, currScope...)
+	}
+	return []ContextErr{c}
+}
+
+func (c ContextErr) GetScope() Scope {
+	return c.scope
+}
+
+func (c ContextErr) GetSource() parser.Scanner {
+	return c.source
 }
 
 func wrapContext(err error, expr Expr, scope Scope) error {

--- a/rel/expr_test.go
+++ b/rel/expr_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/arr-ai/wbnf/parser"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,4 +28,28 @@ func TestGetLastScope(t *testing.T) {
 
 	err = wrapContext(fmt.Errorf("random"), EmptyTuple, EmptyScope)
 	assert.True(t, err.(ContextErr).GetLastScope().m.Equal(EmptyScope.m))
+}
+
+func TestGetImportantFrames(t *testing.T) {
+	t.Parallel()
+
+	err := wrapContext(fmt.Errorf("random"), EmptyTuple, EmptyScope)
+	assert.Equal(t, []ContextErr{err.(ContextErr)}, err.(ContextErr).GetImportantFrames())
+
+	err2 := wrapContext(err, EmptyTuple, EmptyScope)
+	err3 := wrapContext(err2, EmptyTuple, EmptyScope)
+
+	assert.Equal(t, []ContextErr{err.(ContextErr)}, err3.(ContextErr).GetImportantFrames())
+
+	err = NewContextErr(fmt.Errorf("random"), *parser.NewScannerAt("random", 5, 1), EmptyScope)
+	err2 = NewContextErr(err, *parser.NewScannerAt("random", 3, 1), EmptyScope)
+	err3 = NewContextErr(err2, *parser.NewScannerAt("random", 1, 1), EmptyScope)
+	assert.Equal(t,
+		[]ContextErr{
+			err3.(ContextErr),
+			err2.(ContextErr),
+			err.(ContextErr),
+		},
+		err3.(ContextErr).GetImportantFrames(),
+	)
 }


### PR DESCRIPTION
Fixes #434 .

Changes proposed in this pull request:
- Stack frame navigation in arrai debug shell

When evaluation fails, it will drop into the debug shell with the last frame. This PR adds the `/up` which will change into the previous frame and replace the scope with the corresponding frame's scope. `/down` will change into the next frame.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
