### PR TITLE
Add //os.exists to check for existence of file or directory

### DIFF
--- a/docs/std-os.md
+++ b/docs/std-os.md
@@ -18,6 +18,10 @@ Usage:
 
 `cwd` contains a string representing the current user directory.
 
+## `//os.exists(filepath <: string) <: boolean`
+
+`exists` returns `true` if a file or directory exists at `filepath`, or `false` otherwise.
+
 ## `//os.file(filepath <: string) <: array_of_bytes`
 
 `file` returns the content of a file located at `filepath` in the form of an array of bytes.

--- a/syntax/std_os.go
+++ b/syntax/std_os.go
@@ -16,6 +16,7 @@ func stdOs() rel.Attr {
 		rel.NewAttr("path_separator", stdOsPathSeparator()),
 		rel.NewAttr("path_list_separator", stdOsPathListSeparator()),
 		rel.NewAttr("cwd", stdOsCwd()),
+		rel.NewNativeFunctionAttr("exists", stdOsExists),
 		rel.NewNativeFunctionAttr("file", stdOsFile),
 		rel.NewNativeFunctionAttr("get_env", stdOsGetEnv),
 		rel.NewNativeFunctionAttr("&stdin", stdOsStdinVar.read),

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -40,6 +40,9 @@ func stdOsExists(v rel.Value) (rel.Value, error) {
 	if os.IsNotExist(err) {
 		return rel.NewBool(false), nil
 	}
+	if err != nil {
+		return nil, err
+	}
 	return rel.NewBool(true), nil
 }
 

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -35,6 +35,14 @@ func stdOsCwd() rel.Value {
 	return rel.NewString([]rune(wd))
 }
 
+func stdOsExists(v rel.Value) (rel.Value, error) {
+	_, err := os.Stat(v.(rel.String).String())
+	if os.IsNotExist(err) {
+		return rel.NewBool(false), nil
+	}
+	return rel.NewBool(true), nil
+}
+
 func stdOsFile(v rel.Value) (rel.Value, error) {
 	f, err := ioutil.ReadFile(v.(rel.String).String())
 	if err != nil {

--- a/syntax/std_os_test.go
+++ b/syntax/std_os_test.go
@@ -19,3 +19,8 @@ func TestStdOsStdin(t *testing.T) {
 	AssertCodesEvalToSameValue(t, `<<97, 98, 99>>`, `//os.stdin`)
 	AssertCodesEvalToSameValue(t, `<<97, 98, 99>>`, `//os.stdin`)
 }
+
+func TestStdOsExists(t *testing.T) {
+	AssertCodesEvalToSameValue(t, `true`, `//os.exists('std_os_test.go')`)
+	AssertCodesEvalToSameValue(t, `false`, `//os.exists('doesntexist.anywhere')`)
+}

--- a/syntax/std_os_wasm.go
+++ b/syntax/std_os_wasm.go
@@ -26,6 +26,10 @@ func stdOsCwd() rel.Value {
 	panic("not implemented")
 }
 
+func stdOsExists(rel.Value) (rel.Value, error) {
+	panic("not implemented")
+}
+
 func stdOsFile(rel.Value) (rel.Value, error) {
 	panic("not implemented")
 }


### PR DESCRIPTION
Fixes #594.

Changes proposed in this pull request:
- Add `//os.exists(filepath)` to std_os.go

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
