### PR TITLE
nested pattern fallback

### DIFF
--- a/docs/tutorial/binding.md
+++ b/docs/tutorial/binding.md
@@ -289,4 +289,7 @@ that weren't explicitly matched by other patterns.
 @> let (b?: x:42) = (a: 1); x = 42
 @> let [x, y, z?:0] = [1, 2]; [x, y, z] = [1, 2, 0]
 @> let {"b"?: x:42, ...t} = {"a": 1}; [x, t] = [42, {"a": 1}]
+@> let (x?: (y: (k?: w:42))) = (x: (y: (z: 1))); w
+@> let {"a"?: {"b": {"c"?: x:42}}} = {"a": {"b": {"k": 1}}}; x
+@> let [x, [y, z?:0]] = [1, [2]]; [x, y, z]
 ```

--- a/docs/tutorial/binding.md
+++ b/docs/tutorial/binding.md
@@ -291,5 +291,5 @@ that weren't explicitly matched by other patterns.
 @> let {"b"?: x:42, ...t} = {"a": 1}; [x, t] = [42, {"a": 1}]
 @> let (x?: (y: (k?: w:42))) = (x: (y: (z: 1))); w
 @> let {"a"?: {"b": {"c"?: x:42}}} = {"a": {"b": {"k": 1}}}; x
-@> let [x, [y, z?:0]] = [1, [2]]; [x, y, z]
+@> let [x, [y, ?z:0]] = [1, [2]]; [x, y, z]        # syntax [?z:0] is a simplified syntax for [@index? z:0] - consistent with dicts and tuples
 ```

--- a/rel/pattern_array.go
+++ b/rel/pattern_array.go
@@ -5,30 +5,11 @@ import (
 	"fmt"
 )
 
-type PatternFallback struct {
-	pattern  Pattern
-	fallback Expr
-}
-
-func NewPatternFallback(pattern Pattern, fallback Expr) PatternFallback {
-	return PatternFallback{
-		pattern:  pattern,
-		fallback: fallback,
-	}
-}
-
-func (f PatternFallback) String() string {
-	if f.fallback == nil {
-		return f.pattern.String()
-	}
-	return fmt.Sprintf("%s?:%s", f.pattern, f.fallback)
-}
-
 type ArrayPattern struct {
-	items []PatternFallback
+	items []FallbackPattern
 }
 
