### PR TITLE
fixes indentation problem from xstr

### DIFF
--- a/syntax/parse_string_test.go
+++ b/syntax/parse_string_test.go
@@ -30,6 +30,184 @@ func TestXStringIndent(t *testing.T) {
 	t.Parallel()
 	AssertCodesEvalToSameValue(t, `"a\nb"`, "$`\n  a\n  b`")
 	AssertCodesEvalToSameValue(t, `"a\nb\n  c\nd"`, "$'\n  a\n  b\n    c\n  d'")
+	AssertCodesEvalToSameValue(t,
+		`
+"letter: a
+letter: b
+letter: c"
+`,
+		`
+$"${['a', 'b', 'c'] >> $'letter: ${.}'::\i}"
+        `,
+	)
+
+	AssertCodesEvalToSameValue(t,
+		`
+"stuff xyzabc stuff 123123123"
+`,
+		`
+$"stuff xyz${"abc"} stuff ${"123123123"}"
+        `,
+	)
+
+	AssertCodesEvalToSameValue(t,
+		`
+"abc:
+    letter: a
+    letter: b
+    letter: c"
+`,
+		`$"
+        abc:
+            ${['a', 'b', 'c'] >> $'letter: ${.}'::\i}
+        "`,
+	)
+
+	AssertCodesEvalToSameValue(t,
+		`
+"stuff
+    123
+    321
+    456
+    654
+333"
+`,
+		`$"
+        stuff
+            ${123}
+            ${321}
+            456
+            ${654}
+        ${333}
+        "`,
+	)
+
+	AssertCodesEvalToSameValue(t,
+		`
+"abc:
+    letter:
+        a
+    letter:
+        b
+    letter:
+        c"
+`,
+		`$"
+        abc:
+            ${['a', 'b', 'c'] >> $'
+            letter:
+                ${.}
+            '::\i}
+        "`,
+	)
+
+	AssertCodesEvalToSameValue(t,
+		`
+"letters:
+    letter:
+        d
+    letter:
+        e
+    letter:
+        f
+
+    numbers:
+        number:
+            1
+        number:
+            2
+        number:
+            3"`,
+		`$"
+        letters:
+            ${['d', 'e', 'f'] >> $"
+                letter:
+                    ${.}
+            "::\i}
+
+            numbers:
+                ${[1, 2, 3] >> $"
+                    number:
+                        ${.}
+                "::\i}
+        "`,
+	)
+
+	AssertCodesEvalToSameValue(t,
+		`
+"abc:
+    letter:
+        a
+    letter:
+        b
+    letter:
+        c"`,
+		`$"
+        abc:
+            ${['a', 'b', 'c'] >> $'
+            letter:
+                ${.}
+            '::\i}
+        "`,
+	)
+
+	AssertCodesEvalToSameValue(t,
+		`
+"letters:
+    letter:
+        d
+    letter:
+        e
+    letter:
+        f
+numbers:
+number:
+    1
+number:
+    2
+number:
+    3"`,
+		`$"
+        letters:
+            ${['d', 'e', 'f'] >> $"
+                letter:
+                    ${.}
+            "::\i}
+        numbers:
+        ${[1, 2, 3] >> $"
+            number:
+                ${.}
+        "::\i}
+        "`,
+	)
+
+	AssertCodesEvalToSameValue(t,
+		`
+"letters:letter:
+    d
+letter:
+    e
+letter:
+    f
+numbers:
+number:
+    1
+number:
+    2
+number:
+    3"`,
+		`$"
+        letters:${['d', 'e', 'f'] >> $"
+                letter:
+                    ${.}
+            "::\i}
+        numbers:
+        ${[1, 2, 3] >> $"
+            number:
+                ${.}
+        "::\i}
+        "`,
+	)
 }
 
 func TestXStringWS(t *testing.T) {


### PR DESCRIPTION
initially the expression
```
$`
abc:
	${[1, 2, 3] >> $`
		number:
			${.}
	`}
`
```

would output
```
abc:
	number:
	1
	number:
	2
	number:
	3
```
this commit fixes that, now it outputs
```
abc:
	number:
		1
	number:
		2
	number:
		3
```
Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
