### PR TITLE
Version for dirty repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ Version=$(tagName)
 else
 
 ifeq (, $(shell git status -s)) # it doesn't have uncommitted or untracked changes
-Version=$(FullCommit) (~$(words $(diffLogs)) = $(tagName))
+Version=$(FullCommit) (from $(tagName))
 else
-Version=DIRTY-$(FullCommit) (~$(words $(diffLogs)) = $(tagName))
+Version=DIRTY-$(FullCommit) (from $(tagName))
 endif
 
 endif

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ Version=$(tagName)
 else
 
 ifeq (, $(shell git status -s)) # it doesn't have uncommitted or untracked changes
-Version=$(FullCommit)~$(words $(diffLogs)) = $(tagName)
+Version=$(FullCommit) (~$(words $(diffLogs)) = $(tagName))
 else
-Version=DIRTY-$(FullCommit)~$(words $(diffLogs)) = $(tagName)
+Version=DIRTY-$(FullCommit) (~$(words $(diffLogs)) = $(tagName))
 endif
 
 endif


### PR DESCRIPTION
Fixes #456 .

Changes proposed in this pull request:
Changed the different logs behind HEAD from
```
$ arrai v
arrai 751a975944edadf56a2558a8a21eebcfd47fc52e (~3 = v0.123.0) darwin/amd64
```
to
```
$ arrai v
arrai 751a975944edadf56a2558a8a21eebcfd47fc52e (from v0.123.0) darwin/amd64
```
It is simple and no confusion.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
