### PR TITLE
fix #550, add more concise tuple projection syntax

### DIFF
--- a/rel/expr_tuple_project.go
+++ b/rel/expr_tuple_project.go
@@ -1,0 +1,50 @@
+package rel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arr-ai/wbnf/parser"
+	"github.com/go-errors/errors"
+)
+
+type TupleProjectExpr struct {
+	ExprScanner
+	base    Expr
+	inverse bool
+	attrs   Names
+}
+
+func NewTupleProjectExpr(scanner parser.Scanner, base Expr, inverse bool, attrs []string) Expr {
+	return &TupleProjectExpr{ExprScanner{scanner}, base, inverse, NewNames(attrs...)}
+}
+
+func (tp *TupleProjectExpr) Eval(local Scope) (Value, error) {
+	val, err := tp.base.Eval(local)
+	if err != nil {
+		return nil, WrapContext(err, tp, local)
+	}
+	tuple, isTuple := val.(Tuple)
+	if !isTuple {
+		return nil, WrapContext(errors.Errorf("lhs does not evaluate to tuple: %s", val), tp, local)
+	}
+	if !tp.attrs.IsSubsetOf(tuple.Names()) {
+		return nil, WrapContext(errors.Errorf("names are not subset of lhs: %s", tuple.Names()), tp, local)
+	}
+
+	if tp.inverse {
+		return TupleProjectAllBut(tuple, tp.attrs), nil
+	}
+
+	return tuple.Project(tp.attrs), nil
+}
+
+func (tp *TupleProjectExpr) String() string {
+	str := strings.Builder{}
+	str.WriteString(fmt.Sprintf("(%s).", tp.base))
+	if tp.inverse {
+		str.WriteRune('~')
+	}
+	str.WriteString(tp.attrs.String())
+	return str.String()
+}

--- a/rel/names.go
+++ b/rel/names.go
@@ -1,8 +1,9 @@
 package rel
 
 import (
-	"bytes"
+	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/arr-ai/frozen"
 )
