### PR TITLE
Log errors when asserts fail

### DIFF
--- a/syntax/std_rel_test.go
+++ b/syntax/std_rel_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestRelUnion(t *testing.T) {
 	t.Parallel()
 
-	AssertCodeEvalsToType(t, `{1, 2, 3, 4}`, `//rel.union({{1, 2}, {2, 3}, {3, 4}})`)
-	AssertCodeEvalsToType(t, `{1, 2, 3}   `, `//rel.union({{1}, {2}, {3}})         `)
-	AssertCodeEvalsToType(t, `{1}         `, `//rel.union({{1}, {1}, {1}})         `)
-	AssertCodeEvalsToType(t, `{}          `, `//rel.union({})                      `)
+	AssertCodesEvalToSameValue(t, `{1, 2, 3, 4}`, `//rel.union({{1, 2}, {2, 3}, {3, 4}})`)
+	AssertCodesEvalToSameValue(t, `{1, 2, 3}   `, `//rel.union({{1}, {2}, {3}})         `)
+	AssertCodesEvalToSameValue(t, `{1}         `, `//rel.union({{1}, {1}, {1}})         `)
+	AssertCodesEvalToSameValue(t, `{}          `, `//rel.union({})                      `)
 }

--- a/syntax/test_helpers.go
+++ b/syntax/test_helpers.go
@@ -34,7 +34,7 @@ func AssertCodesEvalToSameValue(t *testing.T, expected, code string) bool {
 	}
 	// log.Printf("code=%v, codeExpr=%v", code, codeExpr)
 	if !rel.AssertExprsEvalToSameValue(t, expectedExpr, value) {
-		t.Logf("\nexpected: %s\ncode:     %s", expected, code)
+		t.Errorf("\nexpected: %s\ncode:     %s", expected, code)
 		return false
 	}
 	return true
@@ -62,7 +62,7 @@ func AssertCodeEvalsToType(t *testing.T, expected interface{}, code string) bool
 	}
 	codeExpr := pc.CompileExpr(ast)
 	if !rel.AssertExprEvalsToType(t, expected, codeExpr) {
-		t.Logf("\nexpected: %T\ncode:     %s", expected, code)
+		t.Errorf("\nexpected: %T\ncode:     %s", expected, code)
 		return false
 	}
 	return true


### PR DESCRIPTION
Currently these assertion failures just log the difference but the test appears to pass.

It turns out `TestRelUnion` is actually failing the assertion in `master` but `make` is passing.