### PR TITLE
Fix protobuf import semantics

### DIFF
--- a/rel/value.go
+++ b/rel/value.go
@@ -174,6 +174,8 @@ func NewValue(v interface{}) (Value, error) {
 	switch x := v.(type) {
 	case Value:
 		return x, nil
+	case bool:
+		return NewBool(x), nil
 	case uint:
 		return NewNumber(float64(x)), nil
 	case uint8:
@@ -198,6 +200,12 @@ func NewValue(v interface{}) (Value, error) {
 		return NewNumber(float64(x)), nil
 	case float64:
 		return NewNumber(x), nil
+	case string:
+		return NewString([]rune(x)), nil
+	case []rune:
+		return NewString(x), nil
+	case []byte:
+		return NewBytes(x), nil
 	case map[string]interface{}:
 		return NewTupleFromMap(x)
 	case []interface{}:

--- a/syntax/pb_test.go
+++ b/syntax/pb_test.go
@@ -36,23 +36,17 @@ func TestTransformProtobufToTupleMapList(t *testing.T) {
 	code := decodePetshop + `shop.apps('PetShopApi').name.part.@`
 	AssertCodesEvalToSameValue(t, `0`, code)
 
-	code = decodePetshop + `shop.apps('PetShopApi').name.part.@item.@item`
+	code = decodePetshop + `shop.apps('PetShopApi').name.part.@item`
 	AssertCodesEvalToSameValue(t, `'PetShopApi'`, code)
 
 	code = decodePetshop + `shop.apps('PetShopApi').attrs('package').s`
 	AssertCodesEvalToSameValue(t, "'io.sysl.demo.petshop.api'", code)
 	// With index
-	code = decodePetshop + `shop.apps('PetShopApi').endpoints('GET /petshop').attrs('patterns').a.elt(0).@item.s`
+	code = decodePetshop + `shop.apps('PetShopApi').endpoints('GET /petshop').attrs('patterns').a.elt(0).s`
 	AssertCodesEvalToSameValue(t, "'rest'", code)
 
-	code = decodePetshop + `shop.apps('PetShopApi').endpoints('GET /petshop').attrs('patterns').a.elt.@item.@item.s`
+	code = decodePetshop + `shop.apps('PetShopApi').endpoints('GET /petshop').attrs('patterns').a.elt.@item.s`
 	AssertCodesEvalToSameValue(t, "'rest'", code)
-
-	code = decodePetshop + `shop.apps('PetShopApi').endpoints('GET /petshop').attrs('patterns').a.elt(0).@`
-	AssertCodesEvalToSameValue(t, "0", code)
-
-	code = decodePetshop + `shop.apps('PetShopApi').endpoints('GET /petshop').attrs('patterns').a.elt.@`
-	AssertCodesEvalToSameValue(t, "0", code)
 }
 
 func TestTransformProtobufToTupleEnum(t *testing.T) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Arrays output as [a, b, c] instead of `[(@:0, @item:a), (@:0, @item:b), (@:0, @item:c)]`
- Errors unpacking elements return errors instead of adding error messages to the output.
- Refactor logic for primitive types.

Checklist:
- [ ] Added related tests
- [ ] Made corresponding changes to the documentation
