### PR TITLE
Correct `cond` default syntax keyword

### DIFF
--- a/docs/tutorial/shell.md
+++ b/docs/tutorial/shell.md
@@ -152,7 +152,7 @@ further input. Here's a more complex example.
  > cond (
  >     length > 1: "too big",
  >     length < 1: "too small",
- >     *: "just right"
+ >     _: "just right"
  > )
 ```
 


### PR DESCRIPTION
Correct `cond` default syntax keyword, changed from `*` to `_`

Fixes # .

Changes proposed in this pull request:
- Correct cond default syntax keyword, changed from * to _
- 

Checklist:
- [ ] Added related tests
- [ ] Made corresponding changes to the documentation
