### PR TITLE
Use quote format for GitHub template instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Let us know about an unexpected error, a crash, or an incorrect behavior.
 labels: bug
 ---
 
-Please **do not post any internal, closed source snippets** on this public issue tracker!
+> Please **do not post any internal, closed source snippets** on this public issue tracker!
 
 ### Description
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Let us know about an unexpected error, a crash, or an incorrect behavior.
 labels: bug
 ---
 
-> Please **do not post any internal, closed source snippets** on this public issue tracker!
+Please **do not post any internal, closed source snippets** on this public issue tracker!
 
 ### Description
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest a new feature or other enhancement.
 labels: enhancement
 ---
 
-> Please **do not post any internal, closed source snippets** on this public issue tracker!
+Please **do not post any internal, closed source snippets** on this public issue tracker!
 
 ### Purpose
 
@@ -14,4 +14,3 @@ labels: enhancement
 
 ### Suggested approaches
 What have you tried, and how might this problem be solved?
-

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,4 +13,4 @@ Please **do not post any internal, closed source snippets** on this public issue
 
 
 ### Suggested approaches
-What have you tried, and how might this problem be solved?
+> What have you tried, and how might this problem be solved?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,10 +4,11 @@ about: Suggest a new feature or other enhancement.
 labels: enhancement
 ---
 
-Please **do not post any internal, closed source snippets** on this public issue tracker!
+> Please **do not post any internal, closed source snippets** on this public issue tracker!
 
 ### Purpose
-Please describe the _end goal_ you are trying to achieve that has led you to request this feature.
+
+> Please describe the _end goal_ you are trying to achieve that has led you to request this feature.
 
 
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,7 +4,7 @@ about: Not sure if it's a bug or a feature request? Ask a question!
 labels: question
 ---
 
-Please **do not post any internal, closed source snippets** on this public issue tracker!
+> Please **do not post any internal, closed source snippets** on this public issue tracker!
 
 > What would you like to know?
 >

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,11 +4,10 @@ about: Not sure if it's a bug or a feature request? Ask a question!
 labels: question
 ---
 
-> Please **do not post any internal, closed source snippets** on this public issue tracker!
+Please **do not post any internal, closed source snippets** on this public issue tracker!
 
 > What would you like to know?
 >
 > If it's a question about arr.ai's behaviour, please include your version (the output of `$ arrai info`).
 >
 > You can also [chat to us on Slack](https://anzoss.slack.com/archives/CSDD7K0PP) or [ask on Stack Overflow](https://stackoverflow.com/questions/tagged/arrai).
-


### PR DESCRIPTION
These instructions stand out fine in the editor view, but I'd like them to be greyed out in the rendered view.

Actually, never mind. We need the warning to also stand out for people posting comments.