### PR TITLE
Implement filter op

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -178,6 +178,24 @@ $ echo {0..10} | ax '2^.'
 ```
 -->
 
+### Filter a collection of values with Control Var cases
+
+```bash
+$ arrai eval '{1, [2, 3], 4, [5, 6]} filter . {[a, b]: a + b}'
+{5, 11}
+```
+
+```bash
+$ arrai eval '{1, [2, 3], 4, [5, 6], [7, 8, 9]} filter . {[a, ..., b]: a + b}'
+{5, 11, 16}
+```
+
+```bash
+$ arrai eval '{1, [2, 3], 4, [5, 6]} filter . {[_, _]: 42}'
+{42}
+```
+
+
 ### Transform json and filter value from it
 
 Filter out value of `a` from json 

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -66,7 +66,7 @@ pattern -> extra
         | C* exprpattern=STR C*;
 extra -> ("..." ident=IDENT?);
 
-ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min};
+ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min} | "filter" expr;
 IDENT  -> /{ \. | [$@A-Za-z_][0-9$@A-Za-z_]* };
 PKGPATH -> /{ (?: \\ | [^\\}] )* };
 STR    -> /{ " (?: \\. | [^\\"] )* "

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -2,6 +2,7 @@ expr   -> C* amp="&"* @ C* arrow=(
               nest |
               unnest |
               ARROW @ |
+              FILTER cond=(controlVar=@ "{" (condition=pattern ":" value=@):SEQ_COMMENT,? "}") |
               binding="->" C* "\\" C* pattern C* %%bind C* @ |
               binding="->" C* %%bind @
           )* C*
@@ -66,7 +67,8 @@ pattern -> extra
         | C* exprpattern=STR C*;
 extra -> ("..." ident=IDENT?);
 
-ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min} | "filter" expr;
+ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min};
+FILTER -> /{filter};
 IDENT  -> /{ \. | [$@A-Za-z_][0-9$@A-Za-z_]* };
 PKGPATH -> /{ (?: \\ | [^\\}] )* };
 STR    -> /{ " (?: \\. | [^\\"] )* "

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -284,7 +284,7 @@ func (pc ParseContext) compileArrow(b ast.Branch, name string, c ast.Children) r
 	if arrows, has := b["arrow"]; has {
 		for _, arrow := range arrows.(ast.Many) {
 			branch := arrow.(ast.Branch)
-			part, d := which(branch, "nest", "unnest", "ARROW", "binding")
+			part, d := which(branch, "nest", "unnest", "ARROW", "binding", "FILTER")
 			switch part {
 			case "nest":
 				expr = parseNest(expr, branch["nest"].(ast.One).Node.(ast.Branch))
@@ -301,6 +301,10 @@ func (pc ParseContext) compileArrow(b ast.Branch, name string, c ast.Children) r
 					rhs = rel.NewFunction(source, p, rhs)
 				}
 				expr = binops["->"](source, expr, rhs)
+			case "FILTER":
+				pred := pc.CompileExpr(arrow.(ast.Branch))
+				lhs := rel.NewWhereExpr(source, expr, pred)
+				expr = rel.NewDArrowExpr(source, lhs, pred)
 			}
 		}
 	}

--- a/syntax/expr_filter_test.go
+++ b/syntax/expr_filter_test.go
@@ -5,6 +5,7 @@ import "testing"
 func TestFilter(t *testing.T) {
 	t.Parallel()
 	AssertCodesEvalToSameValue(t, `{42}`, `{1, [2, 3], 4, [5, 6]} filter . {[a, b]: 42}`)
+	AssertCodesEvalToSameValue(t, `{42}`, `{1, [2, 3], 4, [5, 6]} filter . {[_, _]: 42}`)
 	AssertCodesEvalToSameValue(t, `{5, 11}`, `{1, [2, 3], 4, [5, 6]} filter . {[a, b]: a + b}`)
 	AssertCodesEvalToSameValue(t, `{5, 11, 16}`, `{1, [2, 3], 4, [5, 6], [7, 8, 9]} filter . {[a, ..., b]: a + b}`)
 }

--- a/syntax/expr_filter_test.go
+++ b/syntax/expr_filter_test.go
@@ -7,5 +7,6 @@ func TestFilter(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `{42}`, `{1, [2, 3], 4, [5, 6]} filter . {[a, b]: 42}`)
 	AssertCodesEvalToSameValue(t, `{42}`, `{1, [2, 3], 4, [5, 6]} filter . {[_, _]: 42}`)
 	AssertCodesEvalToSameValue(t, `{5, 11}`, `{1, [2, 3], 4, [5, 6]} filter . {[a, b]: a + b}`)
+	AssertCodesEvalToSameValue(t, `{1, 4, 5, 11}`, `{1, [2, 3], 4, [5, 6]} filter . {[a, b]: a + b, k: k}`)
 	AssertCodesEvalToSameValue(t, `{5, 11, 16}`, `{1, [2, 3], 4, [5, 6], [7, 8, 9]} filter . {[a, ..., b]: a + b}`)
 }

--- a/syntax/expr_filter_test.go
+++ b/syntax/expr_filter_test.go
@@ -4,5 +4,7 @@ import "testing"
 
 func TestFilter(t *testing.T) {
 	t.Parallel()
+	AssertCodesEvalToSameValue(t, `{42}`, `{1, [2, 3], 4, [5, 6]} filter . {[a, b]: 42}`)
 	AssertCodesEvalToSameValue(t, `{5, 11}`, `{1, [2, 3], 4, [5, 6]} filter . {[a, b]: a + b}`)
+	AssertCodesEvalToSameValue(t, `{5, 11, 16}`, `{1, [2, 3], 4, [5, 6], [7, 8, 9]} filter . {[a, ..., b]: a + b}`)
 }

--- a/syntax/expr_filter_test.go
+++ b/syntax/expr_filter_test.go
@@ -1,0 +1,8 @@
+package syntax
+
+import "testing"
+
+func TestFilter(t *testing.T) {
+	t.Parallel()
+	AssertCodesEvalToSameValue(t, `{5, 11}`, `{1, [2, 3], 4, [5, 6]} filter . {[a, b]: a + b}`)
+}

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -16,6 +16,7 @@ expr   -> C* amp="&"* @ C* arrow=(
               nest |
               unnest |
               ARROW @ |
+              FILTER cond=(controlVar=@ "{" (condition=pattern ":" value=@):SEQ_COMMENT,? "}") |
               binding="->" C* "\\" C* pattern C* %%bind C* @ |
               binding="->" C* %%bind @
           )* C*
@@ -80,7 +81,8 @@ pattern -> extra
         | C* exprpattern=STR C*;
 extra -> ("..." ident=IDENT?);
 
-ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min} | "filter" expr;
+ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min};
+FILTER -> /{filter};
 IDENT  -> /{ \. | [$@A-Za-z_][0-9$@A-Za-z_]* };
 PKGPATH -> /{ (?: \\ | [^\\}] )* };
 STR    -> /{ " (?: \\. | [^\\"] )* "

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -80,7 +80,7 @@ pattern -> extra
         | C* exprpattern=STR C*;
 extra -> ("..." ident=IDENT?);
 
-ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min};
+ARROW  -> /{:>|=>|>>|orderby|order|rank|where|sum|max|mean|median|min} | "filter" expr;
 IDENT  -> /{ \. | [$@A-Za-z_][0-9$@A-Za-z_]* };
 PKGPATH -> /{ (?: \\ | [^\\}] )* };
 STR    -> /{ " (?: \\. | [^\\"] )* "


### PR DESCRIPTION
Fixes #445 .

Changes proposed in this pull request:
- Add filter operator `{1, [2, 3], 4, [5, 6]} filter . {[a, b]: 42}`

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
