### PR TITLE
replace fs access with afero

### DIFF
--- a/cmd/arrai/run.go
+++ b/cmd/arrai/run.go
@@ -33,7 +33,8 @@ func run(c *cli.Context) error {
 func evalFile(ctx context.Context, path string, w io.Writer, out string) error {
 	if exists, err := tools.FileExists(ctx, path); err != nil {
 		return err
-	} else if !exists {
+	}
+	if !exists {
 		if !strings.Contains(path, string([]rune{os.PathSeparator})) {
 			return fmt.Errorf(`"%s": not a command and not found as a file in the current directory`, path)
 		}

--- a/cmd/arrai/run.go
+++ b/cmd/arrai/run.go
@@ -33,15 +33,14 @@ func run(c *cli.Context) error {
 func evalFile(ctx context.Context, path string, w io.Writer, out string) error {
 	if exists, err := tools.FileExists(ctx, path); err != nil {
 		return err
-	}
-	if !exists {
+	} else if !exists {
 		if !strings.Contains(path, string([]rune{os.PathSeparator})) {
 			return fmt.Errorf(`"%s": not a command and not found as a file in the current directory`, path)
 		}
 		return fmt.Errorf(`"%s": file not found`, path)
 	}
 
-	buf, err := ctxfs.FsRead(ctxfs.SourceFsFrom(ctx), path)
+	buf, err := ctxfs.ReadFile(ctxfs.SourceFsFrom(ctx), path)
 	if err != nil {
 		return err
 	}

--- a/cmd/arrai/run.go
+++ b/cmd/arrai/run.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/arr-ai/arrai/pkg/arraictx"
+	"github.com/arr-ai/arrai/pkg/ctxfs"
 	"github.com/arr-ai/arrai/tools"
 	"github.com/urfave/cli/v2"
 )
@@ -30,24 +31,19 @@ func run(c *cli.Context) error {
 }
 
 func evalFile(ctx context.Context, path string, w io.Writer, out string) error {
-	if !tools.FileExists(path) {
+	if exists, err := tools.FileExists(ctx, path); err != nil {
+		return err
+	} else if !exists {
 		if !strings.Contains(path, string([]rune{os.PathSeparator})) {
 			return fmt.Errorf(`"%s": not a command and not found as a file in the current directory`, path)
 		}
 		return fmt.Errorf(`"%s": file not found`, path)
 	}
 
-	f, err := os.Open(path)
+	buf, err := ctxfs.FsRead(ctxfs.SourceFsFrom(ctx), path)
 	if err != nil {
 		return err
 	}
-	fi, err := f.Stat()
-	if err != nil {
-		return err
-	}
-	buf := make([]byte, fi.Size())
-	if _, err := f.Read(buf); err != nil {
-		return err
-	}
+
 	return evalExpr(ctx, path, string(buf), w, out)
 }

--- a/cmd/arrai/sync_other.go
+++ b/cmd/arrai/sync_other.go
@@ -123,7 +123,7 @@ func buildTree(ctx context.Context, root string) (map[string]interface{}, error)
 			if err != nil {
 				log.Printf("ERROR WALKING TO %s: %s", path, err)
 			} else if !info.IsDir() {
-				data, err := ctxfs.FsRead(ctxfs.SourceFsFrom(ctx), path)
+				data, err := ctxfs.ReadFile(ctxfs.SourceFsFrom(ctx), path)
 				if err != nil {
 					return errors.WrapPrefix(err, "reading "+path, 0)
 				}

--- a/cmd/arrai/test.go
+++ b/cmd/arrai/test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/arr-ai/arrai/internal/test"
+	"github.com/arr-ai/arrai/pkg/arraictx"
 	"github.com/arr-ai/arrai/tools"
 
 	"github.com/urfave/cli/v2"
@@ -22,11 +24,11 @@ var testCommand = &cli.Command{
 func doTest(c *cli.Context) error {
 	tools.SetArgs(c)
 	file := c.Args().Get(0)
-	return testPath(file, os.Stdout)
+	return testPath(arraictx.InitRunCtx(context.Background()), file, os.Stdout)
 }
 
 // testPath runs and reports on all tests in the subtree of the given path.
-func testPath(path string, w io.Writer) error {
+func testPath(ctx context.Context, path string, w io.Writer) error {
 	if path == "" {
 		path = "."
 	}
@@ -37,7 +39,7 @@ func testPath(path string, w io.Writer) error {
 		return fmt.Errorf(`"%s": file not found`, path)
 	}
 
-	results, err := test.Test(w, path)
+	results, err := test.Test(ctx, w, path)
 	if err != nil {
 		return err
 	}

--- a/cmd/arrai/test_test.go
+++ b/cmd/arrai/test_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/arr-ai/arrai/pkg/arraictx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,7 +13,7 @@ func TestTest(t *testing.T) {
 	t.Parallel()
 
 	var s strings.Builder
-	err := testPath("./../../examples/test", &s)
+	err := testPath(arraictx.InitRunCtx(context.Background()), "./../../examples/test", &s)
 	require.Nil(t, err)
 	windowsOsStr := `Tests:
 ..\..\examples\test\multiple_cases_test.arrai

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -34,7 +34,7 @@ func Test(ctx context.Context, w io.Writer, path string) (Results, error) {
 	fmt.Fprintf(w, "Tests:\n%s\n", strings.Join(files, "\n"))
 
 	for _, file := range files {
-		bytes, err := ctxfs.FsRead(ctxfs.SourceFsFrom(ctx), file)
+		bytes, err := ctxfs.ReadFile(ctxfs.SourceFsFrom(ctx), file)
 		if err != nil {
 			return results, err
 		}

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/arr-ai/arrai/pkg/arraictx"
+	"github.com/arr-ai/arrai/pkg/ctxfs"
 	"github.com/arr-ai/arrai/rel"
 	"github.com/arr-ai/arrai/syntax"
 )
 
 // Test runs all tests in the subtree of path and returns the results.
-func Test(w io.Writer, path string) (Results, error) {
+func Test(ctx context.Context, w io.Writer, path string) (Results, error) {
 	results := Results{}
 	var files []string
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
@@ -34,11 +33,8 @@ func Test(w io.Writer, path string) (Results, error) {
 
 	fmt.Fprintf(w, "Tests:\n%s\n", strings.Join(files, "\n"))
 
-	//TODO: init with values
-	ctx := arraictx.InitRunCtx(context.Background())
-
 	for _, file := range files {
-		bytes, err := ioutil.ReadFile(file)
+		bytes, err := ctxfs.FsRead(ctxfs.SourceFsFrom(ctx), file)
 		if err != nil {
 			return results, err
 		}

--- a/pkg/ctxfs/ctxfs.go
+++ b/pkg/ctxfs/ctxfs.go
@@ -47,3 +47,21 @@ func RuntimeFsFrom(ctx context.Context) afero.Fs {
 	}
 	return defaultFs
 }
+
+func FsRead(fs afero.Fs, filePath string) ([]byte, error) {
+	f, err := fs.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, fi.Size())
+	if _, err = f.Read(buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/pkg/ctxfs/ctxfs.go
+++ b/pkg/ctxfs/ctxfs.go
@@ -2,6 +2,7 @@ package ctxfs
 
 import (
 	"context"
+	"io/ioutil"
 
 	"github.com/spf13/afero"
 )
@@ -48,20 +49,12 @@ func RuntimeFsFrom(ctx context.Context) afero.Fs {
 	return defaultFs
 }
 
-func FsRead(fs afero.Fs, filePath string) ([]byte, error) {
+func ReadFile(fs afero.Fs, filePath string) ([]byte, error) {
 	f, err := fs.Open(filePath)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 
-	fi, err := f.Stat()
-	if err != nil {
-		return nil, err
-	}
-	buf := make([]byte, fi.Size())
-	if _, err = f.Read(buf); err != nil {
-		return nil, err
-	}
-	return buf, nil
+	return ioutil.ReadAll(f)
 }

--- a/syntax/import.go
+++ b/syntax/import.go
@@ -126,7 +126,7 @@ func fileValue(ctx context.Context, filename string) (rel.Expr, error) {
 		filename += ".arrai"
 	}
 
-	bytes, err := ctxfs.FsRead(ctxfs.SourceFsFrom(ctx), filename)
+	bytes, err := ctxfs.ReadFile(ctxfs.SourceFsFrom(ctx), filename)
 	if err != nil {
 		return nil, err
 	}

--- a/syntax/import.go
+++ b/syntax/import.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/arr-ai/arrai/pkg/ctxfs"
 	"github.com/arr-ai/arrai/rel"
 	"github.com/arr-ai/arrai/tools"
 	"github.com/arr-ai/arrai/tools/module"
@@ -22,7 +23,7 @@ var cache = newCache()
 
 func importLocalFile(ctx context.Context, fromRoot bool, importPath string) (rel.Expr, error) {
 	if fromRoot {
-		rootPath, err := findRootFromModule(filepath.Dir(importPath))
+		rootPath, err := findRootFromModule(ctx, filepath.Dir(importPath))
 		if err != nil {
 			return nil, err
 		}
@@ -74,7 +75,7 @@ func importModuleFile(ctx context.Context, importPath string) (rel.Expr, error) 
 	return fileValue(ctx, filepath.Join(m.Dir, strings.TrimPrefix(importPath, m.Name)))
 }
 
-func findRootFromModule(modulePath string) (string, error) {
+func findRootFromModule(ctx context.Context, modulePath string) (string, error) {
 	currentPath, err := filepath.Abs(modulePath)
 	if err != nil {
 		return "", err
@@ -87,7 +88,7 @@ func findRootFromModule(modulePath string) (string, error) {
 
 	// Keep walking up the directories to find nearest root marker
 	for {
-		exists := tools.FileExists(filepath.Join(currentPath, arraiRootMarker))
+		exists, err := tools.FileExists(ctx, filepath.Join(currentPath, arraiRootMarker))
 		reachedRoot := currentPath == systemRoot || (err != nil && os.IsPermission(err))
 		switch {
 		case exists:
@@ -125,10 +126,11 @@ func fileValue(ctx context.Context, filename string) (rel.Expr, error) {
 		filename += ".arrai"
 	}
 
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := ctxfs.FsRead(ctxfs.SourceFsFrom(ctx), filename)
 	if err != nil {
 		return nil, err
 	}
+
 	switch filepath.Ext(filename) {
 	case ".json":
 		return bytesJSONToArrai(bytes)

--- a/syntax/std_os_nonwasm.go
+++ b/syntax/std_os_nonwasm.go
@@ -59,7 +59,7 @@ func stdOsFile(ctx context.Context, v rel.Value) (rel.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf, err := ctxfs.FsRead(ctxfs.RuntimeFsFrom(ctx), filePath.String())
+	buf, err := ctxfs.ReadFile(ctxfs.RuntimeFsFrom(ctx), filePath.String())
 	if err != nil {
 		//TODO: wrap this in an arrai error message
 		return nil, err

--- a/tools/file_util.go
+++ b/tools/file_util.go
@@ -1,16 +1,24 @@
 package tools
 
-import "os"
+import (
+	"context"
+	"os"
 
-// FileExists returns true if a file is existing.
-func FileExists(file string) bool {
+	"github.com/arr-ai/arrai/pkg/ctxfs"
+)
+
+// FileExists returns true if a file is existing. This is meant to be used with
+// SourceFs related operations.
+func FileExists(ctx context.Context, file string) (bool, error) {
 	if len(file) == 0 {
-		return false
+		return false, nil
 	}
-
-	info, err := os.Stat(file)
-	if os.IsNotExist(err) {
-		return false
+	info, err := ctxfs.SourceFsFrom(ctx).Stat(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
 	}
-	return !info.IsDir()
+	return !info.IsDir(), nil
 }


### PR DESCRIPTION
This PR replaces `os.File` and `ioutil.ReadFile` with `afero` to avoid direct os access.

Checklist:
- [ ] Added related tests
- [ ] Made corresponding changes to the documentation
