### PR TITLE
allow shorter form of pattern fallback in tuple

### DIFF
--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -59,11 +59,11 @@ tail   -> get
                     |     ":" end=expr  (":" step=expr)?
                 ):SEQ_COMMENT,
             ")");
-pattern -> extra 
+pattern -> extra
         | %!patternterms(pattern|expr)
         | IDENT
-        | NUM 
-        | C* "(" exprpattern=expr:SEQ_COMMENT,? ")" C* 
+        | NUM
+        | C* "(" exprpattern=expr:SEQ_COMMENT,? ")" C*
         | C* exprpattern=STR C*;
 extra -> ("..." ident=IDENT?);
 fallback -> ("?"? ":" fall=expr);
@@ -89,7 +89,7 @@ SEQ_COMMENT -> "," C*;
   | C* odelim="{" C* dict=(pairs=((extra|key=(expr tail=("?")?) ":" value=(top fall=(":" expr)?))):SEQ_COMMENT,?) cdelim="}" C*
   | C* odelim="[" C* array=(%!sparse_sequence(tail=("?")? top fall=(":" expr)?)?) C* cdelim="]" C*
   | C* odelim="<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* cdelim=">>" C*
-  | C* odelim="(" tuple=(pairs=(extra | (((name tail="?") | rec="rec"? name | name?) ":" v=(top fall=(":" expr)?))):SEQ_COMMENT,?) cdelim=")" C*
+  | C* odelim="(" tuple=(pairs=(extra | (((name? tail="?") | rec="rec"? name | name?) ":" v=(top fall=(":" expr)?))):SEQ_COMMENT,?) cdelim=")" C*
 };
 
 .macro sparse_sequence(top) {

--- a/syntax/expr_tuple_test.go
+++ b/syntax/expr_tuple_test.go
@@ -79,3 +79,13 @@ func TestTupleRec(t *testing.T) {
 		`,
 	)
 }
+
+func TestTuplePattern(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `42`, `let (x?: x:42) = (); x     `)
+	AssertCodesEvalToSameValue(t, `24`, `let (x?: x:42) = (x: 24); x`)
+
+	AssertCodesEvalToSameValue(t, `42`, `let (?: x:42) = (); x      `)
+	AssertCodesEvalToSameValue(t, `24`, `let (?: x:42) = (x: 24); x `)
+}

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -73,11 +73,11 @@ tail   -> get
                     |     ":" end=expr  (":" step=expr)?
                 ):SEQ_COMMENT,
             ")");
-pattern -> extra 
+pattern -> extra
         | %!patternterms(pattern|expr)
         | IDENT
-        | NUM 
-        | C* "(" exprpattern=expr:SEQ_COMMENT,? ")" C* 
+        | NUM
+        | C* "(" exprpattern=expr:SEQ_COMMENT,? ")" C*
         | C* exprpattern=STR C*;
 extra -> ("..." ident=IDENT?);
 fallback -> ("?"? ":" fall=expr);
@@ -103,7 +103,7 @@ SEQ_COMMENT -> "," C*;
   | C* odelim="{" C* dict=(pairs=((extra|key=(expr tail=("?")?) ":" value=(top fall=(":" expr)?))):SEQ_COMMENT,?) cdelim="}" C*
   | C* odelim="[" C* array=(%!sparse_sequence(tail=("?")? top fall=(":" expr)?)?) C* cdelim="]" C*
   | C* odelim="<<" C* bytes=(item=(STR|NUM|CHAR|IDENT|"("top")"):SEQ_COMMENT,?) C* cdelim=">>" C*
-  | C* odelim="(" tuple=(pairs=(extra | (((name tail="?") | rec="rec"? name | name?) ":" v=(top fall=(":" expr)?))):SEQ_COMMENT,?) cdelim=")" C*
+  | C* odelim="(" tuple=(pairs=(extra | (((name? tail="?") | rec="rec"? name | name?) ":" v=(top fall=(":" expr)?))):SEQ_COMMENT,?) cdelim=")" C*
 };
 
 .macro sparse_sequence(top) {


### PR DESCRIPTION
This PR allows

```
let (?: x:42) = (); x
```

which is a shorter form of

```
let (x?: x:42) = (); x
```

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
