### PR TITLE
fix #551, implement attribute-set complement in nest

### DIFF
--- a/rel/expr_nest.go
+++ b/rel/expr_nest.go
@@ -10,14 +10,15 @@ import (
 // NestExpr returns the relation with names grouped into a nested relation.
 type NestExpr struct {
 	ExprScanner
-	lhs   Expr
-	attrs Names
-	attr  string
+	inverse bool
+	lhs     Expr
+	attrs   Names
+	attr    string
 }
 
 // NewNestExpr returns a new NestExpr.
-func NewNestExpr(scanner parser.Scanner, lhs Expr, attrs Names, attr string) Expr {
-	return &NestExpr{ExprScanner{scanner}, lhs, attrs, attr}
+func NewNestExpr(scanner parser.Scanner, inverse bool, lhs Expr, attrs Names, attr string) Expr {
+	return &NestExpr{ExprScanner{scanner}, inverse, lhs, attrs, attr}
 }
 
 // String returns a string representation of the expression.

--- a/rel/ops_rel.go
+++ b/rel/ops_rel.go
@@ -29,9 +29,10 @@ func NestWithFunc(a Set, attrs Names, attr string, fn func(Set, Tuple) Set) Set 
 	}
 	names := mustGetRelationAttrs(a)
 
-	if !attrs.IsSubsetOf(names) {
-		panic(fmt.Errorf("nest attrs (%v) not a subset of relation attrs (%v)", attrs, names))
+	if err := validNestOp(names, attrs); err != nil {
+		panic(err)
 	}
+
 	key := names.Minus(attrs)
 	return Reduce(
 		a,
@@ -56,17 +57,18 @@ func mustGetRelationAttrs(a Set) Names {
 	return names
 }
 
+func validNestOp(setAttrs, nestAttrs Names) error {
+	if !nestAttrs.IsSubsetOf(setAttrs) {
+		return fmt.Errorf("nest attrs (%v) not a subset of relation attrs (%v)", nestAttrs, setAttrs)
+	}
+	return nil
+}
+
 // Nest groups the given attributes into nested relations.
 func Nest(a Set, attrs Names, attr string) Set {
 	return NestWithFunc(a, attrs, attr, func(nest Set, t Tuple) Set {
 		return nest.With(t.Project(attrs))
 	})
-}
-
-func InverseNest(a Set, attrs Names, attr string) Set {
-	names := mustGetRelationAttrs(a)
-	attrs = names.Minus(attrs)
-	return Nest(a, attrs, attr)
 }
 
 func SingleAttrNest(a Set, attr string) Set {

--- a/rel/ops_rel.go
+++ b/rel/ops_rel.go
@@ -27,10 +27,8 @@ func NestWithFunc(a Set, attrs Names, attr string, fn func(Set, Tuple) Set) Set 
 	if !a.IsTrue() {
 		return a
 	}
-	names, ok := RelationAttrs(a)
-	if !ok {
-		panic("Tuple names mismatch in nest lhs")
-	}
+	names := mustGetRelationAttrs(a)
+
 	if !attrs.IsSubsetOf(names) {
 		panic(fmt.Errorf("nest attrs (%v) not a subset of relation attrs (%v)", attrs, names))
 	}
@@ -50,11 +48,25 @@ func NestWithFunc(a Set, attrs Names, attr string, fn func(Set, Tuple) Set) Set 
 	)
 }
 
+func mustGetRelationAttrs(a Set) Names {
+	names, ok := RelationAttrs(a)
+	if !ok {
+		panic("Tuple names mismatch in nest lhs")
+	}
+	return names
+}
+
 // Nest groups the given attributes into nested relations.
 func Nest(a Set, attrs Names, attr string) Set {
 	return NestWithFunc(a, attrs, attr, func(nest Set, t Tuple) Set {
 		return nest.With(t.Project(attrs))
 	})
+}
+
+func InverseNest(a Set, attrs Names, attr string) Set {
+	names := mustGetRelationAttrs(a)
+	attrs = names.Minus(attrs)
+	return Nest(a, attrs, attr)
 }
 
 func SingleAttrNest(a Set, attr string) Set {

--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -39,7 +39,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         | C* NUM C*
         | C* CHAR C*;
 rule   -> C* "[" C* name C* "]" C*;
-nest   -> C* "nest" names? IDENT C*;
+nest   -> C* "nest" (inv="~"? names)? IDENT C*;
 unnest -> C* "unnest" IDENT C*;
 touch  -> C* ("->*" ("&"? IDENT | STR))+ "(" expr:"," ","? ")" C*;
 get    -> C* dot="." ("&"? IDENT | STR | "~"? names) C*;

--- a/syntax/expr_nest_test.go
+++ b/syntax/expr_nest_test.go
@@ -1,0 +1,23 @@
+package syntax
+
+import "testing"
+
+func TestInverseNest(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t,
+		`{(a: {(z: 2), (z: 3)}, x: 1, y: 1), (a: {(z: 4)}, x: 1, y: 2), (a: {(z: 5)}, x: 1, y: 3)}`,
+		`{|x, y, z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)} nest ~|z|a`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`{(a: {(x: 1, y: 1)}, z: 2), (a: {(x: 1, y: 1)}, z: 3), (a: {(x: 1, y: 2)}, z: 4), (a: {(x: 1, y: 3)}, z: 5)}`,
+		`{|x, y, z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)} nest ~|x, y|a`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`{(a: {|x, y, z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)})}`,
+		`{|x, y, z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)} nest ~|x, y, z|a`,
+	)
+
+	AssertCodePanics(t, `{|x, y, z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)} nest ~|b|a`)
+	AssertCodePanics(t, `{(x: 1, y: 1), (x: 1, y: 2, z: 3)} nest ~|x|a                    `)
+}

--- a/syntax/expr_nest_test.go
+++ b/syntax/expr_nest_test.go
@@ -6,18 +6,20 @@ func TestInverseNest(t *testing.T) {
 	t.Parallel()
 
 	AssertCodesEvalToSameValue(t,
-		`{(a: {(z: 2), (z: 3)}, x: 1, y: 1), (a: {(z: 4)}, x: 1, y: 2), (a: {(z: 5)}, x: 1, y: 3)}`,
+		`{(a: {(x: 1, y: 1)}, z: 2), (a: {(x: 1, y: 1)}, z: 3), (a: {(x: 1, y: 2)}, z: 4), (a: {(x: 1, y: 3)}, z: 5)}`,
 		`{|x, y, z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)} nest ~|z|a`,
 	)
 	AssertCodesEvalToSameValue(t,
-		`{(a: {(x: 1, y: 1)}, z: 2), (a: {(x: 1, y: 1)}, z: 3), (a: {(x: 1, y: 2)}, z: 4), (a: {(x: 1, y: 3)}, z: 5)}`,
+		`{(a: {(z: 2), (z: 3)}, x: 1, y: 1), (a: {(z: 4)}, x: 1, y: 2), (a: {(z: 5)}, x: 1, y: 3)}`,
 		`{|x, y, z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)} nest ~|x, y|a`,
 	)
-	AssertCodesEvalToSameValue(t,
-		`{(a: {|x, y, z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)})}`,
+	AssertCodeErrors(t,
+		`nest attrs cannot be on all of relation attrs (|x, y, z|)`,
 		`{|x, y, z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)} nest ~|x, y, z|a`,
 	)
-
-	AssertCodePanics(t, `{|x, y, z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)} nest ~|b|a`)
-	AssertCodePanics(t, `{(x: 1, y: 1), (x: 1, y: 2, z: 3)} nest ~|x|a                    `)
+	AssertCodeErrors(t,
+		`nest attrs (|b|) not a subset of relation attrs (|x, y, z|)`,
+		`{|x, y, z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)} nest ~|b|a`,
+	)
+	AssertCodePanics(t, `{(x: 1, y: 1), (x: 1, y: 2, z: 3)} nest ~|x|a`)
 }

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -172,5 +172,6 @@ func parseNest(lhs rel.Expr, branch ast.Branch) rel.Expr {
 	for i, name := range names {
 		namestrings[i] = name.One("").Scanner().String()
 	}
-	return rel.NewNestExpr(attr, lhs, rel.NewNames(namestrings...), attr.String())
+	_, isInverse := branch["inv"]
+	return rel.NewNestExpr(attr, isInverse, lhs, rel.NewNames(namestrings...), attr.String())
 }

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -53,7 +53,7 @@ expr   -> C* amp="&"* @ C* arrow=(
         | C* NUM C*
         | C* CHAR C*;
 rule   -> C* "[" C* name C* "]" C*;
-nest   -> C* "nest" names? IDENT C*;
+nest   -> C* "nest" (inv="~"? names)? IDENT C*;
 unnest -> C* "unnest" IDENT C*;
 touch  -> C* ("->*" ("&"? IDENT | STR))+ "(" expr:"," ","? ")" C*;
 get    -> C* dot="." ("&"? IDENT | STR | "~"? names) C*;


### PR DESCRIPTION
Fixes #551 .

Changes proposed in this pull request:
- allow `{|x, y, z| ...} nest ~|x|a` which is equivalent to `{|x, y, z| ...} nest |y, z|a` 

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
