### PR TITLE
--out modes for run and eval

### DIFF
--- a/cmd/arrai/eval.go
+++ b/cmd/arrai/eval.go
@@ -88,9 +88,7 @@ func outputValue(ctx context.Context, value rel.Value, out string) error {
 	if len(parts) == 1 {
 		parts = []string{"", parts[0]}
 	}
-	opts := strings.SplitN(parts[0], "-", 2)
-	mode := opts[0]
-	opts = opts[1:]
+	mode := parts[0]
 	arg := parts[1]
 
 	fs := ctxfs.RuntimeFsFrom(ctx)

--- a/cmd/arrai/eval.go
+++ b/cmd/arrai/eval.go
@@ -1,32 +1,61 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"strings"
+
+	"github.com/arr-ai/arrai/pkg/ctxfs"
 
 	"github.com/arr-ai/arrai/rel"
 	"github.com/arr-ai/arrai/syntax"
 	"github.com/arr-ai/arrai/tools"
+	"github.com/spf13/afero"
 	"github.com/urfave/cli/v2"
 )
+
+var outFlag = &cli.StringFlag{
+	Name:    "out",
+	Aliases: []string{"o"},
+	Usage:   "Control output behaviour",
+}
 
 var evalCommand = &cli.Command{
 	Name:    "eval",
 	Aliases: []string{"e"},
 	Usage:   "evaluate an arrai expression",
 	Action:  eval,
+	Flags: []cli.Flag{
+		outFlag,
+	},
 }
 
