### PR TITLE
Handle closure call error

### DIFF
--- a/rel/value_set_closure.go
+++ b/rel/value_set_closure.go
@@ -137,7 +137,10 @@ func (c Closure) CallAll(arg Value) (Set, error) {
 		}
 		return NewSet(val), nil
 	}
-	scope, _ := c.f.arg.Bind(c.scope, arg) //nolint: errcheck
+	scope, err := c.f.arg.Bind(c.scope, arg)
+	if err != nil {
+		return nil, err
+	}
 	val, err := c.f.body.Eval(c.scope.Update(scope))
 	if err != nil {
 		return nil, err

--- a/syntax/expr_fn_test.go
+++ b/syntax/expr_fn_test.go
@@ -6,4 +6,6 @@ func TestExprFn(t *testing.T) {
 	t.Parallel()
 	AssertCodesEvalToSameValue(t, `3`, `(\[x, y] x + y)([1, 2])`)
 	AssertCodesEvalToSameValue(t, `3`, `(\z \[x, y] z/(x + y))(9, [1, 2])`)
+	AssertCodeErrors(t, `(\[x, y] 42)([1, 2, 3])`, "")
+	AssertCodeErrors(t, `(\[x, y] x + y)([1, 2, 3])`, "")
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- `(\[x, y] 42)([1, 2, 3])` and `(\[x, y] x + y)([1, 2, 3])` should fail

Checklist:
- [x] Added related tests
