### PR TITLE
Fix syntax of cond exprs

### DIFF
--- a/syntax/arrai.wbnf
+++ b/syntax/arrai.wbnf
@@ -2,7 +2,7 @@ expr   -> C* amp="&"* @ C* arrow=(
               nest |
               unnest |
               ARROW @ |
-              FILTER cond=(controlVar=@ "{" (condition=pattern ":" value=@):SEQ_COMMENT,? "}") |
+              FILTER cond=(controlVar=@ "{" (condition=pattern ":" value=expr):SEQ_COMMENT,? "}") |
               binding="->" C* "\\" C* pattern C* %%bind C* @ |
               binding="->" C* %%bind @
           )* C*

--- a/syntax/expr_filter_test.go
+++ b/syntax/expr_filter_test.go
@@ -9,4 +9,8 @@ func TestFilter(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `{5, 11}`, `{1, [2, 3], 4, [5, 6]} filter . {[a, b]: a + b}`)
 	AssertCodesEvalToSameValue(t, `{1, 4, 5, 11}`, `{1, [2, 3], 4, [5, 6]} filter . {[a, b]: a + b, k: k}`)
 	AssertCodesEvalToSameValue(t, `{5, 11, 16}`, `{1, [2, 3], 4, [5, 6], [7, 8, 9]} filter . {[a, ..., b]: a + b}`)
+
+	AssertCodesEvalToSameValue(t,
+		`{1, 2, 3, 4}`,
+		`//rel.union({[1, 2], {3, 4}} filter . {[...a]: a => .@item, {...a}: a})`)
 }

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -16,7 +16,7 @@ expr   -> C* amp="&"* @ C* arrow=(
               nest |
               unnest |
               ARROW @ |
-              FILTER cond=(controlVar=@ "{" (condition=pattern ":" value=@):SEQ_COMMENT,? "}") |
+              FILTER cond=(controlVar=@ "{" (condition=pattern ":" value=expr):SEQ_COMMENT,? "}") |
               binding="->" C* "\\" C* pattern C* %%bind C* @ |
               binding="->" C* %%bind @
           )* C*


### PR DESCRIPTION
Previously, arrow operators couldn't appear as result exprs

Fixes # .

Changes proposed in this pull request:
- 
- 

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