-func evalImpl(source string, w io.Writer) error {
-	return evalExpr(".", source, w)
+func eval(c *cli.Context) error {
+	tools.SetArgs(c)
+	source := c.Args().Get(0)
+
+	ctx := context.Background()
+	ctx = ctxfs.SourceFsOnto(ctx, afero.NewOsFs())
+	ctx = ctxfs.RuntimeFsOnto(ctx, afero.NewOsFs())
+
+	return evalImpl(ctx, source, os.Stdout, c.Value("out").(string))
 }
 
-func evalExpr(path, source string, w io.Writer) error {
+func evalImpl(ctx context.Context, source string, w io.Writer, out string) error {
+	return evalExpr(ctx, ".", source, w, out)
+}
+
+func evalExpr(ctx context.Context, path, source string, w io.Writer, out string) error {
 	value, err := syntax.EvaluateExpr(path, source)
 	if err != nil {
 		return err
+	}
+
+	if out != "" {
+		return outputValue(ctx, value, out)
 	}
 
 	var s string
@@ -54,8 +83,87 @@ func evalExpr(path, source string, w io.Writer) error {
 	return nil
 }
 
-func eval(c *cli.Context) error {
-	tools.SetArgs(c)
-	source := c.Args().Get(0)
-	return evalImpl(source, os.Stdout)
+func outputValue(ctx context.Context, value rel.Value, out string) error {
+	parts := strings.SplitN(out, ":", 2)
+	if len(parts) == 1 {
+		parts = []string{"", parts[0]}
+	}
+	opts := strings.SplitN(parts[0], "-", 2)
+	mode := opts[0]
+	opts = opts[1:]
+	arg := parts[1]
+
+	fs := ctxfs.RuntimeFsFrom(ctx)
+	switch mode {
+	case "file", "f", "":
+		return outputFile(value, arg, fs, false)
+	case "dir", "d":
+		if t, is := value.(rel.Dict); is {
+			if err := outputTupleDir(t, arg, fs, true); err != nil {
+				return err
+			}
+			return outputTupleDir(t, arg, fs, false)
+		}
+	}
+	return fmt.Errorf("invalid --out flag: %s", out)
+}
+
+func outputTupleDir(t rel.Dict, dir string, fs afero.Fs, dryRun bool) error {
+	if _, err := fs.Stat(dir); os.IsNotExist(err) {
+		if err := fs.Mkdir(dir, 0755); err != nil {
+			return err
+		}
+	}
+	for e := t.DictEnumerator(); e.MoveNext(); {
+		k, v := e.Current()
+		name, is := k.(rel.String)
+		if !is {
+			return fmt.Errorf("dir output dict key must be a non-empty string")
+		}
+		subpath := path.Join(dir, name.String())
+		switch content := v.(type) {
+		case rel.Dict:
+			if err := outputTupleDir(content, subpath, fs, dryRun); err != nil {
+				return err
+			}
+		case rel.Bytes, rel.String:
+			if err := outputFile(content, subpath, fs, dryRun); err != nil {
+				return err
+			}
+		case rel.Set:
+			if content.IsTrue() {
+				return fmt.Errorf("dir output entry must be dict, string or byte array")
+			}
+			if err := outputFile(content, subpath, fs, dryRun); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func outputFile(content rel.Value, path string, fs afero.Fs, dryRun bool) error {
+	var bytes []byte
+	switch content := content.(type) {
+	case rel.Bytes:
+		bytes = content.Bytes()
+	case rel.String:
+		bytes = []byte(content.String())
+	default:
+		if _, is := content.(rel.Set); !(is && !content.IsTrue()) {
+			return fmt.Errorf("file output not string or byte array: %v", content)
+		}
+		bytes = []byte{}
+	}
+
+	if dryRun {
+		return nil
+	}
+
+	f, err := fs.Create(path)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(bytes)
+	return err
 }

--- a/cmd/arrai/eval_test.go
+++ b/cmd/arrai/eval_test.go
@@ -1,16 +1,43 @@
 package main
 
 import (
+	"context"
+	"io/ioutil"
 	"strings"
 	"testing"
 
+	"github.com/arr-ai/arrai/pkg/ctxfs"
+
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
 func assertEvalOutputs(t *testing.T, expected, source string) bool { //nolint:unparam
 	var sb strings.Builder
-	return assert.NoError(t, evalImpl(source, &sb)) &&
+	return assert.NoError(t, evalImpl(context.Background(), source, &sb, "")) &&
 		assert.Equal(t, expected, strings.TrimRight(sb.String(), "\n"))
+}
+
+func assertEvalCreates(t *testing.T, expected map[string]string, source, out string) bool { //nolint:unparam
+	var sb strings.Builder
+
+	memFs := afero.NewBasePathFs(afero.NewMemMapFs(), "/")
+	ctx := ctxfs.RuntimeFsOnto(context.Background(), memFs)
+
+	stdoutOK := assert.NoError(t, evalImpl(ctx, source, &sb, out)) &&
+		assert.Equal(t, "", strings.TrimRight(sb.String(), "\n"))
+	outOK := true
+	for path, content := range expected {
+		fs, err := memFs.Open(path)
+		if assert.NoError(t, err) {
+			data, err := ioutil.ReadAll(fs)
+			if assert.NoError(t, err) && assert.Equal(t, content, string(data), "path=%s", path) {
+				continue
+			}
+		}
+		outOK = false
+	}
+	return stdoutOK && outOK
 }
 
 func TestEvalNumberULP(t *testing.T) {
@@ -29,4 +56,32 @@ func TestEvalComplex(t *testing.T) {
 	t.Parallel()
 	assertEvalOutputs(t, `[42, 'abc']`, `[42, "abc"]`)
 	assertEvalOutputs(t, `{42, 'abc'}`, `{"abc", 42}`)
+}
+
+func TestEvalOutFile(t *testing.T) {
+	t.Parallel()
+	assertEvalCreates(t, map[string]string{
+		"/output": "hello",
+	}, `"hello"`, "file:/output")
+	assertEvalCreates(t, map[string]string{
+		"/output": "hello again",
+	}, `"hello again"`, "f:/output")
+	assertEvalCreates(t, map[string]string{
+		"/output": "hello yet again",
+	}, `"hello yet again"`, ":/output")
+	assertEvalCreates(t, map[string]string{
+		"/output": "we must stop meeting like this",
+	}, `"we must stop meeting like this"`, "/output")
+}
+
+func TestEvalOutDir(t *testing.T) {
+	t.Parallel()
+	assertEvalCreates(t, map[string]string{
+		"/files/foo": "hello\n",
+		"/files/bar": "goodbye\n",
+	}, `{"foo": "hello\n", "bar": "goodbye\n"}`, "dir:/files")
+	assertEvalCreates(t, map[string]string{
+		"/files/foo":     "hello\n",
+		"/files/bar/baz": "goodbye\n",
+	}, `{"foo": "hello\n", "bar/baz": "goodbye\n"}`, "d:/files")
 }

--- a/cmd/arrai/run_test.go
+++ b/cmd/arrai/run_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"testing"
 
@@ -11,15 +12,15 @@ import (
 func TestEvalFile(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	require.NoError(t, evalFile("../../examples/jsfuncs/jsfuncs.arrai", &buf))
-	require.NoError(t, evalFile("../../examples/grpc/app.arrai", &buf))
+	require.NoError(t, evalFile(context.Background(), "../../examples/jsfuncs/jsfuncs.arrai", &buf, ""))
+	require.NoError(t, evalFile(context.Background(), "../../examples/grpc/app.arrai", &buf, ""))
 }
 
 func TestEvalNotExistingFile(t *testing.T) {
 	t.Parallel()
 	require.Equal(t, `"version": not a command and not found as a file in the current directory`,
-		evalFile("version", nil).Error())
+		evalFile(context.Background(), "version", nil, "").Error())
 
 	require.Equal(t, `"`+string([]rune{'.', os.PathSeparator})+`version": file not found`,
-		evalFile(string([]rune{'.', os.PathSeparator})+"version", nil).Error())
+		evalFile(context.Background(), string([]rune{'.', os.PathSeparator})+"version", nil, "").Error())
 }

--- a/docs/cmdline/eval.md
+++ b/docs/cmdline/eval.md
@@ -1,0 +1,34 @@
+# arrai eval
+
+Arr.ai's `eval` command evaluates its argument as an arr.ai expression and, by
+default, prints its value to stdout:
+
+```bash
+$ arrai eval '2 + 2'
+4
+```
+
+The `e` command is a shortcut and behaves identically to `eval`.
+
+```bash
+$ arrai e '2 + 2'
+4
+```
+
+## Output controls
+
+The `eval` command supports the `--out` flag (shorthand `-o`), which changes
+arr.ai's output behaviour as follows:
+
+| option | description |
+|-|-|
+| `--out=file:<path>` | Outputs the evaluated result, which must be a string or byte array, to the file specified by `<path>`. `file` may be abbreviated to `f`. |
+| `--out=dir:<path>` | Outputs the evaluated result to the directory specified by `<path>`. The result to be output must be a recursively nested dict of dicts, with strings and/or byte arrays at the leaves. Each dict represents the contents of a directory at the location given by its key while each string or byte array correspondingly represents the contents of a file. `dir` may be abbreviated to `d`.  |
+
+For both `--out=file` and `--out=dir`, strings are UTF-8 encoded when written to the corresponding file.
+
+### Examples
+
+```bash
+arrai e --out=file:example.txt '"hello\n"'
+arrai e -o f:example.txt '"hello\n"'

--- a/docs/cmdline/eval.md
+++ b/docs/cmdline/eval.md
@@ -1,7 +1,9 @@
-# arrai eval
+# arrai eval and run
 
-Arr.ai's `eval` command evaluates its argument as an arr.ai expression and, by
-default, prints its value to stdout:
+Arr.ai's `eval` and `run` commands evaluate argument as an arr.ai expression
+and, by default, print the result to stdout.
+
+The `eval` command evaluates its argument as an arr.ai expression.
 
 ```bash
 $ arrai eval '2 + 2'
@@ -13,6 +15,18 @@ The `e` command is a shortcut and behaves identically to `eval`.
 ```bash
 $ arrai e '2 + 2'
 4
+```
+
+The `run` command evalutes the contents of the source file specified by its
+argument.
+
+```bash
+$ cat hi.arrai
+$"Hello, ${//os.args(1)}!"
+$ arrai run hi.arrai Alice
+Hello, Alice!
+$ arrai r hi.arrai Alice
+Hello, Alice!
 ```
 
 ## Output controls
@@ -30,5 +44,38 @@ For both `--out=file` and `--out=dir`, strings are UTF-8 encoded when written to
 ### Examples
 
 ```bash
-arrai e --out=file:example.txt '"hello\n"'
-arrai e -o f:example.txt '"hello\n"'
+$ arrai e --out=file:example.txt '$"Hello, ${//os.args(1)}!\n"' Bob
+$ cat example.txt
+Hello, Bob!
+$ arrai e -o f:example.txt '"hello\n"'
+$ cat example.txt
+hello
+$ arrai e -o :example.txt '"hello\n"'
+$ cat example.txt
+hello
+$ arrai e -o example.txt '"hello\n"'
+$ cat example.txt
+hello
+```
+
+Note that `--out=file` offers several shortenings. The final example above only
+works if the path itself doesn't have a `:` in it.
+
+```bash
+$ arrai e --out=dir:out 'let [_, name, ...] = //os.args;
+{
+    "foo.txt": $"Hello, ${name}.\n",
+    "bar": {"baz.txt": <<"Goodbye, ", name, "!", 10>>}
+}' Bob
+$ tree out
+out
+├── bar
+│   └── baz.txt
+└── foo.txt
+
+1 directory, 2 files
+$ cat out/foo.txt
+Hello, Bob.
+$ cat out/bar/baz.txt
+Goodbye, Bob!
+```

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rjeczalik/notify v0.9.2
 	github.com/sirupsen/logrus v1.6.0
+	github.com/spf13/afero v1.3.3
 	github.com/stretchr/testify v1.6.1
 	github.com/tealeg/xlsx v1.0.5
 	github.com/urfave/cli/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334/go.mod h1:SK73t
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -77,8 +78,10 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -93,6 +96,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/spf13/afero v1.3.3 h1:p5gZEKLYoL7wh8VrJesMaYeNxdEd1v3cb4irOk9zB54=
+github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -108,6 +113,7 @@ github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -117,6 +123,7 @@ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200602114024-627f9648deb9 h1:pNX+40auqi2JqRfOP1akLGtYcn15TUbkhwuCO3foqqM=
 golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -126,6 +133,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/ctxfs/ctxfs.go
+++ b/pkg/ctxfs/ctxfs.go
@@ -1,0 +1,49 @@
+package ctxfs
+
+import (
+	"context"
+
+	"github.com/spf13/afero"
+)
+
+type ctxkey int
+
+const (
+	sourceFsKey ctxkey = iota
+	runtimeFsKey
+)
+
+var defaultFs afero.Fs
+
+// Sets the default Fs to be returned from SourceFsFrom and RuntimeFsFrom.
+func SetDefaultFs(fs afero.Fs) {
+	defaultFs = fs
+}
+
+// SourceFsOnto returns a new Context with sourceFs added to ctx.
+func SourceFsOnto(ctx context.Context, sourceFs afero.Fs) context.Context {
+	return context.WithValue(ctx, sourceFsKey, sourceFs)
+}
+
+// SourceFsFrom extracts the filesystem used for import resolution from ctx.
+func SourceFsFrom(ctx context.Context) afero.Fs {
+	if v := ctx.Value(sourceFsKey); v != nil {
+		return v.(afero.Fs)
+	}
+	return defaultFs
+}
+
+// RuntimeFsOnto returns a new Context with runtimeFs added to ctx.
+func RuntimeFsOnto(ctx context.Context, runtimeFs afero.Fs) context.Context {
+	return context.WithValue(ctx, runtimeFsKey, runtimeFs)
+}
+
+// RuntimeFsFrom extracts the filesystem used to access the filesystem from ctx.
+// It will be used by //os.file and similar functions.
+// TODO: Actually use it.
+func RuntimeFsFrom(ctx context.Context) afero.Fs {
+	if v := ctx.Value(runtimeFsKey); v != nil {
+		return v.(afero.Fs)
+	}
+	return defaultFs
+}


### PR DESCRIPTION
Partially implements #528.

Changes proposed in this pull request:
- Add `--out=file:<path>` and `--out=dir:<path>` flags to `eval` and `run` commands.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