-func NewArrayPattern(elements ...PatternFallback) ArrayPattern {
+func NewArrayPattern(elements ...FallbackPattern) ArrayPattern {
 	return ArrayPattern{elements}
 }
 

--- a/rel/pattern_fallback.go
+++ b/rel/pattern_fallback.go
@@ -34,9 +34,9 @@ func (p FallbackPattern) Bind(local Scope, value Value) (Scope, error) {
 	return p.pattern.Bind(EmptyScope, value)
 }
 
-func (f FallbackPattern) String() string {
-	if f.fallback == nil {
-		return f.pattern.String()
+func (p FallbackPattern) String() string {
+	if p.fallback == nil {
+		return p.pattern.String()
 	}
-	return fmt.Sprintf("%s:%s", f.pattern, f.fallback)
+	return fmt.Sprintf("%s:%s", p.pattern, p.fallback)
 }

--- a/rel/pattern_fallback.go
+++ b/rel/pattern_fallback.go
@@ -38,5 +38,5 @@ func (f FallbackPattern) String() string {
 	if f.fallback == nil {
 		return f.pattern.String()
 	}
-	return fmt.Sprintf("%s?:%s", f.pattern, f.fallback)
+	return fmt.Sprintf("%s:%s", f.pattern, f.fallback)
 }

--- a/rel/pattern_fallback.go
+++ b/rel/pattern_fallback.go
@@ -7,10 +7,10 @@ import (
 
 type FallbackPattern struct {
 	pattern  Pattern
-	fallback Pattern
+	fallback Expr
 }
 
-func NewFallbackPattern(pattern, fallback Pattern) FallbackPattern {
+func NewFallbackPattern(pattern Pattern, fallback Expr) FallbackPattern {
 	return FallbackPattern{
 		pattern:  pattern,
 		fallback: fallback,
@@ -25,11 +25,13 @@ func (p FallbackPattern) Bind(local Scope, value Value) (Scope, error) {
 	if p.fallback == nil {
 		return EmptyScope, errors.New("no value and no fallback")
 	}
-	scope, err := p.fallback.Bind(local, value)
+
+	var err error
+	value, err = p.fallback.Eval(local)
 	if err != nil {
 		return EmptyScope, err
 	}
-	return p.pattern.Bind(scope, value)
+	return p.pattern.Bind(EmptyScope, value)
 }
 
 func (f FallbackPattern) String() string {

--- a/rel/pattern_fallback.go
+++ b/rel/pattern_fallback.go
@@ -1,0 +1,40 @@
+package rel
+
+import (
+	"errors"
+	"fmt"
+)
+
+type FallbackPattern struct {
+	pattern  Pattern
+	fallback Pattern
+}
+
+func NewFallbackPattern(pattern, fallback Pattern) FallbackPattern {
+	return FallbackPattern{
+		pattern:  pattern,
+		fallback: fallback,
+	}
+}
+
+func (p FallbackPattern) Bind(local Scope, value Value) (Scope, error) {
+	if value != nil {
+		return p.pattern.Bind(EmptyScope, value)
+	}
+
+	if p.fallback == nil {
+		return EmptyScope, errors.New("no value and no fallback")
+	}
+	scope, err := p.fallback.Bind(local, value)
+	if err != nil {
+		return EmptyScope, err
+	}
+	return p.pattern.Bind(scope, value)
+}
+
+func (f FallbackPattern) String() string {
+	if f.fallback == nil {
+		return f.pattern.String()
+	}
+	return fmt.Sprintf("%s?:%s", f.pattern, f.fallback)
+}

--- a/rel/pattern_tuple.go
+++ b/rel/pattern_tuple.go
@@ -21,7 +21,7 @@ func (a TuplePatternAttr) String() string {
 	if a.pattern.fallback == nil {
 		return fmt.Sprintf("%s: %s", a.name, a.pattern)
 	}
-	return fmt.Sprintf("%s?: %s:%s", a.name, a.pattern, a.pattern.fallback)
+	return fmt.Sprintf("%s?: %s", a.name, a.pattern)
 }
 
 func (a *TuplePatternAttr) IsWildcard() bool {

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -86,7 +86,7 @@ SEQ_COMMENT -> "," C*;
     C* odelim="{" C* rel=(names tuple=("(" v=top:SEQ_COMMENT, ")"):SEQ_COMMENT,?) cdelim="}" C*
   | C* odelim="{" C* set=(elt=top:SEQ_COMMENT,?) cdelim="}" C*
   | C* odelim="{" C* dict=(pairs=((extra|key=(expr tail=("?")?) ":" value=(top fall=(":" expr)?))):SEQ_COMMENT,?) cdelim="}" C*
-  | C* odelim="[" C* array=(%!sparse_sequence(top fallback?)?) C* cdelim="]" C*
+  | C* odelim="[" C* array=(%!sparse_sequence(tail=("?")? ":" value=(top fall=(":" expr)?))?) C* cdelim="]" C*
   | C* odelim="<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* cdelim=">>" C*
   | C* odelim="(" tuple=(pairs=(extra | (((name tail="?") | rec="rec"? name | name?) ":" v=(top fall=(":" expr)?))):SEQ_COMMENT,?) cdelim=")" C*
 };

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -272,7 +272,8 @@ func (pc ParseContext) compileDictPattern(b ast.Branch) rel.Pattern {
 			if fall == nil {
 				entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyExpr, rel.NewFallbackPattern(valuePtn, nil)))
 			} else if tail != nil && fall != nil {
-				entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyExpr, rel.NewFallbackPattern(valuePtn, pc.CompileExpr(fall.(ast.Branch)))))
+				entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyExpr,
+					rel.NewFallbackPattern(valuePtn, pc.CompileExpr(fall.(ast.Branch)))))
 			} else {
 				panic("fallback item does not match")
 			}

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -259,7 +259,7 @@ func (pc ParseContext) compileDictPattern(b ast.Branch) rel.Pattern {
 		for _, pair := range pairs {
 			if extra := pair.One("extra"); extra != nil {
 				p := pc.compileExtraElementPattern(extra.(ast.Branch))
-				entryPtns = append(entryPtns, rel.NewDictPatternEntry(nil, p, nil))
+				entryPtns = append(entryPtns, rel.NewDictPatternEntry(nil, rel.NewFallbackPattern(p, nil)))
 				continue
 			}
 			key := pair.One("key")
@@ -269,10 +269,10 @@ func (pc ParseContext) compileDictPattern(b ast.Branch) rel.Pattern {
 
 			tail := key.One("tail")
 			fall := value.One("fall")
-			if tail == nil && fall == nil {
-				entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyExpr, valuePtn, nil))
+			if fall == nil {
+				entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyExpr, rel.NewFallbackPattern(valuePtn, nil)))
 			} else if tail != nil && fall != nil {
-				entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyExpr, valuePtn, pc.CompileExpr(fall.(ast.Branch))))
+				entryPtns = append(entryPtns, rel.NewDictPatternEntry(keyExpr, rel.NewFallbackPattern(valuePtn, pc.CompileExpr(fall.(ast.Branch)))))
 			} else {
 				panic("fallback item does not match")
 			}

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -205,9 +205,9 @@ func (pc ParseContext) compileSparsePatterns(b ast.Branch) []rel.FallbackPattern
 			continue
 		}
 		ptn := pc.compilePattern(expr.(ast.Branch))
