### PR TITLE
Optimize nest for single attribute

### DIFF
--- a/rel/expr_single_nest.go
+++ b/rel/expr_single_nest.go
@@ -1,0 +1,37 @@
+package rel
+
+import (
+	"fmt"
+
+	"github.com/arr-ai/wbnf/parser"
+	"github.com/go-errors/errors"
+)
+
+// NestExpr returns the relation with names grouped into a nested relation.
+type SingleNestExpr struct {
+	ExprScanner
+	lhs  Expr
+	attr string
+}
+
+// NewNestExpr returns a new NestExpr.
+func NewSingleNestExpr(scanner parser.Scanner, lhs Expr, attr string) Expr {
+	return &SingleNestExpr{ExprScanner{scanner}, lhs, attr}
+}
+
+// String returns a string representation of the expression.
+func (e *SingleNestExpr) String() string {
+	return fmt.Sprintf("(%s nest %s)", e.lhs, e.attr)
+}
+
+// Eval returns e.lhs with e.attrs grouped under e.attr.
+func (e *SingleNestExpr) Eval(local Scope) (Value, error) {
+	value, err := e.lhs.Eval(local)
+	if err != nil {
+		return nil, WrapContext(err, e, local)
+	}
+	if set, ok := value.(Set); ok {
+		return SingleAttrNest(set, e.attr), nil
+	}
+	return nil, WrapContext(errors.Errorf("nest not applicable to %T", value), e, local)
+}

--- a/rel/ops_rel.go
+++ b/rel/ops_rel.go
@@ -23,8 +23,7 @@ func RelationAttrs(a Set) (Names, bool) {
 	return names, true
 }
 
-// Nest groups the given attributes into nested relations.
-func Nest(a Set, attrs Names, attr string) Set {
+func NestWithFunc(a Set, attrs Names, attr string, fn func (Set, Tuple) Set) Set {
 	if !a.IsTrue() {
 		return a
 	}
@@ -44,11 +43,24 @@ func Nest(a Set, attrs Names, attr string) Set {
 		func(key Value, tuples Set) Set {
 			nested := None
 			for e := tuples.Enumerator(); e.MoveNext(); {
-				nested = nested.With(e.Current().(Tuple).Project(attrs))
+				nested = fn(nested, e.Current().(Tuple))
 			}
 			return NewSet(Merge(key.(Tuple), NewTuple(Attr{attr, nested})))
 		},
 	)
+}
+
+// Nest groups the given attributes into nested relations.
+func Nest(a Set, attrs Names, attr string) Set {
+	return NestWithFunc(a, attrs, attr, func(nest Set, t Tuple) Set {
+		return nest.With(t.Project(attrs))
+	})
+}
+
+func SingleAttrNest(a Set, attr string) Set {
+	return NestWithFunc(a, NewNames(attr), attr, func(nest Set, t Tuple) Set {
+		return nest.With(t.MustGet(attr))
+	})
 }
 
 // Unnest unpacks the attributes of a nested relation into the outer relation.

--- a/rel/ops_rel.go
+++ b/rel/ops_rel.go
@@ -23,7 +23,7 @@ func RelationAttrs(a Set) (Names, bool) {
 	return names, true
 }
 
-func NestWithFunc(a Set, attrs Names, attr string, fn func (Set, Tuple) Set) Set {
+func NestWithFunc(a Set, attrs Names, attr string, fn func(Set, Tuple) Set) Set {
 	if !a.IsTrue() {
 		return a
 	}

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -39,7 +39,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         | C* NUM C*
         | C* CHAR C*;
 rule   -> C* "[" C* name C* "]" C*;
-nest   -> C* "nest" names IDENT C*;
+nest   -> C* "nest" names? IDENT C*;
 unnest -> C* "unnest" IDENT C*;
 touch  -> C* ("->*" ("&"? IDENT | STR))+ "(" expr:"," ","? ")" C*;
 get    -> C* dot="." ("&"? IDENT | STR | "~"? names) C*;

--- a/syntax/expr_single_nest_test.go
+++ b/syntax/expr_single_nest_test.go
@@ -1,0 +1,24 @@
+package syntax
+
+import "testing"
+
+func TestSingleAttrNest(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t,
+		`{(x: 1, y: {2, 3}), (x: 2, y: {4})}`,
+		`{|x,y| (1, 2), (1, 3), (2, 4)} nest y`,
+	)
+
+	AssertCodesEvalToSameValue(t,
+		`{(x: 1, y: {2, 3, 4})}`,
+		`{|x,y| (1, 2), (1, 3), (1, 4)} nest y`,
+	)
+
+	AssertCodesEvalToSameValue(t,
+		`{(x: 1, y: {2}), (x: 2, y: {3}), (x: 3, y: {4})}`,
+		`{|x,y| (1, 2), (2, 3), (3, 4)} nest y`,
+	)
+
+	AssertCodesEvalToSameValue(t, `{}`, `{} nest y`)
+}

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -163,7 +163,11 @@ func (pc ParseContext) Parse(s *parser.Scanner) (ast.Branch, error) {
 
 func parseNest(lhs rel.Expr, branch ast.Branch) rel.Expr {
 	attr := branch.One("IDENT").One("").Scanner()
-	names := branch["names"].(ast.One).Node.(ast.Branch)["IDENT"].(ast.Many)
+	namesBranch, exist := branch["names"]
+	if !exist {
+		return rel.NewSingleNestExpr(attr, lhs, attr.String())
+	}
+	names := namesBranch.(ast.One).Node.(ast.Branch)["IDENT"].(ast.Many)
 	namestrings := make([]string, len(names))
 	for i, name := range names {
 		namestrings[i] = name.One("").Scanner().String()

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -53,7 +53,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         | C* NUM C*
         | C* CHAR C*;
 rule   -> C* "[" C* name C* "]" C*;
-nest   -> C* "nest" names IDENT C*;
+nest   -> C* "nest" names? IDENT C*;
 unnest -> C* "unnest" IDENT C*;
 touch  -> C* ("->*" ("&"? IDENT | STR))+ "(" expr:"," ","? ")" C*;
 get    -> C* dot="." ("&"? IDENT | STR | "~"? names) C*;


### PR DESCRIPTION
Change proposed in this pull request:
- Introduce optimized single attribute nest `x nest y`

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
