### PR TITLE
Implements merge operator `+>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ into the world of arr.ai programming.
 See the [Introduction to Arr.ai](docs/README.md) to learn more about the arr.ai
 language.
 
-See the [Standard Library Reference](docs/std.md) to learn which are batteries
+See the [Standard Library Reference](docs/std.md) to learn what batteries
 are included in arr.ai.
 
 ### Arr.ai Examples

--- a/docs/example.md
+++ b/docs/example.md
@@ -262,3 +262,19 @@ $ arrai eval '{|a,b| (1,2), (1,3)} <&> {|a,c| (1,2), (1,3)}'
 $ arrai eval '{|a,b,c| (1,2,2), (1,2,3)} <&> {|b,c,d| (2,3,4), (1,3,4)}'
 {(a: 1, b: 2, c: 3, d: 4)}
 ```
+
+### Merging operator
+
+Merges two tuples and combines all rhs(right-hand side) attributes and any lhs(left-hand side) attributes whose name isn't on the rhs into a new tuple.
+
+#### Examples
+
+```bash
+arrai e '(a: 1, b: 2) +> (b: 3, c: 4)'
+(a: 1, b: 3, c: 4)
+```
+
+```bash
+arrai e '(a: 1, b: (c: 2)) +> (b: (c: 4), c: 4)'
+(a: 1, b: (c: 4), c: 4)
+```

--- a/docs/example.md
+++ b/docs/example.md
@@ -263,18 +263,23 @@ $ arrai eval '{|a,b,c| (1,2,2), (1,2,3)} <&> {|b,c,d| (2,3,4), (1,3,4)}'
 {(a: 1, b: 2, c: 3, d: 4)}
 ```
 
-### Merging operator
+### Merge
 
-Merges two tuples and combines all rhs(right-hand side) attributes and any lhs(left-hand side) attributes whose name isn't on the rhs into a new tuple.
+Merge combines two tuples, producing a single tuple containing a union of their attributes. If the same name is present in both the LHS (left-hand side) and RHS (right-hand side) tuples, the RHS value takes precedence in the output.
 
 #### Examples
 
 ```bash
-arrai e '(a: 1, b: 2) +> (b: 3, c: 4)'
+$ arrai e '(a: 1, b: 2) +> (b: 3, c: 4)'
 (a: 1, b: 3, c: 4)
 ```
 
 ```bash
-arrai e '(a: 1, b: (c: 2)) +> (b: (c: 4), c: 4)'
+$ arrai e '(a: 1, b: (c: 2)) +> (b: (c: 4), c: 4)'
 (a: 1, b: (c: 4), c: 4)