-		if fallback := expr.One("fallback"); fallback != nil {
-			fall := pc.CompileExpr(fallback.One("fall").(ast.Branch))
-			result = append(result, rel.NewFallbackPattern(ptn, fall))
+		if fall := expr.One("fall"); fall != nil {
+			fallback := pc.CompileExpr(fall.(ast.Branch))
+			result = append(result, rel.NewFallbackPattern(ptn, fallback))
 			continue
 		}
 		result = append(result, rel.NewFallbackPattern(ptn, nil))

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -228,7 +228,7 @@ func (pc ParseContext) compileTuplePattern(b ast.Branch) rel.Pattern {
 
 			if extra := pair.One("extra"); extra != nil {
 				v = pc.compilePattern(pair.(ast.Branch))
-				attrs = append(attrs, rel.NewTuplePatternAttr(k, v, nil))
+				attrs = append(attrs, rel.NewTuplePatternAttr(k, rel.NewFallbackPattern(v, nil)))
 			} else {
 				v = pc.compilePattern(pair.One("v").(ast.Branch))
 				if name := pair.One("name"); name != nil {
@@ -239,10 +239,10 @@ func (pc ParseContext) compileTuplePattern(b ast.Branch) rel.Pattern {
 
 				tail := pair.One("tail")
 				fall := pair.One("v").One("fall")
-				if tail == nil && fall == nil {
-					attrs = append(attrs, rel.NewTuplePatternAttr(k, v, nil))
+				if fall == nil {
+					attrs = append(attrs, rel.NewTuplePatternAttr(k, rel.NewFallbackPattern(v, nil)))
 				} else if tail != nil && fall != nil {
-					attrs = append(attrs, rel.NewTuplePatternAttr(k, v, pc.CompileExpr(fall.(ast.Branch))))
+					attrs = append(attrs, rel.NewTuplePatternAttr(k, rel.NewFallbackPattern(v, pc.CompileExpr(fall.(ast.Branch)))))
 				} else {
 					panic("fallback item does not match")
 				}

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -188,7 +188,7 @@ func (pc ParseContext) compilePatterns(exprs ...ast.Node) []rel.Pattern {
 	return result
 }
 
-func (pc ParseContext) compileSparsePatterns(b ast.Branch) []rel.PatternFallback {
+func (pc ParseContext) compileSparsePatterns(b ast.Branch) []rel.FallbackPattern {
 	var nodes []ast.Node
 	if firstItem, exists := b["first_item"]; exists {
 		nodes = []ast.Node{firstItem.(ast.One).Node}
@@ -198,19 +198,19 @@ func (pc ParseContext) compileSparsePatterns(b ast.Branch) []rel.PatternFallback
 			}
 		}
 	}
-	result := make([]rel.PatternFallback, 0, len(nodes))
+	result := make([]rel.FallbackPattern, 0, len(nodes))
 	for _, expr := range nodes {
 		if expr.One("empty") != nil {
-			result = append(result, rel.NewPatternFallback(nil, nil))
+			result = append(result, rel.NewFallbackPattern(nil, nil))
 			continue
 		}
 		ptn := pc.compilePattern(expr.(ast.Branch))
 		if fallback := expr.One("fallback"); fallback != nil {
 			fall := pc.CompileExpr(fallback.One("fall").(ast.Branch))
-			result = append(result, rel.NewPatternFallback(ptn, fall))
+			result = append(result, rel.NewFallbackPattern(ptn, fall))
 			continue
 		}
-		result = append(result, rel.NewPatternFallback(ptn, nil))
+		result = append(result, rel.NewFallbackPattern(ptn, nil))
 	}
 	return result
 }

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -200,7 +200,9 @@ func TestExprLetGetPattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `1`, `let {"a"?: x:42} = {"a": 1}; x`)
 	AssertCodesEvalToSameValue(t, `42`, `let {"b"?: x:42} = {"a": 1}; x`)
 	AssertCodesEvalToSameValue(t, `[1, 2]`, `let {'ids'?: ids:[]} = {'ids': [1, 2]}; ids`)
-	AssertCodesEvalToSameValue(t, `[42, {"a": 1}]`, `let {"b"?: x:42, ...t} = {"a": 1}; [x, t]`)
+	// AssertCodesEvalToSameValue(t, `[42, {"a": 1}]`, `let {"b"?: x:42, ...t} = {"a": 1}; [x, t]`)
+	AssertCodesEvalToSameValue(t, `1`, `let {"a"?: {"b": {"c"?: x:42}}} = {"a": {"b": {"c": 1}}}; x`)
+	AssertCodesEvalToSameValue(t, `42`, `let {"a"?: {"b": {"c"?: x:42}}} = {"a": {"b": {"k": 1}}}; x`)
 
 	AssertCodesEvalToSameValue(t, `1`, `let (a?: x:42) = (a: 1); x`)
 	AssertCodesEvalToSameValue(t, `42`, `let (b?: x:42) = (a: 1); x`)

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -203,4 +203,7 @@ func TestExprLetGetPattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `[1, 2, 0]`, `let [x, y, z?:0] = [1, 2]; [x, y, z]`)
 	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [x, y, z?:0] = [1, 2, 3]; [x, y, z]`)
 	AssertCodesEvalToSameValue(t, `[42, {"a": 1}]`, `let {"b"?: x:42, ...t} = {"a": 1}; [x, t]`)
+	AssertCodesEvalToSameValue(t, `1`, `let (x?: (y: (z?: w:42))) = (x: (y: (z: 1))); w`)
+	AssertCodesEvalToSameValue(t, `42`, `let (x?: (y: (k?: w:42))) = (x: (y: (z: 1))); w`)
+	AssertCodeErrors(t, "", `let (x?: (k: (z?: w:42))) = (x: (y: (z: 1))); w`)
 }

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -188,7 +188,9 @@ func TestExprLetExtraElementsInPattern(t *testing.T) {
 
 func TestExprLetNestedPattern(t *testing.T) {
 	t.Parallel()
-	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [[x, y], z] = [[1, 2], 3]; [x, y, z]`)
+	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [[[x], y], z] = [[[1], 2], 3]; [x, y, z]`)
+	AssertCodesEvalToSameValue(t, `1`, `let {"a": {"b": {"c": x}}} = {"a": {"b": {"c": 1}}}; x`)
+	AssertCodesEvalToSameValue(t, `1`, `let (x: (y: (z: w))) = (x: (y: (z: 1))); w`)
 	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [{"a": x}, (b: y), z] = [{"a": 1}, (b: 2), 3]; [x, y, z]`)
 	AssertCodeErrors(t, "", `let [[x]] = []; 42`)
 }
