### PR TITLE
strip last whitespaces in a string template

### DIFF
--- a/docs/expr-str.md
+++ b/docs/expr-str.md
@@ -55,8 +55,7 @@ Expression strings apply the following rules to handle whitespace:
    ghi
    ```
 
-3. The last newline (`\n`) along with any whitespaces after the newline will be
-   removed.
+3. If the last newline (`\n`) is followed by pure whitespace, the newline and whitespace are discarded.
 
 4. If, after indentation removal, an embedded expression is the only remaining
    content on a line, and the formatted result is empty, then the entire line,

--- a/docs/expr-str.md
+++ b/docs/expr-str.md
@@ -55,8 +55,8 @@ Expression strings apply the following rules to handle whitespace:
    ghi
    ```
 
-3. If the last newline (`\n`) is followed by pure whitespace, that whitespace is
-   discarded.
+3. The last newline (`\n`) along with any whitespaces after the newline will be
+   removed.
 
 4. If, after indentation removal, an embedded expression is the only remaining
    content on a line, and the formatted result is empty, then the entire line,

--- a/syntax/compile_xstr.go
+++ b/syntax/compile_xstr.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	leadingWSRE   = regexp.MustCompile(`\A[\t ]*`)
-	lastWSRE      = regexp.MustCompile(`\n[\t ]+\z`)
+	lastWSRE      = regexp.MustCompile(`\n[\t ]*\z`)
 	expansionRE   = regexp.MustCompile(`(?::([-+#*\.\_0-9a-z]*))(:(?:\\.|[^\\:}])*)?(?::((?:\\.|[^\\:}])*))?`)
 	indentRE      = regexp.MustCompile(`(\n[\t ]*)(?:[^\t ]|\z)[^\n]*\z`)
 	firstIndentRE = regexp.MustCompile(`\A((\n[\t ]+)(?:\n)|(\n))`)
@@ -64,7 +64,7 @@ func (pc ParseContext) compileExpandableString(b ast.Branch, c ast.Children) rel
 
 	if last, is := parts[len(parts)-1].(string); is {
 		if loc := lastWSRE.FindStringIndex(last); loc != nil {
-			parts[len(parts)-1] = last[:loc[0]+1]
+			parts[len(parts)-1] = last[:loc[0]]
 		}
 	}
 

--- a/syntax/parse_string_test.go
+++ b/syntax/parse_string_test.go
@@ -229,8 +229,7 @@ func TestXStringSuppressNewlinesAfterEmptyComputedLines(t *testing.T) {
 		`
 "stuff:
     abc
-    ghi
-"
+    ghi"
 		`,
 		`
 $"
@@ -245,8 +244,7 @@ stuff:
 		`
 "stuff:
     abc
-ghi
-"
+ghi"
 		`,
 		`
 $"
@@ -261,8 +259,7 @@ ghi
 		`
 "stuff:
     abc
-    ghi
-"
+    ghi"
 		`,
 		`
 $"
@@ -276,8 +273,7 @@ stuff:
 		`
 "stuff:
     abc
-        ghi
-"
+        ghi"
 		`,
 		`
 $"
@@ -292,8 +288,7 @@ stuff:
 "stuff:
     abc
 
-	ghi
-"
+	ghi"
 		`,
 		`
 $"
@@ -301,8 +296,7 @@ stuff:
     abc
 	${''}
 
-	ghi
-"
+	ghi"
 		`,
 	)
 	AssertCodesEvalToSameValue(t,
@@ -310,8 +304,7 @@ stuff:
 "stuff:
 	abc
 	def
-	ghi
-"
+	ghi"
 		`,
 		`
 $"
@@ -328,8 +321,7 @@ stuff:
 "stuff:
 	abc
 	def
-	ghi
-"
+	ghi"
 		`,
 		`
 $"
@@ -344,8 +336,7 @@ stuff:
 		`
 "stuff:
 	abc
-	defghi
-"
+	defghi"
 		`,
 		`
 $"
@@ -369,15 +360,38 @@ func TestXStringSuppressLastLineWS(t *testing.T) {
 			${[1, 2, 3] >> $"
 				${.}
 				.
-				"::\n}
+				"::\n\n:\n}
 		"`)
 	AssertCodesEvalToSameValue(t, `"1\n.\n\n2\n.\n\n3\n.\n"`, `
 		$"
 			${[1, 2, 3] >> $"
 				${.}
 				.
-			"::\n}
+			"::\n\n:\n}
 		"`)
+	AssertCodesEvalToSameValue(t, `"stuff:\n\tletter:\n\t\td\n\tletter:\n\t\te\n\tletter:\n\t\tf"`,
+		`
+$"
+stuff:
+	${['d', 'e', 'f'] >> $"
+		letter:
+			${.}
+	"::\i}
+"
+		`,
+	)
+	AssertCodesEvalToSameValue(t, `"stuff:\n\tletter:\n\t\td\n\tletter:\n\t\te\n\tletter:\n\t\tf\n\t\t\t"`,
+		`
+$"
+stuff:
+	${['d', 'e', 'f'] >> $"
+		letter:
+			${.}
+	"::\i}
+${"\t\t\t"}
+"
+		`,
+	)
 }
 
 func TestXStringArrays(t *testing.T) {


### PR DESCRIPTION
Initially, the expression
```
$"
stuff:
	${[1, 2, 3] >> $"
		letter:
	"::\i}
"
```

will output:
```
stuff:
	letter:

	letter:

	letter:

```

This is caused by the newline after the word `letter:` in the string template.

This commit removes the last whitespaces of string expression for better formatting of
multiline expression.
The output now is:
```
stuff:
	letter:
	letter:
	letter:
```
Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
