### PR TITLE
Add //os.isatty(fd) to allow scripts to handle //os.stdin more intelligently

### DIFF
--- a/docs/std-os.md
+++ b/docs/std-os.md
@@ -39,6 +39,17 @@ Usage:
 |:-|:-|
 | `//os.get_env("KEY")` | `"string_value"` |
 
+## `//os.isatty(fileDescriptor <: int) <: bool`
+
+`isatty` returns `true` if the `fileDescriptor` (0 for `stdin`, 1 for `stdout`) is a terminal, or `false` otherwise (e.g. if input is piped in).
+
+Usage:
+
+| example | equals |
+|:-|:-|
+| `arrai eval "//os.isatty(0)"` | `true` |
+| `echo "" | arrai eval "//os.isatty(0)"` | `false` |
+
 ## `//os.path_separator <: string`
 
 `path_separator` contains the path separator of the current operating system.

--- a/rel/value_set_array.go
+++ b/rel/value_set_array.go
@@ -22,7 +22,7 @@ func NewArray(values ...Value) Set {
 	return NewOffsetArray(0, values...)
 }
 
-// NewArray constructs an array as a relation.
+// NewOffsetArray constructs an offset array as a relation.
 func NewOffsetArray(offset int, values ...Value) Set {
 	// Trim holes from both ends.
 	for i, v := range values {

--- a/rel/value_set_bytes.go
+++ b/rel/value_set_bytes.go
@@ -15,7 +15,7 @@ type Bytes struct {
 	offset int
 }
 
-// NewBytes constructs an array as a relation.
+// NewBytes constructs a byte array as a relation.
 func NewBytes(b []byte) Set {
 	if len(b) == 0 {
 		return None
@@ -23,7 +23,7 @@ func NewBytes(b []byte) Set {
 	return Bytes{b: b}
 }
 
-// NewBytes constructs an array as a relation.
+// NewOffsetBytes constructs an offset byte array as a relation.
 func NewOffsetBytes(b []byte, offset int) Set {
 	if len(b) == 0 {
 		return None

--- a/rel/value_set_str.go
+++ b/rel/value_set_str.go
@@ -16,12 +16,12 @@ type String struct {
 	holes  int
 }
 
-// NewString constructs an array as a relation.
+// NewString constructs a string as a relation.
 func NewString(s []rune) Set {
 	return NewOffsetString(s, 0)
 }
 
-// NewString constructs an array as a relation.
+// NewOffsetString constructs an offset string as a relation.
 func NewOffsetString(s []rune, offset int) Set {
 	if len(s) == 0 {
 		return None

--- a/syntax/std_os.go
+++ b/syntax/std_os.go
@@ -19,6 +19,7 @@ func stdOs() rel.Attr {
 		rel.NewNativeFunctionAttr("file", stdOsFile),
 		rel.NewNativeFunctionAttr("get_env", stdOsGetEnv),
 		rel.NewNativeFunctionAttr("&stdin", stdOsStdinVar.read),
+		rel.NewNativeFunctionAttr("isatty", stdOsIsATty),
 	)
 }
 

--- a/syntax/std_os.go
+++ b/syntax/std_os.go
@@ -23,13 +23,14 @@ func stdOs() rel.Attr {
 }
 
 type stdOsStdin struct {
-	reader io.Reader
-	mutex  sync.Mutex
-	bytes  rel.Value
+	reader   io.Reader
+	mutex    sync.Mutex
+	bytes    rel.Value
+	hasInput bool
 }
 
-func newStdOsStdin(r io.Reader) *stdOsStdin {
-	return &stdOsStdin{reader: r}
+func newStdOsStdin(r io.Reader, hasInput bool) *stdOsStdin {
+	return &stdOsStdin{reader: r, hasInput: hasInput}
 }
 
 func (d *stdOsStdin) reset(r io.Reader) {
@@ -45,10 +46,16 @@ func (d *stdOsStdin) read(_ rel.Value) (rel.Value, error) {
 	if d.bytes != nil {
 		return d.bytes, nil
 	}
-	f, err := ioutil.ReadAll(stdOsStdinVar.reader)
-	if err != nil {
-		return nil, err
+
+	if d.hasInput {
+		f, err := ioutil.ReadAll(stdOsStdinVar.reader)
+		if err != nil {
+			return nil, err
+		}
+		d.bytes = rel.NewBytes(f)
+	} else {
+		d.bytes = rel.NewBytes([]byte{})
 	}
-	d.bytes = rel.NewBytes(f)
+
 	return d.bytes, nil
 }

--- a/syntax/std_os.go
+++ b/syntax/std_os.go
@@ -24,14 +24,13 @@ func stdOs() rel.Attr {
 }
 
 type stdOsStdin struct {
-	reader   io.Reader
-	mutex    sync.Mutex
-	bytes    rel.Value
-	hasInput bool
+	reader io.Reader
+	mutex  sync.Mutex
+	bytes  rel.Value
 }
 
-func newStdOsStdin(r io.Reader, hasInput bool) *stdOsStdin {
-	return &stdOsStdin{reader: r, hasInput: hasInput}
+func newStdOsStdin(r io.Reader) *stdOsStdin {
+	return &stdOsStdin{reader: r}
 }
 
 func (d *stdOsStdin) reset(r io.Reader) {
@@ -47,16 +46,10 @@ func (d *stdOsStdin) read(_ rel.Value) (rel.Value, error) {
 	if d.bytes != nil {
 		return d.bytes, nil
 	}
-
-	if d.hasInput {
-		f, err := ioutil.ReadAll(stdOsStdinVar.reader)
-		if err != nil {
-			return nil, err
-		}
-		d.bytes = rel.NewBytes(f)
-	} else {
-		d.bytes = rel.NewBytes([]byte{})
+	f, err := ioutil.ReadAll(stdOsStdinVar.reader)
+	if err != nil {
+		return nil, err
 	}
-
+	d.bytes = rel.NewBytes(f)
 	return d.bytes, nil
 }

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -4,9 +4,10 @@ package syntax
 
 import (
 	"fmt"
-	"github.com/mattn/go-isatty"
 	"io/ioutil"
 	"os"
+
+	"github.com/mattn/go-isatty"
 
 	"github.com/arr-ai/arrai/tools"
 

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -21,25 +21,6 @@ func stdOsGetEnv(value rel.Value) (rel.Value, error) {
 	return rel.NewString([]rune(os.Getenv(value.(rel.String).String()))), nil
 }
 
-func stdOsIsATty(value rel.Value) (rel.Value, error) {
-	n, ok := value.(rel.Number)
-	if !ok {
-		return nil, fmt.Errorf("isatty arg must be a number, not %T", value)
-	}
-	fd, ok := n.Int()
-	if !ok {
-		return nil, fmt.Errorf("isatty arg must be an integer, not %s", value)
-	}
-
-	switch fd {
-	case 0:
-		return rel.NewBool(isatty.IsTerminal(os.Stdin.Fd())), nil
-	case 1:
-		return rel.NewBool(isatty.IsTerminal(os.Stdout.Fd())), nil
-	}
-	return nil, fmt.Errorf("isatty not implemented for %v", fd)
-}
-
 func stdOsPathSeparator() rel.Value {
 	return rel.NewString([]rune{os.PathSeparator})
 }
@@ -64,13 +45,23 @@ func stdOsFile(v rel.Value) (rel.Value, error) {
 	return rel.NewBytes(f), nil
 }
 
-// stdinHasInput returns true if there is data to read on stdin.
-func stdinHasInput() bool {
-	stat, err := os.Stdin.Stat()
-	if err != nil {
-		return false
+func stdOsIsATty(value rel.Value) (rel.Value, error) {
+	n, ok := value.(rel.Number)
+	if !ok {
+		return nil, fmt.Errorf("isatty arg must be a number, not %T", value)
 	}
-	return (stat.Mode() & os.ModeCharDevice) == 0
+	fd, ok := n.Int()
+	if !ok {
+		return nil, fmt.Errorf("isatty arg must be an integer, not %s", value)
+	}
+
+	switch fd {
+	case 0:
+		return rel.NewBool(isatty.IsTerminal(os.Stdin.Fd())), nil
+	case 1:
+		return rel.NewBool(isatty.IsTerminal(os.Stdout.Fd())), nil
+	}
+	return nil, fmt.Errorf("isatty not implemented for %v", fd)
 }
 
-var stdOsStdinVar = newStdOsStdin(os.Stdin, stdinHasInput())
+var stdOsStdinVar = newStdOsStdin(os.Stdin)

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -45,7 +45,10 @@ func stdOsFile(v rel.Value) (rel.Value, error) {
 
 // stdinHasInput returns true if there is data to read on stdin.
 func stdinHasInput() bool {
-	stat, _ := os.Stdin.Stat()
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
 	return (stat.Mode() & os.ModeCharDevice) == 0
 }
 

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -43,4 +43,10 @@ func stdOsFile(v rel.Value) (rel.Value, error) {
 	return rel.NewBytes(f), nil
 }
 
-var stdOsStdinVar = newStdOsStdin(os.Stdin)
+// stdinHasInput returns true if there is data to read on stdin.
+func stdinHasInput() bool {
+	stat, _ := os.Stdin.Stat()
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}
+
+var stdOsStdinVar = newStdOsStdin(os.Stdin, stdinHasInput())

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -3,6 +3,8 @@
 package syntax
 
 import (
+	"fmt"
+	"github.com/mattn/go-isatty"
 	"io/ioutil"
 	"os"
 
@@ -17,6 +19,25 @@ func stdOsGetArgs() rel.Value {
 
 func stdOsGetEnv(value rel.Value) (rel.Value, error) {
 	return rel.NewString([]rune(os.Getenv(value.(rel.String).String()))), nil
+}
+
+func stdOsIsATty(value rel.Value) (rel.Value, error) {
+	n, ok := value.(rel.Number)
+	if !ok {
+		return nil, fmt.Errorf("isatty arg must be a number, not %T", value)
+	}
+	fd, ok := n.Int()
+	if !ok {
+		return nil, fmt.Errorf("isatty arg must be an integer, not %s", value)
+	}
+
+	switch fd {
+	case 0:
+		return rel.NewBool(isatty.IsTerminal(os.Stdin.Fd())), nil
+	case 1:
+		return rel.NewBool(isatty.IsTerminal(os.Stdout.Fd())), nil
+	}
+	return nil, fmt.Errorf("isatty not implemented for %v", fd)
 }
 
 func stdOsPathSeparator() rel.Value {

--- a/syntax/std_os_test.go
+++ b/syntax/std_os_test.go
@@ -7,7 +7,6 @@ import (
 
 func TestStdOsStdin(t *testing.T) {
 	// Not parallelisable
-	stdOsStdinVar.hasInput = true
 	stdin := stdOsStdinVar.reader
 	defer func() { stdOsStdinVar.reset(stdin) }()
 
@@ -19,22 +18,6 @@ func TestStdOsStdin(t *testing.T) {
 	stdOsStdinVar.reset(bytes.NewBuffer([]byte("abc")))
 	AssertCodesEvalToSameValue(t, `<<97, 98, 99>>`, `//os.stdin`)
 	AssertCodesEvalToSameValue(t, `<<97, 98, 99>>`, `//os.stdin`)
-}
-
-func TestStdOsStdin_noInput(t *testing.T) {
-	// Not parallelisable
-	stdOsStdinVar.hasInput = false
-	stdin := stdOsStdinVar.reader
-	defer func() { stdOsStdinVar.reset(stdin) }()
-
-	// Access twice to ensure caching behaves properly.
-	stdOsStdinVar.reset(bytes.NewBuffer([]byte("")))
-	AssertCodesEvalToSameValue(t, `{}`, `//os.stdin`)
-	AssertCodesEvalToSameValue(t, `{}`, `//os.stdin`)
-
-	stdOsStdinVar.reset(bytes.NewBuffer([]byte("abc")))
-	AssertCodesEvalToSameValue(t, `{}`, `//os.stdin`)
-	AssertCodesEvalToSameValue(t, `{}`, `//os.stdin`)
 }
 
 func TestStdOsIsATty(t *testing.T) {

--- a/syntax/std_os_test.go
+++ b/syntax/std_os_test.go
@@ -2,11 +2,13 @@ package syntax
 
 import (
 	"bytes"
+	"os"
 	"testing"
 )
 
 func TestStdOsStdin(t *testing.T) {
 	// Not parallelisable
+	stdOsStdinVar = newStdOsStdin(os.Stdin, true)
 	stdin := stdOsStdinVar.reader
 	defer func() { stdOsStdinVar.reset(stdin) }()
 
@@ -18,4 +20,20 @@ func TestStdOsStdin(t *testing.T) {
 	stdOsStdinVar.reset(bytes.NewBuffer([]byte("abc")))
 	AssertCodesEvalToSameValue(t, `<<97, 98, 99>>`, `//os.stdin`)
 	AssertCodesEvalToSameValue(t, `<<97, 98, 99>>`, `//os.stdin`)
+}
+
+func TestStdOsStdin_noInput(t *testing.T) {
+	// Not parallelisable
+	stdOsStdinVar = newStdOsStdin(os.Stdin, false)
+	stdin := stdOsStdinVar.reader
+	defer func() { stdOsStdinVar.reset(stdin) }()
+
+	// Access twice to ensure caching behaves properly.
+	stdOsStdinVar.reset(bytes.NewBuffer([]byte("")))
+	AssertCodesEvalToSameValue(t, `{}`, `//os.stdin`)
+	AssertCodesEvalToSameValue(t, `{}`, `//os.stdin`)
+
+	stdOsStdinVar.reset(bytes.NewBuffer([]byte("abc")))
+	AssertCodesEvalToSameValue(t, `{}`, `//os.stdin`)
+	AssertCodesEvalToSameValue(t, `{}`, `//os.stdin`)
 }

--- a/syntax/std_os_test.go
+++ b/syntax/std_os_test.go
@@ -36,3 +36,15 @@ func TestStdOsStdin_noInput(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `{}`, `//os.stdin`)
 	AssertCodesEvalToSameValue(t, `{}`, `//os.stdin`)
 }
+
+func TestStdOsIsATty(t *testing.T) {
+	t.Parallel()
+
+	AssertCodesEvalToSameValue(t, `false`, `//os.isatty(0)`)
+	AssertCodesEvalToSameValue(t, `false`, `//os.isatty(1)`)
+
+	AssertCodeErrors(t, "isatty arg must be a number, not rel.String", `//os.isatty("0")`)
+	AssertCodeErrors(t, "isatty arg must be an integer, not 0.1", `//os.isatty(0.1)`)
+	AssertCodeErrors(t, "isatty not implemented for 2", `//os.isatty(2)`)
+	AssertCodeErrors(t, "isatty not implemented for -1", `//os.isatty(-1)`)
+}

--- a/syntax/std_os_test.go
+++ b/syntax/std_os_test.go
@@ -2,13 +2,12 @@ package syntax
 
 import (
 	"bytes"
-	"os"
 	"testing"
 )
 
 func TestStdOsStdin(t *testing.T) {
 	// Not parallelisable
-	stdOsStdinVar = newStdOsStdin(os.Stdin, true)
+	stdOsStdinVar.hasInput = true
 	stdin := stdOsStdinVar.reader
 	defer func() { stdOsStdinVar.reset(stdin) }()
 
@@ -24,7 +23,7 @@ func TestStdOsStdin(t *testing.T) {
 
 func TestStdOsStdin_noInput(t *testing.T) {
 	// Not parallelisable
-	stdOsStdinVar = newStdOsStdin(os.Stdin, false)
+	stdOsStdinVar.hasInput = false
 	stdin := stdOsStdinVar.reader
 	defer func() { stdOsStdinVar.reset(stdin) }()
 

--- a/syntax/std_os_wasm.go
+++ b/syntax/std_os_wasm.go
@@ -14,6 +14,10 @@ func stdOsGetEnv(value rel.Value) (rel.Value, error) {
 	panic("not implemented")
 }
 
+func stdOsIsATty(value rel.Value) (rel.Value, error) {
+	panic("not implemented")
+}
+
 func stdOsPathSeparator() rel.Value {
 	panic("not implemented")
 }

--- a/syntax/std_os_wasm.go
+++ b/syntax/std_os_wasm.go
@@ -34,4 +34,4 @@ func stdOsFile(rel.Value) (rel.Value, error) {
 	panic("not implemented")
 }
 
-var stdOsStdinVar = newStdOsStdin(nil, false)
+var stdOsStdinVar = newStdOsStdin(nil)

--- a/syntax/std_os_wasm.go
+++ b/syntax/std_os_wasm.go
@@ -30,4 +30,4 @@ func stdOsFile(rel.Value) (rel.Value, error) {
 	panic("not implemented")
 }
 
-var stdOsStdinVar = newStdOsStdin(nil)
+var stdOsStdinVar = newStdOsStdin(nil, false)


### PR DESCRIPTION
`//os.stdin` hangs if `stdin` is a terminal, which is not always desirable. This allows scripts to behave differently depending on how the script is being run.