@@ -205,5 +207,11 @@ func TestExprLetGetPattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `[42, {"a": 1}]`, `let {"b"?: x:42, ...t} = {"a": 1}; [x, t]`)
 	AssertCodesEvalToSameValue(t, `1`, `let (x?: (y: (z?: w:42))) = (x: (y: (z: 1))); w`)
 	AssertCodesEvalToSameValue(t, `42`, `let (x?: (y: (k?: w:42))) = (x: (y: (z: 1))); w`)
+
+	AssertCodesEvalToSameValue(t, `[1, 2, 0]`, `let [x, y, z?:0] = [1, 2]; [x, y, z]`)
+	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [x, y, z?:0] = [1, 2, 3]; [x, y, z]`)
+	AssertCodesEvalToSameValue(t, `[1, 2, 0]`, `let [x, [y, z?:0]] = [1, [2]]; [x, y, z]`)
+	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [x, [y, z?:0]] = [1, [2, 3]]; [x, y, z]`)
+
 	AssertCodeErrors(t, "", `let (x?: (k: (z?: w:42))) = (x: (y: (z: 1))); w`)
 }

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -210,10 +210,10 @@ func TestExprLetGetPattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `1`, `let (x?: (y: (z?: w:42))) = (x: (y: (z: 1))); w`)
 	AssertCodesEvalToSameValue(t, `42`, `let (x?: (y: (k?: w:42))) = (x: (y: (z: 1))); w`)
 
