### PR TITLE
fixes #527, set and unset use the same rule as IDENT

### DIFF
--- a/internal/shell/shell_cmd.go
+++ b/internal/shell/shell_cmd.go
@@ -47,7 +47,7 @@ func (sc *setCmd) names() []string {
 }
 
 func (sc *setCmd) process(line string, shellData *shellInstance) error {
-	identRe := regexp.MustCompile(`^(?P<ident>[a-zA-Z_]\w*)[ \t]+=`)
+	identRe := regexp.MustCompile(`^(?P<ident>\.|[$@A-Za-z_][0-9$@A-Za-z_]*)[ \t]+=`)
 	identMatches := identRe.FindStringSubmatch(line)
 	if len(identMatches) != 2 {
 		return errors.Errorf(`/set command error, usage: /set <name> = <expr>`)
@@ -69,7 +69,7 @@ func (uc *unsetCmd) names() []string {
 }
 
 func (uc *unsetCmd) process(line string, shellData *shellInstance) error {
-	ident := regexp.MustCompile(`^[a-zA-Z_]\w*`).FindString(line)
+	ident := regexp.MustCompile(`^(\.|[$@A-Za-z_][0-9$@A-Za-z_]*)`).FindString(line)
 	if ident == "" {
 		return errors.Errorf(`/unset command error, usage: /unset <name>`)
 	}

--- a/internal/shell/shell_cmd_test.go
+++ b/internal/shell/shell_cmd_test.go
@@ -23,7 +23,13 @@ func TestTryRunCommand(t *testing.T) {
 
 	sh := newShellInstance(newLineCollector(), []rel.ContextErr{})
 	assert.NoError(t, tryRunCommand(`/set a = 1 + 2`, sh))
+	assert.NoError(t, tryRunCommand(`/set $a = 1 + 2`, sh))
+	assert.NoError(t, tryRunCommand(`/set . = 1 + 2`, sh))
+	assert.NoError(t, tryRunCommand(`/set _a = 1 + 2`, sh))
 	assert.NoError(t, tryRunCommand(`/unset a`, sh))
+	assert.NoError(t, tryRunCommand(`/unset $a`, sh))
+	assert.NoError(t, tryRunCommand(`/unset .`, sh))
+	assert.NoError(t, tryRunCommand(`/unset _a`, sh))
 
 	assert.EqualError(t, tryRunCommand("/hi", sh), "command hi not found")
 	assert.EqualError(t, tryRunCommand("random", sh), "random is not a command")


### PR DESCRIPTION
Fixes #527 .

Changes proposed in this pull request:
- set and unset cmd now use the same variable name rule as IDENT

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
