### PR TITLE
Use repr for pretty printed strings to include offsets

### DIFF
--- a/syntax/prettify.go
+++ b/syntax/prettify.go
@@ -121,7 +121,7 @@ func prettifyDict(dict rel.Dict, indentsNum int) (string, error) {
 }
 
 func prettifyString(str rel.String) (string, error) {
-	return fmt.Sprintf("'%s'", str), nil
+	return fmt.Sprintf("%s", rel.Repr(str)), nil
 }
 
 type Enumerable interface {

--- a/syntax/prettify.go
+++ b/syntax/prettify.go
@@ -121,7 +121,7 @@ func prettifyDict(dict rel.Dict, indentsNum int) (string, error) {
 }
 
 func prettifyString(str rel.String) (string, error) {
-	return fmt.Sprintf("%s", rel.Repr(str)), nil
+	return rel.Repr(str), nil
 }
 
 type Enumerable interface {

--- a/syntax/std_fmt_test.go
+++ b/syntax/std_fmt_test.go
@@ -85,6 +85,13 @@ func TestFmtPrettySet(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `"{1, 2, {3, 4, 5}}"`, `//fmt.pretty({1,2,{3,4,5}})`)
 }
 
+func TestFmtPrettyString(t *testing.T) {
+	t.Parallel()
+	AssertCodesEvalToSameValue(t, `"{}"`, `//fmt.pretty('')`)
+	AssertCodesEvalToSameValue(t, `"'abc'"`, `//fmt.pretty('abc')`)
+	AssertCodesEvalToSameValue(t, `"42\\'abc'"`, `//fmt.pretty(42\'abc')`)
+}
+
 func TestIsSimple(t *testing.T) {
 	assert.True(t, isSimple(rel.NewString([]rune("a"))))
 	assert.True(t, isSimple(rel.NewNumber(12345)))


### PR DESCRIPTION
Fixes #575 .

Changes proposed in this pull request:
- Use repr instead of just the string value.

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