@@ -63,18 +64,7 @@ func (n Names) Equal(i interface{}) bool {
 
 // String returns a string representation of the set of names.
 func (n Names) String() string {
-	var buf bytes.Buffer
-	buf.WriteRune('|')
-	i := 0
-	for e := n.Enumerator(); e.MoveNext(); {
-		if i != 0 {
-			buf.WriteRune(',')
-		}
-		i++
-		buf.WriteString(e.Current())
-	}
-	buf.WriteRune('|')
-	return buf.String()
+	return fmt.Sprintf("|%s|", strings.Join(n.OrderedNames(), ", "))
 }
 
 // With returns a set with all the input names and the given name.

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -42,7 +42,7 @@ rule   -> C* "[" C* name C* "]" C*;
 nest   -> C* "nest" names IDENT C*;
 unnest -> C* "unnest" IDENT C*;
 touch  -> C* ("->*" ("&"? IDENT | STR))+ "(" expr:"," ","? ")" C*;
-get    -> C* dot="." ("&"? IDENT | STR) C*;
+get    -> C* dot="." ("&"? IDENT | STR | "~"? names) C*;
 names  -> C* "|" C* IDENT:"," C* "|" C*;
 name   -> C* IDENT C* | C* STR C*;
 xstr   -> C* quote=/{\$"\s*} part=( sexpr | fragment=/{(?: \\. | \$[^{"] | [^\\"$] )+} )* '"' C*

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -603,6 +603,15 @@ func (pc ParseContext) compileTailFunc(tail ast.Node) rel.SafeTailCallback {
 
 func (pc ParseContext) compileGet(base rel.Expr, get ast.Node) rel.Expr {
 	if get != nil {
+		if names := get.One("names"); names != nil {
+			inverse := get.One("") != nil
+			attrs := parseNames(names.(ast.Branch))
+			return rel.NewTupleProjectExpr(
+				handleAccessScanners(base.Source(), names.Scanner()),
+				base, inverse, attrs,
+			)
+		}
+
 		var scanner parser.Scanner
 		var attr string
 		if ident := get.One("IDENT"); ident != nil {
@@ -613,6 +622,7 @@ func (pc ParseContext) compileGet(base rel.Expr, get ast.Node) rel.Expr {
 			scanner = str.One("").Scanner()
 			attr = parseArraiString(scanner.String())
 		}
+
 		base = rel.NewDotExpr(handleAccessScanners(base.Source(), scanner), base, attr)
 	}
 	return base

--- a/syntax/expr_tuple_project_test.go
+++ b/syntax/expr_tuple_project_test.go
@@ -1,0 +1,27 @@
+package syntax
+
+import "testing"
+
+func TestTupleProjectExpr(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `(a: 1)            `, `(a: 1, b: 2, c: 3).|a|       `)
+	AssertCodesEvalToSameValue(t, `(a: 1, b: 2)      `, `(a: 1, b: 2, c: 3).|a, b|    `)
+	AssertCodesEvalToSameValue(t, `(a: 1, b: 2, c: 3)`, `(a: 1, b: 2, c: 3).|a, b, c| `)
+	AssertCodesEvalToSameValue(t, `(b: 2, c: 3)      `, `(a: 1, b: 2, c: 3).~|a|      `)
+	AssertCodesEvalToSameValue(t, `(c: 3)            `, `(a: 1, b: 2, c: 3).~|a, b|   `)
+	AssertCodesEvalToSameValue(t, `()                `, `(a: 1, b: 2, c: 3).~|a, b, c|`)
+}
+
+func TestTupleProjectExprError(t *testing.T) {
+	t.Parallel()
+
+	AssertCodeErrors(t, `lhs does not evaluate to tuple: {1: 1}`, `{1: 1}.|a|                      `)
+	AssertCodeErrors(t, `lhs does not evaluate to tuple: {1: 1}`, `{1: 1}.~|a|                     `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3).|d|          `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3).|a, b, d|    `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3).|a, b, c, d| `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3).~|d|         `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3).~|a, b, d|   `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3).~|a, b, c, d|`)
+}

--- a/syntax/expr_tuple_project_test.go
+++ b/syntax/expr_tuple_project_test.go
@@ -11,6 +11,13 @@ func TestTupleProjectExpr(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `(b: 2, c: 3)      `, `(a: 1, b: 2, c: 3).~|a|      `)
 	AssertCodesEvalToSameValue(t, `(c: 3)            `, `(a: 1, b: 2, c: 3).~|a, b|   `)
 	AssertCodesEvalToSameValue(t, `()                `, `(a: 1, b: 2, c: 3).~|a, b, c|`)
+
+	AssertCodesEvalToSameValue(t, `(a: 1)            `, `(a: 1, b: 2, c: 3) -> .|a|       `)
+	AssertCodesEvalToSameValue(t, `(a: 1, b: 2)      `, `(a: 1, b: 2, c: 3) -> .|a, b|    `)
+	AssertCodesEvalToSameValue(t, `(a: 1, b: 2, c: 3)`, `(a: 1, b: 2, c: 3) -> .|a, b, c| `)
+	AssertCodesEvalToSameValue(t, `(b: 2, c: 3)      `, `(a: 1, b: 2, c: 3) -> .~|a|      `)
+	AssertCodesEvalToSameValue(t, `(c: 3)            `, `(a: 1, b: 2, c: 3) -> .~|a, b|   `)
+	AssertCodesEvalToSameValue(t, `()                `, `(a: 1, b: 2, c: 3) -> .~|a, b, c|`)
 }
 
 func TestTupleProjectExprError(t *testing.T) {
@@ -24,4 +31,13 @@ func TestTupleProjectExprError(t *testing.T) {
 	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3).~|d|         `)
 	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3).~|a, b, d|   `)
 	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3).~|a, b, c, d|`)
+
+	AssertCodeErrors(t, `lhs does not evaluate to tuple: {1: 1}`, `{1: 1} -> .|a|                      `)
+	AssertCodeErrors(t, `lhs does not evaluate to tuple: {1: 1}`, `{1: 1} -> .~|a|                     `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3) -> .|d|          `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3) -> .|a, b, d|    `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3) -> .|a, b, c, d| `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3) -> .~|d|         `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3) -> .~|a, b, d|   `)
+	AssertCodeErrors(t, `names are not subset of lhs: |a, b, c|`, `(a: 1, b: 2, c: 3) -> .~|a, b, c, d|`)
 }

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -56,7 +56,7 @@ rule   -> C* "[" C* name C* "]" C*;
 nest   -> C* "nest" names IDENT C*;
 unnest -> C* "unnest" IDENT C*;
 touch  -> C* ("->*" ("&"? IDENT | STR))+ "(" expr:"," ","? ")" C*;
-get    -> C* dot="." ("&"? IDENT | STR) C*;
+get    -> C* dot="." ("&"? IDENT | STR | "~"? names) C*;
 names  -> C* "|" C* IDENT:"," C* "|" C*;
 name   -> C* IDENT C* | C* STR C*;
 xstr   -> C* quote=/{\$"\s*} part=( sexpr | fragment=/{(?: \\. | \$[^{"] | [^\\"$] )+} )* '"' C*


### PR DESCRIPTION
Fixes #550.

Changes proposed in this pull request:
1. Allows `t.|a, b, c|` which takes attributes of `a, b, c`
2. Allows `t.~|a, b, c|` which takes all the attributes of `t` except
`a, b, c`
3. Changes `Names.String` to use `OrderedNames` for deterministic output

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
