### PR TITLE
Fix crash with holey arrays in expression strings

### DIFF
--- a/syntax/std_str.go
+++ b/syntax/std_str.go
@@ -10,13 +10,16 @@ import (
 // TODO: Make this more robust.
 func formatValue(format string, value rel.Value) string {
 	var v interface{}
-	if set, ok := value.(rel.Set); ok {
+	switch set := value.(type) {
+	case rel.Set:
 		if s, is := rel.AsString(set); is {
 			v = s
 		} else {
 			v = rel.Repr(set)
 		}
-	} else {
+	case nil:
+		panic(fmt.Errorf("unable to format nil value"))
+	default:
 		v = value.Export()
 	}
 	switch format[len(format)-1] {
@@ -56,7 +59,9 @@ var (
 					if i > 0 {
 						sb.WriteString(delim[1:])
 					}
-					sb.WriteString(formatValue(format, value))
+					if value != nil {
+						sb.WriteString(formatValue(format, value))
+					}
 				}
 				s = sb.String()
 			} else {

--- a/syntax/std_str_test.go
+++ b/syntax/std_str_test.go
@@ -30,3 +30,9 @@ func TestStrTitle(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `"This Is A Test"`, `//str.title("this is a test")`)
 	AssertCodeErrors(t, `//str.title(123)`, "")
 }
+
+func TestStrExprStr(t *testing.T) {
+	t.Parallel()
+	AssertCodesEvalToSameValue(t, `"/a+b+c/"`, `let arr = ['a', 'b', 'c']; $'/${arr::+}/'`)
+	AssertCodesEvalToSameValue(t, `"/a++b+c/"`, `let arr = ['a', , 'b', 'c']; $'/${arr::+}/'`)
+}


### PR DESCRIPTION
Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
