### PR TITLE
Correct cond sample

### DIFF
--- a/docs/tutorial/shell.md
+++ b/docs/tutorial/shell.md
@@ -149,11 +149,11 @@ further input. Here's a more complex example.
 ```arrai
 @> let v = (x: 1, y: 2, z: 3);
  > let length = (v.x^2 + v.y^2 + v.z^2)^0.5;
- > cond (
+ > cond {
  >     length > 1: "too big",
  >     length < 1: "too small",
  >     _: "just right"
- > )
+ > }
 ```
 
 Caution: The current approach to detection uses some simple heuristics such as


### PR DESCRIPTION
Correct cond sample, changed from `cond ()` to `cond {}`.

Fixes # .

Changes proposed in this pull request:
- Correct `cond` sample from `cond(...)` to `cond{...}`
- 

Checklist:
- [ ] Added related tests
- [ ] Made corresponding changes to the documentation
