### PR TITLE
Fix //seq.sub for string sub of empty string

### DIFF
--- a/syntax/std_seq.go
+++ b/syntax/std_seq.go
@@ -224,7 +224,7 @@ func stdSeqSub(old, new, subject rel.Value) (rel.Value, error) {
 			return subject, nil
 		} else if oldIsSet && !newIsSet {
 			return new, nil
-		} else if !oldIsSet && newIsSet {
+		} else {
 			return subject, nil
 		}
 	}

--- a/syntax/std_seq_sub_test.go
+++ b/syntax/std_seq_sub_test.go
@@ -14,6 +14,7 @@ func TestStrSub(t *testing.T) { //nolint:dupl
 		`//seq.sub( "doesn't matter", "hello there","this is still a test")`)
 	AssertCodeErrors(t, "", `//seq.sub("hello there", "test", 1)`)
 	/////////////////
+	AssertCodesEvalToSameValue(t, `""`, `//seq.sub('a', "b", "")`)
 	AssertCodesEvalToSameValue(t, `""`, `//seq.sub( "","", "")`)
 	AssertCodesEvalToSameValue(t, `"A"`, `//seq.sub( "","A", "")`)
 	AssertCodesEvalToSameValue(t, `""`, `//seq.sub( "A","", "")`)


### PR DESCRIPTION
Fixes #588 .

Changes proposed in this pull request:
- If old is non-empty and subject is empty, return subject.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation