### PR TITLE
fixes extra whitespace after computed empty string

### DIFF
--- a/syntax/compile_xstr.go
+++ b/syntax/compile_xstr.go
@@ -180,9 +180,12 @@ func cleanEmptyVal(values rel.Value) []rel.Value {
 		// cleans bare string after the empty computed string
 		cleanRE(firstIndentRE, i+1, func(match, toReplace string) string {
 			if match != "" {
-				// clean bare string before the empty computed string
-				// only cleans this if i+1 will be changed, this is to retain
-				// any whitespaces in the bare string of i-1. Meant to handle
+				// cleans bare string before the empty computed string
+				//
+				// only does this if i+1 will be changed, this is meant to retain
+				// any whitespaces in the bare string of arr[i-1].
+				//
+				// Meant to handle
 				// $`
 				//   abc
 				//   ${''}def

--- a/syntax/compile_xstr.go
+++ b/syntax/compile_xstr.go
@@ -183,7 +183,7 @@ func cleanEmptyVal(values rel.Value) []rel.Value {
 				// cleans bare string before the empty computed string
 				//
 				// only does this if i+1 will be changed, this is meant to retain
-				// any whitespaces in the bare string of arr[i-1].
+				// any suffix whitespaces in the bare string of arr[i-1].
 				//
 				// Meant to handle
 				// $`

--- a/syntax/compile_xstr.go
+++ b/syntax/compile_xstr.go
@@ -164,7 +164,7 @@ func xstrConcat(seq rel.Value) (rel.Value, error) {
 	return rel.NewString([]rune(sb.String())), nil
 }
 
-// this function cleans whitespaces of bare strings before and after a computed emptyt string
+// cleanEmptyVal cleans whitespaces of bare strings before and after a computed empty string.
 func cleanEmptyVal(values rel.Value) []rel.Value {
 	arr := values.(rel.Array).Values()
 	length := len(arr)

--- a/syntax/compile_xstr.go
+++ b/syntax/compile_xstr.go
@@ -125,6 +125,11 @@ func (pc ParseContext) compileExpandableString(b ast.Branch, c ast.Children) rel
 }
 
 func xstrConcat(seq rel.Value) (rel.Value, error) {
+	// this is always a sequence of values between bare string and computed expressions
+	// all bare strings are wrapped in a tuple of one attribute "s"
+	//
+	// bare strings are wrapped in a tuple to differentiate between
+	// regular string and computed expressions
 	values := cleanEmptyVal(seq)
 	recentIndent := "\n"
 	if len(values) == 0 {
@@ -137,7 +142,7 @@ func xstrConcat(seq rel.Value) (rel.Value, error) {
 			continue
 		}
 		switch i := i.(type) {
-		// handle sexpr
+		// handle computed expressions
 		case rel.String:
 			sb.WriteString(strings.ReplaceAll(i.String(), "\n", recentIndent))
 
@@ -165,6 +170,7 @@ func cleanEmptyVal(values rel.Value) []rel.Value {
 	length := len(arr)
 	cleanRE := func(re *regexp.Regexp, index int, cleaner func(string, string) string) {
 		if index >= 0 && index < length {
+			// anything that is wrapped in a tuple is considered bare string
 			if t, isBareString := arr[index].(rel.Tuple); isBareString {
 				if s := t.MustGet("s"); s.IsTrue() {
 					match := ""

--- a/syntax/parse_string_test.go
+++ b/syntax/parse_string_test.go
@@ -223,6 +223,140 @@ func TestXStringSuppressEmptyComputedLines(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `"x\n2"`, "$'\n  x\n  ${''}\n  ${''}\n  ${2}'")
 }
 
+func TestXStringSuppressNewlinesAfterEmptyComputedLines(t *testing.T) {
+	t.Parallel()
+	AssertCodesEvalToSameValue(t,
+		`
+"stuff:
+    abc
+    ghi
+"
+		`,
+		`
+$"
+stuff:
+    abc
+    ${''}
+    ghi
+"
+		`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`
+"stuff:
+    abc
+ghi
+"
+		`,
+		`
+$"
+stuff:
+    abc
+    ${''}
+ghi
+"
+		`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`
+"stuff:
+    abc
+    ghi
+"
+		`,
+		`
+$"
+stuff:
+    abc
+    ${''}ghi
+"
+		`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`
+"stuff:
+    abc
+        ghi
+"
+		`,
+		`
+$"
+stuff:
+    abc
+    ${''}    ghi
+"
+		`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`
+"stuff:
+    abc
+
+	ghi
+"
+		`,
+		`
+$"
+stuff:
+    abc
+	${''}
+
+	ghi
+"
+		`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`
+"stuff:
+	abc
+	def
+	ghi
+"
+		`,
+		`
+$"
+stuff:
+	abc
+	${''}
+	${'def'}
+	ghi
+"
+		`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`
+"stuff:
+	abc
+	def
+	ghi
+"
+		`,
+		`
+$"
+stuff:
+	abc
+	${''}${'def'}
+	ghi
+"
+		`,
+	)
+	AssertCodesEvalToSameValue(t,
+		`
+"stuff:
+	abc
+	defghi
+"
+		`,
+		`
+$"
+stuff:
+	abc
+	${''}${'def'}ghi
+"
+		`,
+	)
+}
+
 func TestXStringSuppressLastLineWS(t *testing.T) {
 	t.Parallel()
 	AssertCodesEvalToSameValue(t, `"xy"`, `$"x${ [] :::=}y"`)


### PR DESCRIPTION
initially the expression
```
$`
    abc
    ${''}
    def
`
```

would output
```
    abc

    def
```

this commit suppresses any lines which only contains computed empty string
```
    abc
    def
```
Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
