### PR TITLE
Return the right error when accessing nonexistent empty tuple key

### DIFF
--- a/rel/expr_dot.go
+++ b/rel/expr_dot.go
@@ -57,7 +57,7 @@ func (x *DotExpr) Eval(local Scope) (_ Value, err error) {
 		if value, found := t.Get(x.attr); found {
 			return value, nil
 		}
-		if x.attr[:1] != "&" {
+		if len(x.attr) > 0 && x.attr[:1] != "&" {
 			if value, found := t.Get("&" + x.attr); found {
 				//TODO: add tupleScope self to allow accessing itself
 				switch f := value.(type) {

--- a/rel/expr_dot_test.go
+++ b/rel/expr_dot_test.go
@@ -18,6 +18,15 @@ func TestDotExprAccessors(t *testing.T) {
 	assert.Equal(t, expr.Attr(), attr)
 }
 
+func TestDotExprErrorOnMissingEmptyAttr(t *testing.T) {
+	t.Parallel()
+
+	lhs := NewTuple(NewAttr("a", NewNumber(1)))
+	expr := NewDotExpr(*parser.NewScanner(""), lhs, "").(*DotExpr)
+
+	AssertExprErrorEquals(t, expr, `Missing attr "" (available: |a|)`)
+}
+
 func TestDotExprErrorOnInvalidStarAttr(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #572.

Changes proposed in this pull request:
- Add a length check for the attribute before slicing it.

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