+```
+
+```bash
+$ arrai e '(a: (b: 1)) +> (a: (c: 2))'
+(a: (c: 2))
 ```

--- a/rel/expr_binary.go
+++ b/rel/expr_binary.go
@@ -298,7 +298,7 @@ func (e *BinExpr) Eval(local Scope) (_ Value, err error) {
 	return val, nil
 }
 
-// evalValForAddArrow evaluates for operator `+>`
+// evalValForAddArrow evaluates operator `+>`
 func evalValForAddArrow(lhs, rhs Value) (Value, error) {
 	if lhs, ok := lhs.(Tuple); ok {
 		if rhs, ok := rhs.(Tuple); ok {

--- a/rel/expr_binary.go
+++ b/rel/expr_binary.go
@@ -80,7 +80,7 @@ func NewAddExpr(scanner parser.Scanner, a, b Expr) Expr {
 		})
 }
 
-// NewAddArrowExpr returns a new ArrowExpr.
+// NewAddArrowExpr returns a new BinExpr which supports operator `+>`
 func NewAddArrowExpr(scanner parser.Scanner, lhs, rhs Expr) Expr {
 	return newBinExpr(scanner, lhs, rhs, "+>", "(%s +> %s)",
 		func(lhs, rhs Value, _ Scope) (Value, error) {

--- a/rel/expr_binary.go
+++ b/rel/expr_binary.go
@@ -307,6 +307,6 @@ func evalValForAddArrow(lhs, rhs Value) (Value, error) {
 	}
 
 	return nil, errors.Errorf(
-		"Both args to %q must be tuples or dicts, not %T and %T",
+		"Both args to %q must be tuples, not %T and %T",
 		"+>", lhs, rhs)
 }

--- a/rel/expr_binary.go
+++ b/rel/expr_binary.go
@@ -80,7 +80,7 @@ func NewAddExpr(scanner parser.Scanner, a, b Expr) Expr {
 		})
 }
 
-// NewAddArrowExpr returns a new BinExpr which supports operator `+>`
+// NewAddArrowExpr returns a new BinExpr which supports operator `+>`.
 func NewAddArrowExpr(scanner parser.Scanner, lhs, rhs Expr) Expr {
 	return newBinExpr(scanner, lhs, rhs, "+>", "(%s +> %s)",
 		func(lhs, rhs Value, _ Scope) (Value, error) {
@@ -298,7 +298,7 @@ func (e *BinExpr) Eval(local Scope) (_ Value, err error) {
 	return val, nil
 }
 
-// evalValForAddArrow evaluates operator `+>`
+// evalValForAddArrow evaluates operator `+>`.
 func evalValForAddArrow(lhs, rhs Value) (Value, error) {
 	if lhs, ok := lhs.(Tuple); ok {
 		if rhs, ok := rhs.(Tuple); ok {

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -11,6 +11,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* @:binop=("without" | "with") C*
         > C* @:binop="||" C*
         > C* @:binop="&&" C*
+        > C* @:binop="+>"
         > C* @:compare=/{!?(?:<:|=|<=?|>=?|\((?:<=?|>=?|<>=?)\))} C*
         > C* @ if=("if" t=expr ("else" f=expr)?)* C*
         > C* @:binop=/{\+\+|[+|]|-%?} C*

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -11,7 +11,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* @:binop=("without" | "with") C*
         > C* @:binop="||" C*
         > C* @:binop="&&" C*
-        > C* @:binop="+>"
+        > C* @:binop="+>" C*
         > C* @:compare=/{!?(?:<:|=|<=?|>=?|\((?:<=?|>=?|<>=?)\))} C*
         > C* @ if=("if" t=expr ("else" f=expr)?)* C*
         > C* @:binop=/{\+\+|[+|]|-%?} C*

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -1018,6 +1018,7 @@ var binops = map[string]binOpFunc{
 	"//":      rel.NewIdivExpr,
 	"^":       rel.NewPowExpr,
 	"\\":      rel.NewOffsetExpr,
+	"+>":      rel.NewAddArrowExpr,
 }
 
 var compareOps = map[string]rel.CompareFunc{

--- a/syntax/expr_binary_test.go
+++ b/syntax/expr_binary_test.go
@@ -16,3 +16,11 @@ func TestRelationCall(t *testing.T) {
 	s := `{"key": "val"}("key")`
 	AssertCodesEvalToSameValue(t, `"val"`, s)
 }
+
+func TestOpsAddArrow(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `(a: 1, b: 2) +> (c: 3, d: 4)`, `(a: 1, b: 2, c: 3, d: 4)`)
+	AssertCodesEvalToSameValue(t, `(a: 1, b: 2) +> (b: 3, c: 4)`, `(a: 1, b: 3, c: 4)`)
+	AssertCodesEvalToSameValue(t, `(a: 1, b: (c: 2)) +> (b: 3, c: 4)`, `(a: 1, b: 3, c: 4)`)
+	AssertCodesEvalToSameValue(t, `(a: 1, b: (c: 2)) +> (b: (c: 4), c: 4)`, `(a: 1, b: (c: 4), c: 4)`)
+	AssertCodesEvalToSameValue(t, `(a: 1, b: (c: 2)) +> (a: (b: 1), b: (c: 4))`, `(a: (b: 1), b: (c: 4))`)
+}

--- a/syntax/expr_binary_test.go
+++ b/syntax/expr_binary_test.go
@@ -18,9 +18,14 @@ func TestRelationCall(t *testing.T) {
 }
 
 func TestOpsAddArrow(t *testing.T) {
+	t.Parallel()
+
 	AssertCodesEvalToSameValue(t, `(a: 1, b: 2) +> (c: 3, d: 4)`, `(a: 1, b: 2, c: 3, d: 4)`)
 	AssertCodesEvalToSameValue(t, `(a: 1, b: 2) +> (b: 3, c: 4)`, `(a: 1, b: 3, c: 4)`)
 	AssertCodesEvalToSameValue(t, `(a: 1, b: (c: 2)) +> (b: 3, c: 4)`, `(a: 1, b: 3, c: 4)`)
 	AssertCodesEvalToSameValue(t, `(a: 1, b: (c: 2)) +> (b: (c: 4), c: 4)`, `(a: 1, b: (c: 4), c: 4)`)
 	AssertCodesEvalToSameValue(t, `(a: 1, b: (c: 2)) +> (a: (b: 1), b: (c: 4))`, `(a: (b: 1), b: (c: 4))`)
+
+	AssertCodeErrors(t, "", `{1, 2, 3} +> {4, 5, 6}`)
+	AssertCodeErrors(t, "", `1 +> 4`)
 }

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -25,7 +25,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* @:binop=("without" | "with") C*
         > C* @:binop="||" C*
         > C* @:binop="&&" C*
-        > C* @:binop="+>"
+        > C* @:binop="+>" C*
         > C* @:compare=/{!?(?:<:|=|<=?|>=?|\((?:<=?|>=?|<>=?)\))} C*
         > C* @ if=("if" t=expr ("else" f=expr)?)* C*
         > C* @:binop=/{\+\+|[+|]|-%?} C*

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -25,6 +25,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         > C* @:binop=("without" | "with") C*
         > C* @:binop="||" C*
         > C* @:binop="&&" C*
+        > C* @:binop="+>"
         > C* @:compare=/{!?(?:<:|=|<=?|>=?|\((?:<=?|>=?|<>=?)\))} C*
         > C* @ if=("if" t=expr ("else" f=expr)?)* C*
         > C* @:binop=/{\+\+|[+|]|-%?} C*


### PR DESCRIPTION
Fixes #133 .

Changes proposed in this pull request:
- Merges two tuples and combines all rhs(right-hand side) attributes and any lhs(left-hand side) attributes whose name isn't on the rhs into a new tuple.
- 

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
