### PR TITLE
Fixed parenthesis enclosed expression issue  

### DIFF
--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -56,7 +56,13 @@ tail   -> get
                     |     ":" end=expr  (":" step=expr)?
                 ):SEQ_COMMENT,
             ")");
-pattern -> extra | %!patternterms(pattern|expr) | IDENT | NUM | C* "(" exprpattern=expr:SEQ_COMMENT,? ")" C* | C* exprpattern=STR C*;
+pattern -> extra 
+        | %!patternterms(pattern|expr)
+        | C* odelim="(" identpattern=IDENT cdelim=")" C*
+        | IDENT
+        | NUM 
+        | C* "(" exprpattern=expr:SEQ_COMMENT,? ")" C* 
+        | C* exprpattern=STR C*;
 extra -> ("..." ident=IDENT?);
 
 ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min};

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -61,7 +61,6 @@ extra -> ("..." ident=IDENT?);
 
 ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min};
 IDENT  -> /{ \. | [$@A-Za-z_][0-9$@A-Za-z_]* };
-IDENT_NODOT  -> /{ [$@A-Za-z_][0-9$@A-Za-z_]* };
 PKGPATH -> /{ (?: \\ | [^\\}] )* };
 STR    -> /{ " (?: \\. | [^\\"] )* "
            | ' (?: \\. | [^\\'] )* '
@@ -81,7 +80,6 @@ SEQ_COMMENT -> "," C*;
   | C* odelim="[" C* array=(%!sparse_sequence(top)?) C* cdelim="]" C*
   | C* odelim="<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* cdelim=">>" C*
   | C* odelim="(" tuple=(pairs=(extra | ((rec="rec"? name| name?) ":" v=top)):SEQ_COMMENT,?) cdelim=")" C*
-  | C* odelim="(" identpattern=IDENT_NODOT cdelim=")" C*
 };
 
 .macro sparse_sequence(top) {

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -61,6 +61,7 @@ extra -> ("..." ident=IDENT?);
 
 ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min};
 IDENT  -> /{ \. | [$@A-Za-z_][0-9$@A-Za-z_]* };
+IDENT_NODOT  -> /{ [$@A-Za-z_][0-9$@A-Za-z_]* };
 PKGPATH -> /{ (?: \\ | [^\\}] )* };
 STR    -> /{ " (?: \\. | [^\\"] )* "
            | ' (?: \\. | [^\\'] )* '
@@ -80,7 +81,7 @@ SEQ_COMMENT -> "," C*;
   | C* odelim="[" C* array=(%!sparse_sequence(top)?) C* cdelim="]" C*
   | C* odelim="<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* cdelim=">>" C*
   | C* odelim="(" tuple=(pairs=(extra | ((rec="rec"? name| name?) ":" v=top)):SEQ_COMMENT,?) cdelim=")" C*
