### PR TITLE
fixes suppression of line after empty computed string

### DIFF
--- a/syntax/compile_xstr.go
+++ b/syntax/compile_xstr.go
@@ -192,9 +192,9 @@ func cleanEmptyVal(values rel.Array) []rel.Value {
 			}
 			changeRight := false
 
-			// cleans bare string before the empty computed string
+			// Cleans bare string before the empty computed string.
 			//
-			// cleaning happens if and only if both strings before and after
+			// Cleaning happens if and only if both strings before and after
 			// the empty string. This is meant to remove the whole line if
 			// the empty string is the only thing in that line. For example:
 			// $`
@@ -203,8 +203,8 @@ func cleanEmptyVal(values rel.Array) []rel.Value {
 			//       children
 			//  `
 			//
-			// if one of the sides don't require cleaning or if only one of the
-			// regex match, cleaning isn't done to both sides to retain
+			// If one of the sides don't require cleaning (if only one of the
+			// regex match), cleaning isn't done to both sides to retain
 			// whitespaces. Essentially, to handle these cases:
 			// $`                               $`
 			//   root: ${''}           or         root:

--- a/syntax/parse_string_test.go
+++ b/syntax/parse_string_test.go
@@ -346,6 +346,18 @@ stuff:
 "
 		`,
 	)
+	AssertCodesEvalToSameValue(t,
+		`
+"stuff:
+	abc"
+		`,
+		`
+$"
+stuff:${''}
+	abc
+"
+		`,
+	)
 }
 
 func TestXStringSuppressLastLineWS(t *testing.T) {


### PR DESCRIPTION
Initially, the following expr:
```
$`
	root:${''}
		children
`
```

will output
```
root:	children
```

This commit fixes that
```
root:
	children
```
Checklist:
- [x] Added related tests
