### PR TITLE
Handle empty keys in //tuple

### DIFF
--- a/syntax/std.go
+++ b/syntax/std.go
@@ -52,12 +52,15 @@ func StdScope() rel.Scope {
 						attrs := make([]rel.Attr, 0, t.Count())
 						for e := t.DictEnumerator(); e.MoveNext(); {
 							keyVal, value := e.Current()
-							key := ""
+							var key string
 							// keyVal won't be a rel.String if it's empty.
 							if _, ok := keyVal.(rel.String); ok {
 								key = keyVal.String()
-							} else if _, ok := keyVal.(rel.GenericSet); !ok || keyVal.IsTrue() {
-								return nil, fmt.Errorf("all keys of arg to //tuple must be strings, not %T", keyVal)
+							} else if _, ok := keyVal.(rel.GenericSet); ok && !keyVal.IsTrue() {
+								key = ""
+							} else {
+								return nil, fmt.Errorf(
+									"all keys of arg to //tuple must be strings, not %T", keyVal)
 							}
 							attrs = append(attrs, rel.NewAttr(key, value))
 						}

--- a/syntax/std.go
+++ b/syntax/std.go
@@ -51,8 +51,13 @@ func StdScope() rel.Scope {
 					case rel.Dict:
 						attrs := make([]rel.Attr, 0, t.Count())
 						for e := t.DictEnumerator(); e.MoveNext(); {
-							key, value := e.Current()
-							attrs = append(attrs, rel.NewAttr(key.(rel.String).String(), value))
+							keyVal, value := e.Current()
+							key := ""
+							// keyVal won't be a rel.String if it's empty.
+							if keyStr, ok := keyVal.(rel.String); ok {
+								key = keyStr.String()
+							}
+							attrs = append(attrs, rel.NewAttr(key, value))
 						}
 						return rel.NewTuple(attrs...), nil
 					case rel.Set:

--- a/syntax/std.go
+++ b/syntax/std.go
@@ -53,15 +53,11 @@ func StdScope() rel.Scope {
 						for e := t.DictEnumerator(); e.MoveNext(); {
 							keyVal, value := e.Current()
 							key := ""
-							if keyVal.IsTrue() {
+							// keyVal won't be a rel.String if it's empty.
+							if _, ok := keyVal.(rel.String); ok {
 								key = keyVal.String()
-							} else {
-								switch keyVal.(type) {
-								case rel.Number:
-									key = "0"
-								case rel.Tuple:
-									key = "()"
-								}
+							} else if _, ok := keyVal.(rel.GenericSet); !ok || keyVal.IsTrue() {
+								return nil, fmt.Errorf("all keys of arg to //tuple must be strings, not %T", keyVal)
 							}
 							attrs = append(attrs, rel.NewAttr(key, value))
 						}

--- a/syntax/std.go
+++ b/syntax/std.go
@@ -55,6 +55,13 @@ func StdScope() rel.Scope {
 							key := ""
 							if keyVal.IsTrue() {
 								key = keyVal.String()
+							} else {
+								switch keyVal.(type) {
+								case rel.Number:
+									key = "0"
+								case rel.Tuple:
+									key = "()"
+								}
 							}
 							attrs = append(attrs, rel.NewAttr(key, value))
 						}

--- a/syntax/std.go
+++ b/syntax/std.go
@@ -53,9 +53,8 @@ func StdScope() rel.Scope {
 						for e := t.DictEnumerator(); e.MoveNext(); {
 							keyVal, value := e.Current()
 							key := ""
-							// keyVal won't be a rel.String if it's empty.
-							if keyStr, ok := keyVal.(rel.String); ok {
-								key = keyStr.String()
+							if keyVal.IsTrue() {
+								key = keyVal.String()
 							}
 							attrs = append(attrs, rel.NewAttr(key, value))
 						}

--- a/syntax/std_test.go
+++ b/syntax/std_test.go
@@ -6,13 +6,17 @@ func TestStdTuple(t *testing.T) {
 	t.Parallel()
 
 	AssertCodesEvalToSameValue(t, `()`, `//tuple({})`)
+	AssertCodesEvalToSameValue(t, `(a:1)`, `//tuple({"a":1})`)
+	AssertCodesEvalToSameValue(t, `(a:1, b:2)`, `//tuple({"a":1, "b":2})`)
+
 	AssertCodesEvalToSameValue(t, `('':1)`, `//tuple({"":1})`)
 	AssertCodesEvalToSameValue(t, `('':1)`, `//tuple({{}:1})`)
 	AssertCodesEvalToSameValue(t, `('':1)`, `//tuple({[]:1})`)
+	AssertCodesEvalToSameValue(t, `('0': 0)`, `//tuple({0: 0})`)
+	AssertCodesEvalToSameValue(t, `('()':())`, `//tuple({(): ()})`)
+
 	AssertCodesEvalToSameValue(t, `('1':2)`, `//tuple({1:2})`)
 	AssertCodesEvalToSameValue(t, `('[1]':2)`, `//tuple({[1]:2})`)
-	AssertCodesEvalToSameValue(t, `(a:1)`, `//tuple({"a":1})`)
-	AssertCodesEvalToSameValue(t, `(a:1, b:2)`, `//tuple({"a":1, "b":2})`)
 
 	AssertCodeErrors(t, "", `//tuple((a:1))`)
 	AssertCodeErrors(t, "", `//tuple(42)`)

--- a/syntax/std_test.go
+++ b/syntax/std_test.go
@@ -12,12 +12,11 @@ func TestStdTuple(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `('':1)`, `//tuple({"":1})`)
 	AssertCodesEvalToSameValue(t, `('':1)`, `//tuple({{}:1})`)
 	AssertCodesEvalToSameValue(t, `('':1)`, `//tuple({[]:1})`)
-	AssertCodesEvalToSameValue(t, `('0': 0)`, `//tuple({0: 0})`)
-	AssertCodesEvalToSameValue(t, `('()':())`, `//tuple({(): ()})`)
 
-	AssertCodesEvalToSameValue(t, `('1':2)`, `//tuple({1:2})`)
-	AssertCodesEvalToSameValue(t, `('[1]':2)`, `//tuple({[1]:2})`)
-
+	AssertCodeErrors(t, "", `//tuple({0: 0})`)
+	AssertCodeErrors(t, "", `//tuple({(): ()})`)
+	AssertCodeErrors(t, "", `//tuple({1:2})`)
+	AssertCodeErrors(t, "", `//tuple({[1]:2})`)
 	AssertCodeErrors(t, "", `//tuple((a:1))`)
 	AssertCodeErrors(t, "", `//tuple(42)`)
 }

--- a/syntax/std_test.go
+++ b/syntax/std_test.go
@@ -7,6 +7,10 @@ func TestStdTuple(t *testing.T) {
 
 	AssertCodesEvalToSameValue(t, `()`, `//tuple({})`)
 	AssertCodesEvalToSameValue(t, `('':1)`, `//tuple({"":1})`)
+	AssertCodesEvalToSameValue(t, `('':1)`, `//tuple({{}:1})`)
+	AssertCodesEvalToSameValue(t, `('':1)`, `//tuple({[]:1})`)
+	AssertCodesEvalToSameValue(t, `('1':2)`, `//tuple({1:2})`)
+	AssertCodesEvalToSameValue(t, `('[1]':2)`, `//tuple({[1]:2})`)
 	AssertCodesEvalToSameValue(t, `(a:1)`, `//tuple({"a":1})`)
 	AssertCodesEvalToSameValue(t, `(a:1, b:2)`, `//tuple({"a":1, "b":2})`)
 

--- a/syntax/std_test.go
+++ b/syntax/std_test.go
@@ -6,6 +6,7 @@ func TestStdTuple(t *testing.T) {
 	t.Parallel()
 
 	AssertCodesEvalToSameValue(t, `()`, `//tuple({})`)
+	AssertCodesEvalToSameValue(t, `('':1)`, `//tuple({"":1})`)
 	AssertCodesEvalToSameValue(t, `(a:1)`, `//tuple({"a":1})`)
 	AssertCodesEvalToSameValue(t, `(a:1, b:2)`, `//tuple({"a":1, "b":2})`)
 


### PR DESCRIPTION
Fixes #571.

Changes proposed in this pull request:
- Ensure dict key is a string before converting. If empty, just use "".

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
