### PR TITLE
Added parenthesis for number of different logs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ Version=$(tagName)
 else
 
 ifeq (, $(shell git status -s)) # it doesn't have uncommitted or untracked changes
-Version=$(FullCommit)~$(words $(diffLogs)) = $(tagName)
+Version=$(FullCommit) (~$(words $(diffLogs)) = $(tagName))
 else
-Version=DIRTY-$(FullCommit)~$(words $(diffLogs)) = $(tagName)
+Version=DIRTY-$(FullCommit) (~$(words $(diffLogs)) = $(tagName))
 endif
 
 endif


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Changed output to:
```
arrai -v
arrai DIRTY-cca2f85f92bbdcc5852d7bebe9ef20399b874f2f (~1 = v0.64.0) darwin/i386
``` 

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
