### PR TITLE
Fix syntax of cond sample

### DIFF
--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -425,7 +425,7 @@ func (pc ParseContext) compileIf(b ast.Branch, c ast.Children) rel.Expr {
 	loggingOnce.Do(func() {
 		log.Error(context.Background(),
 			errors.New("operator if is deprecated and will be removed soon, please use operator cond instead. "+
-				"Operator cond sample: let a = cond ( 2 > 1 : 1, 2 > 3 :2, * : 3)"))
+				"Operator cond sample: let a = cond {2 > 1: 1, 2 > 3: 2, _: 3}"))
 	})
 
 	result := pc.CompileExpr(b.One(exprTag).(ast.Branch))


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix syntax of cond sample

It's still not a very good example, since the first case necessarily always matches

Checklist:
- [ ] Added related tests
- [x] Made corresponding changes to the documentation