-	AssertCodesEvalToSameValue(t, `[1, 2, 0]`, `let [x, y, z?:0] = [1, 2]; [x, y, z]`)
-	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [x, y, z?:0] = [1, 2, 3]; [x, y, z]`)
-	AssertCodesEvalToSameValue(t, `[1, 2, 0]`, `let [x, [y, z?:0]] = [1, [2]]; [x, y, z]`)
-	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [x, [y, z?:0]] = [1, [2, 3]]; [x, y, z]`)
+	AssertCodesEvalToSameValue(t, `[1, 2, 0]`, `let [x, y, ?z:0] = [1, 2]; [x, y, z]`)
+	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [x, y, ?z:0] = [1, 2, 3]; [x, y, z]`)
+	AssertCodesEvalToSameValue(t, `[1, 2, 0]`, `let [x, [y, ?z:0]] = [1, [2]]; [x, y, z]`)
+	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [x, [y, ?z:0]] = [1, [2, 3]]; [x, y, z]`)
 
 	AssertCodeErrors(t, "", `let (x?: (k: (z?: w:42))) = (x: (y: (z: 1))); w`)
 }

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -200,11 +200,11 @@ func TestExprLetGetPattern(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `1`, `let {"a"?: x:42} = {"a": 1}; x`)
 	AssertCodesEvalToSameValue(t, `42`, `let {"b"?: x:42} = {"a": 1}; x`)
 	AssertCodesEvalToSameValue(t, `[1, 2]`, `let {'ids'?: ids:[]} = {'ids': [1, 2]}; ids`)
+	AssertCodesEvalToSameValue(t, `[42, {"a": 1}]`, `let {"b"?: x:42, ...t} = {"a": 1}; [x, t]`)
+
 	AssertCodesEvalToSameValue(t, `1`, `let (a?: x:42) = (a: 1); x`)
 	AssertCodesEvalToSameValue(t, `42`, `let (b?: x:42) = (a: 1); x`)
-	AssertCodesEvalToSameValue(t, `[1, 2, 0]`, `let [x, y, z?:0] = [1, 2]; [x, y, z]`)
-	AssertCodesEvalToSameValue(t, `[1, 2, 3]`, `let [x, y, z?:0] = [1, 2, 3]; [x, y, z]`)
-	AssertCodesEvalToSameValue(t, `[42, {"a": 1}]`, `let {"b"?: x:42, ...t} = {"a": 1}; [x, t]`)
+	AssertCodesEvalToSameValue(t, `[1, 42]`, `let (a: x, b?: y:42) = (a: 1); [x, y]`)
 	AssertCodesEvalToSameValue(t, `1`, `let (x?: (y: (z?: w:42))) = (x: (y: (z: 1))); w`)
 	AssertCodesEvalToSameValue(t, `42`, `let (x?: (y: (k?: w:42))) = (x: (y: (z: 1))); w`)
 

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -100,7 +100,7 @@ SEQ_COMMENT -> "," C*;
     C* odelim="{" C* rel=(names tuple=("(" v=top:SEQ_COMMENT, ")"):SEQ_COMMENT,?) cdelim="}" C*
   | C* odelim="{" C* set=(elt=top:SEQ_COMMENT,?) cdelim="}" C*
   | C* odelim="{" C* dict=(pairs=((extra|key=(expr tail=("?")?) ":" value=(top fall=(":" expr)?))):SEQ_COMMENT,?) cdelim="}" C*
-  | C* odelim="[" C* array=(%!sparse_sequence(top fallback?)?) C* cdelim="]" C*
+  | C* odelim="[" C* array=(%!sparse_sequence(tail=("?")? top fall=(":" expr)?)?) C* cdelim="]" C*
   | C* odelim="<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* cdelim=">>" C*
   | C* odelim="(" tuple=(pairs=(extra | (((name tail="?") | rec="rec"? name | name?) ":" v=(top fall=(":" expr)?))):SEQ_COMMENT,?) cdelim=")" C*
 };


### PR DESCRIPTION
Fixes #469 .

Changes proposed in this pull request:
- support nested fallback in array pattern: `@> let [x, [y, ?z:0]] = [1, [2]]; [x, y, z]`
- support nested fallback in tuple pattern: `@> let (x?: (y: (k?: w:42))) = (x: (y: (z: 1))); w`
- support nested fallback in dict pattern: `@> let {"a"?: {"b": {"c"?: x:42}}} = {"a": {"b": {"k": 1}}}; x`

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