-  | C* odelim="(" identpattern=[$@A-Za-z_][0-9$@A-Za-z_]* cdelim=")" C*
+  | C* odelim="(" identpattern=IDENT_NODOT cdelim=")" C*
 };
 
 .macro sparse_sequence(top) {

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -80,7 +80,7 @@ SEQ_COMMENT -> "," C*;
   | C* odelim="[" C* array=(%!sparse_sequence(top)?) C* cdelim="]" C*
   | C* odelim="<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* cdelim=">>" C*
   | C* odelim="(" tuple=(pairs=(extra | ((rec="rec"? name| name?) ":" v=top)):SEQ_COMMENT,?) cdelim=")" C*
-  | C* odelim="(" identpattern=IDENT cdelim=")" C*
+  | C* odelim="(" identpattern=[$@A-Za-z_][0-9$@A-Za-z_]* cdelim=")" C*
 };
 
 .macro sparse_sequence(top) {

--- a/syntax/expr_arrow_test.go
+++ b/syntax/expr_arrow_test.go
@@ -6,6 +6,9 @@ func TestApplyExpr(t *testing.T) {
 	t.Parallel()
 	AssertCodesEvalToSameValue(t, `42`, `6 -> 7 * .`)
 	AssertCodesEvalToSameValue(t, `42`, `6 -> \x 7 * x`)
+
+	AssertCodesEvalToSameValue(t, `[1,2,3]`, `[1,2,3] -> (.)`)
+	AssertCodesEvalToSameValue(t, `[1,2,3]`, `[1,2,3] -> .`)
 }
 
 func TestSeqArrow(t *testing.T) {

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -12,7 +12,13 @@ func TestExprLet(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; let y = 2; (:x, :y)`)
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; (:x, y: 2)`)
 
-	AssertCodeErrors(t, `let (x) = 5;x`, "")
+	AssertCodesEvalToSameValue(t, `1`, `let a = 1;(a)`) // (a) is an expression
+	AssertCodesEvalToSameValue(t, `4`, `let x = 4; let (x) = 4;x`)
+	AssertCodesEvalToSameValue(t, `4`, `let x = 4; let (x) = (4);x`)
+	AssertCodesEvalToSameValue(t, `4`, `let x = 4; let (x) =(4 + 0);x`)
+	AssertCodesEvalToSameValue(t, `1`, `let [a,b] = [1,2];let (b) = (a + 1);a`)
+
+	AssertCodeErrors(t, `let (x) = 5;x`, "") // (x) should be parsed as an expression and fail because x isn't bound.
 }
 
 func TestExprLetExprPattern(t *testing.T) { //nolint:dupl

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -12,13 +12,15 @@ func TestExprLet(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; let y = 2; (:x, :y)`)
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; (:x, y: 2)`)
 
-	AssertCodesEvalToSameValue(t, `1`, `let a = 1;(a)`) // (a) is an expression
 	AssertCodesEvalToSameValue(t, `4`, `let x = 4; let (x) = 4;x`)
 	AssertCodesEvalToSameValue(t, `4`, `let x = 4; let (x) = (4);x`)
 	AssertCodesEvalToSameValue(t, `4`, `let x = 4; let (x) =(4 + 0);x`)
 	AssertCodesEvalToSameValue(t, `1`, `let [a,b] = [1,2];let (b) = (a + 1);a`)
 
-	AssertCodeErrors(t, `let (x) = 5;x`, "") // (x) should be parsed as an expression and fail because x isn't bound.
+	AssertCodesEvalToSameValue(t, `1`, `let a = 1;a`)
+	AssertCodesEvalToSameValue(t, `1`, `let a = 1;(a)`) // (a) is an expression
+	AssertCodeErrors(t, `let (x) = 5;x`, "")            // (x) should be parsed as an expression and fail because x isn't bound.
+	AssertCodeErrors(t, `let (x) = 5;(x)`, "")
 }
 
 func TestExprLetExprPattern(t *testing.T) { //nolint:dupl

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -2,7 +2,7 @@ package syntax
 
 import "testing"
 
-func TestExprLet(t *testing.T) {
+func TestExprLet(t *testing.T) { //nolint:dupl
 	t.Parallel()
 	AssertCodesEvalToSameValue(t, `7`, `let x = 6; 7`)
 	AssertCodesEvalToSameValue(t, `42`, `let x = 6; x * 7`)
@@ -19,7 +19,9 @@ func TestExprLet(t *testing.T) {
 
 	AssertCodesEvalToSameValue(t, `1`, `let a = 1;a`)
 	AssertCodesEvalToSameValue(t, `1`, `let a = 1;(a)`) // (a) is an expression
-	AssertCodeErrors(t, `let (x) = 5;x`, "")            // (x) should be parsed as an expression and fail because x isn't bound.
+
+	// (x) should be parsed as an expression and fail because x isn't bound.
+	AssertCodeErrors(t, `let (x) = 5;x`, "")
 	AssertCodeErrors(t, `let (x) = 5;(x)`, "")
 }
 
@@ -122,7 +124,7 @@ func TestExprLetDictPattern(t *testing.T) {
 	AssertCodePanics(t, `let {"x": a, "x": a} = {"x": 4, "x": 4}; a`)
 }
 
-func TestExprLetSetPattern(t *testing.T) {
+func TestExprLetSetPattern(t *testing.T) { //nolint:dupl
 	t.Parallel()
 	AssertCodesEvalToSameValue(t, `1`, `let {} = {}; 1`)
 	AssertCodesEvalToSameValue(t, `1`, `let {42} = {42}; 1`)

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -11,6 +11,8 @@ func TestExprLet(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `(x: 1)`, `let x = 1; (:x)`)
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; let y = 2; (:x, :y)`)
 	AssertCodesEvalToSameValue(t, `(x: 1, y: 2)`, `let x = 1; (:x, y: 2)`)
+
+	AssertCodeErrors(t, `let (x) = 5;x`, "")
 }
 
 func TestExprLetExprPattern(t *testing.T) { //nolint:dupl

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -94,7 +94,7 @@ SEQ_COMMENT -> "," C*;
   | C* odelim="[" C* array=(%!sparse_sequence(top)?) C* cdelim="]" C*
   | C* odelim="<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* cdelim=">>" C*
   | C* odelim="(" tuple=(pairs=(extra | ((rec="rec"? name| name?) ":" v=top)):SEQ_COMMENT,?) cdelim=")" C*
-  | C* odelim="(" identpattern=IDENT cdelim=")" C*
+  | C* odelim="(" identpattern=[$@A-Za-z_][0-9$@A-Za-z_]* cdelim=")" C*
 };
 
 .macro sparse_sequence(top) {

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -75,7 +75,6 @@ extra -> ("..." ident=IDENT?);
 
 ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min};
 IDENT  -> /{ \. | [$@A-Za-z_][0-9$@A-Za-z_]* };
-IDENT_NODOT  -> /{ [$@A-Za-z_][0-9$@A-Za-z_]* };
 PKGPATH -> /{ (?: \\ | [^\\}] )* };
 STR    -> /{ " (?: \\. | [^\\"] )* "
            | ' (?: \\. | [^\\'] )* '
@@ -95,7 +94,6 @@ SEQ_COMMENT -> "," C*;
   | C* odelim="[" C* array=(%!sparse_sequence(top)?) C* cdelim="]" C*
   | C* odelim="<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* cdelim=">>" C*
   | C* odelim="(" tuple=(pairs=(extra | ((rec="rec"? name| name?) ":" v=top)):SEQ_COMMENT,?) cdelim=")" C*
-  | C* odelim="(" identpattern=IDENT_NODOT cdelim=")" C*
 };
 
 .macro sparse_sequence(top) {

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -75,6 +75,7 @@ extra -> ("..." ident=IDENT?);
 
 ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min};
 IDENT  -> /{ \. | [$@A-Za-z_][0-9$@A-Za-z_]* };
+IDENT_NODOT  -> /{ [$@A-Za-z_][0-9$@A-Za-z_]* };
 PKGPATH -> /{ (?: \\ | [^\\}] )* };
 STR    -> /{ " (?: \\. | [^\\"] )* "
            | ' (?: \\. | [^\\'] )* '
@@ -94,7 +95,7 @@ SEQ_COMMENT -> "," C*;
   | C* odelim="[" C* array=(%!sparse_sequence(top)?) C* cdelim="]" C*
   | C* odelim="<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* cdelim=">>" C*
   | C* odelim="(" tuple=(pairs=(extra | ((rec="rec"? name| name?) ":" v=top)):SEQ_COMMENT,?) cdelim=")" C*
-  | C* odelim="(" identpattern=[$@A-Za-z_][0-9$@A-Za-z_]* cdelim=")" C*
+  | C* odelim="(" identpattern=IDENT_NODOT cdelim=")" C*
 };
 
 .macro sparse_sequence(top) {

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -70,7 +70,13 @@ tail   -> get
                     |     ":" end=expr  (":" step=expr)?
                 ):SEQ_COMMENT,
             ")");
-pattern -> extra | %!patternterms(pattern|expr) | IDENT | NUM | C* "(" exprpattern=expr:SEQ_COMMENT,? ")" C* | C* exprpattern=STR C*;
+pattern -> extra 
+        | %!patternterms(pattern|expr)
+        | C* odelim="(" identpattern=IDENT cdelim=")" C*
+        | IDENT
+        | NUM 
+        | C* "(" exprpattern=expr:SEQ_COMMENT,? ")" C* 
+        | C* exprpattern=STR C*;
 extra -> ("..." ident=IDENT?);
 
 ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min};


### PR DESCRIPTION
Fixes #442 .

Changes proposed in this pull request:
- Will pasre `(a)` in `let a = 5;(a)` to expression.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
