### PR TITLE
Exit with an error code if app.Run returns an err

### DIFF
--- a/cmd/arrai/main.go
+++ b/cmd/arrai/main.go
@@ -104,6 +104,7 @@ VERSION:
 		} else {
 			logrus.Info("unable to start debug shell: standard input is not a terminal")
 		}
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Without an exit error, commands like `arrai run nonexistent_file.arrai > out.txt` will produce an empty `out.txt` since the `arrai run` command is considered successful.