### PR TITLE
fixes comparison of datatypes with offset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,6 @@ require (
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20200612171551-7676ae05be11 // indirect
 	google.golang.org/grpc v1.29.1
+	google.golang.org/protobuf v1.24.0
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/rel/value_set_bytes.go
+++ b/rel/value_set_bytes.go
@@ -88,7 +88,7 @@ func (b Bytes) Hash(seed uintptr) uintptr {
 func (b Bytes) Equal(v interface{}) bool {
 	switch x := v.(type) {
 	case Bytes:
-		if len(b.b) != len(x.b) {
+		if len(b.b) != len(x.b) || b.offset != x.offset {
 			return false
 		}
 		for i, c := range b.b {

--- a/rel/value_set_str.go
+++ b/rel/value_set_str.go
@@ -81,7 +81,7 @@ func (s String) Hash(seed uintptr) uintptr {
 func (s String) Equal(v interface{}) bool {
 	switch x := v.(type) {
 	case String:
-		if len(s.s) != len(x.s) {
+		if len(s.s) != len(x.s) || s.offset != x.offset {
 			return false
 		}
 		for i, c := range s.s {

--- a/syntax/expr_let_test.go
+++ b/syntax/expr_let_test.go
@@ -77,10 +77,10 @@ func TestExprLetArrayPattern(t *testing.T) { //nolint:dupl
 	AssertCodesEvalToSameValue(t, `2`, `let x = 3; let [_, b, (x)] = [1, 2, 3]; b`)
 	AssertCodesEvalToSameValue(t, `2`, `let x = 3; let [x] = [2]; x`)
 	AssertCodesEvalToSameValue(t,
-		`('': [88\'+'], @rule: 'expr', expr: [(expr: [('': 87\'1')]), ('': [90\'*'], expr: [('': 89\'2'), ('': 91\'3')])])`,
+		`('': [75\'+'], @rule: 'expr', expr: [(expr: [('': 74\'1')]), ('': [77\'*'], expr: [('': 76\'2'), ('': 78\'3')])])`,
 		`let [g] = [{://grammar.lang.wbnf: expr -> @:[-+] > @:[/*] > \d+; :}]; {:g:1+2*3:}`)
 	AssertCodesEvalToSameValue(t,
-		`('': [88\'+'], @rule: 'expr', expr: [(expr: [('': 87\'1')]), ('': [90\'*'], expr: [('': 89\'2'), ('': 91\'3')])])`,
+		`('': [94\'+'], @rule: 'expr', expr: [(expr: [('': 93\'1')]), ('': [96\'*'], expr: [('': 95\'2'), ('': 97\'3')])])`,
 		`let (a: g, b: x) = (a: {://grammar.lang.wbnf: expr -> @:[-+] > @:[/*] > \d+; :}, b: 42); {:g:1+2*3:}`)
 
 	AssertCodeErrors(t, "", `let [(x)] = [2]; x`)

--- a/syntax/expr_set_compare_test.go
+++ b/syntax/expr_set_compare_test.go
@@ -53,3 +53,30 @@ func TestSetCompare(t *testing.T) {
 		}
 	}
 }
+
+func TestStringCompare(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `true `, `"abc" = "abc"  `)
+	AssertCodesEvalToSameValue(t, `false`, `"abc" = "ab"   `)
+	AssertCodesEvalToSameValue(t, `false`, `"abc" = 2\"abc"`)
+	AssertCodesEvalToSameValue(t, `false`, `"abc" = {}     `)
+}
+
+func TestBytesCompare(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `true `, `<<"abc">> = <<"abc">>  `)
+	AssertCodesEvalToSameValue(t, `false`, `<<"abc">> = <<"ab">>   `)
+	AssertCodesEvalToSameValue(t, `false`, `<<"abc">> = 2\<<"abc">>`)
+	AssertCodesEvalToSameValue(t, `false`, `<<"abc">> = {}         `)
+}
+
+func TestArrayCompare(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `true `, `[1, 2, 3] = [1, 2, 3]   `)
+	AssertCodesEvalToSameValue(t, `false`, `[1, 2, 3] = [1, 2]      `)
+	AssertCodesEvalToSameValue(t, `false`, `[1, 2, 3] = -1\[1, 2, 3]`)
+	AssertCodesEvalToSameValue(t, `false`, `[1, 2, 3] = {}          `)
+}


### PR DESCRIPTION
fixes comparison of datatypes with offset. Fixes #553 

Initially
```
@> "abc" = 2\"abc"
true
```

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
