### PR TITLE
fix #425, allows `.` at the end without entering multiline mode in ai

### DIFF
--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -252,7 +252,12 @@ func (l *lineCollector) isBalanced() bool {
 		return false
 	}
 
-	if strings.HasSuffix(lastLine, ";") || strings.HasSuffix(lastLine, ":") || strings.HasSuffix(lastLine, ".") {
+	// allows single `.` but still not allowing x.
+	if regexp.MustCompile(`[\w\d]\.$`).Match([]byte(lastLine)) {
+		return false
+	}
+
+	if strings.HasSuffix(lastLine, ";") || strings.HasSuffix(lastLine, ":") {
 		return false
 	}
 

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -108,6 +108,15 @@ func TestIsBalanced(t *testing.T) {
 	c.appendLine("\\.")
 	assert.False(t, c.isBalanced())
 
+	c.appendLine(".")
+	assert.True(t, c.isBalanced())
+
+	c.appendLine("x.")
+	assert.False(t, c.isBalanced())
+
+	c.appendLine("1.")
+	assert.False(t, c.isBalanced())
+
 	c.appendLine("\\a random")
 	assert.True(t, c.isBalanced())
 


### PR DESCRIPTION
Fixes #425 .

Changes proposed in this pull request:
- Allows a line to end with `.` but not all scenarios. Partial attribute access will still enter multiline mode.

Checklist:
- [x] Added related tests

