### PR TITLE
allow nested import root and import root fixes

### DIFF
--- a/cmd/arrai/run_test.go
+++ b/cmd/arrai/run_test.go
@@ -19,12 +19,12 @@ func TestModuleImportRoot(t *testing.T) {
 
 	//
 	// path1
-	// ├── arraiRootMarker
+	// ├── ModuleRootSentinel
 	// └── path2
 	//     ├── path3
 	//     │   └── import_from_root.arrai
 	//     └── path4
-	//         ├── arraiRootMarker
+	//         ├── ModuleRootSentinel
 	//         ├── 1.arrai
 	//         ├── import_from_same_dir_root.arrai
 	//         └── path5
@@ -37,8 +37,8 @@ func TestModuleImportRoot(t *testing.T) {
 	files := []struct {
 		fileName, expr string
 	}{
-		{filepath.Join("path1", syntax.ArraiRootMarker), ""},
-		{filepath.Join("path1/path2/path4", syntax.ArraiRootMarker), ""},
+		{filepath.Join("path1", syntax.ModuleRootSentinel), ""},
+		{filepath.Join("path1/path2/path4", syntax.ModuleRootSentinel), ""},
 		{"path1/path2/path3/import_from_root.arrai", "//{/path2/path4/path5/2}"},
 		{"path1/path2/path4/1.arrai", "1"},
 		{"path1/path2/path4/import_from_same_dir_root.arrai", "//{/1}"},

--- a/cmd/arrai/run_test.go
+++ b/cmd/arrai/run_test.go
@@ -4,11 +4,102 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/arr-ai/arrai/pkg/arraictx"
+	"github.com/arr-ai/arrai/pkg/ctxfs"
+	"github.com/arr-ai/arrai/syntax"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
+
+func TestModuleImportRoot(t *testing.T) {
+	t.Parallel()
+
+	//
+	// path1
+	// ├── arraiRootMarker
+	// └── path2
+	//     ├── path3
+	//     │   └── import_from_root.arrai
+	//     └── path4
+	//         ├── arraiRootMarker
+	//         ├── 1.arrai
+	//         ├── import_from_same_dir_root.arrai
+	//         └── path5
+	//             ├── 2.arrai
+	//             └── import_from_nested_root.arrai
+	//
+	importTestFs := afero.NewMemMapFs()
+	require.NoError(t, importTestFs.MkdirAll(mustAbs(t, "path1/path2/path3"), os.ModeDir))
+	require.NoError(t, importTestFs.MkdirAll(mustAbs(t, "path1/path2/path4"), os.ModeDir))
+	files := []struct {
+		fileName, expr string
+	}{
+		{filepath.Join("path1", syntax.ArraiRootMarker), ""},
+		{filepath.Join("path1/path2/path4", syntax.ArraiRootMarker), ""},
+		{"path1/path2/path3/import_from_root.arrai", "//{/path2/path4/path5/2}"},
+		{"path1/path2/path4/1.arrai", "1"},
+		{"path1/path2/path4/import_from_same_dir_root.arrai", "//{/1}"},
+		{"path1/path2/path4/path5/2.arrai", "2"},
+		{"path1/path2/path4/path5/import_from_nested_root.arrai", "//{/1}"},
+	}
+	for _, af := range files {
+		f, err := importTestFs.Create(mustAbs(t, af.fileName))
+		require.NoError(t, err)
+		defer f.Close()
+		mustWrite(t, f, []byte(af.expr))
+	}
+
+	ctx := ctxfs.SourceFsOnto(context.Background(), importTestFs)
+	cases := []struct {
+		filePath, expected string
+	}{
+		{"path1/path2/path3/import_from_root.arrai", "2"},
+		{"path1/path2/path4/import_from_same_dir_root.arrai", "1"},
+		{"path1/path2/path4/path5/import_from_nested_root.arrai", "1"},
+	}
+	for _, c := range cases {
+		var buf bytes.Buffer
+		require.NoError(t, evalFile(ctx, mustAbs(t, c.filePath), &buf, ""))
+		require.Equal(t, c.expected+"\n", buf.String())
+	}
+}
+
+func TestNoImportRoot(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll(mustAbs(t, "path/to/file"), os.ModeDir))
+	f, err := fs.Create(mustAbs(t, "path/to/file/test.arrai"))
+	require.NoError(t, err)
+	defer f.Close()
+	mustWrite(t, f, []byte("//{/file}"))
+
+	f, err = fs.Create(mustAbs(t, "file.arrai"))
+	require.NoError(t, err)
+	defer f.Close()
+	mustWrite(t, f, []byte("1"))
+
+	require.EqualError(t,
+		evalFile(
+			ctxfs.SourceFsOnto(context.Background(), fs),
+			mustAbs(t, "path/to/file/test.arrai"), &bytes.Buffer{}, "",
+		),
+		"module root not found")
+}
+
+func mustAbs(t *testing.T, filePath string) string {
+	abs, err := filepath.Abs(filePath)
+	require.NoError(t, err)
+	return abs
+}
+
+func mustWrite(t *testing.T, f afero.File, content []byte) {
+	_, err := f.Write(content)
+	require.NoError(t, err)
+}
 
 func TestEvalFile(t *testing.T) {
 	t.Parallel()

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -41,7 +40,7 @@ func Compile(ctx context.Context, filePath, source string) (rel.Expr, error) {
 		if filePath == NoPath {
 			dirpath = NoPath
 		} else {
-			dirpath = path.Dir(filePath)
+			dirpath = filepath.Dir(filePath)
 		}
 	}
 	pc := ParseContext{SourceDir: dirpath}
@@ -1051,16 +1050,16 @@ func (pc ParseContext) compilePackage(ctx context.Context, b ast.Branch, c ast.C
 		scanner := pkgpath.One("").(ast.Leaf).Scanner()
 		name := scanner.String()
 		if strings.HasPrefix(name, "/") {
-			filepath := strings.Trim(name, "/")
+			filePath := strings.Trim(name, "/")
 			fromRoot := pkg["dot"] == nil
 			if pc.SourceDir == "" {
 				return nil, fmt.Errorf("local import %q invalid; no local context", name)
 			}
-			importPath := filepath
+			importPath := filepath.Clean(filePath)
 			if !fromRoot {
-				importPath = path.Join(pc.SourceDir, filepath)
+				importPath = filepath.Join(pc.SourceDir, filePath)
 			}
-			expr, err := importLocalFile(ctx, fromRoot, importPath)
+			expr, err := importLocalFile(ctx, fromRoot, importPath, pc.SourceDir)
 			if err != nil {
 				return nil, err
 			}

--- a/syntax/import.go
+++ b/syntax/import.go
@@ -92,7 +92,8 @@ func findRootFromModule(ctx context.Context, modulePath string) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	paths := append(make([]string, 0, len(strings.Split(currentPath, string(os.PathSeparator)))), currentPath)
+	// 16 is enough for pretty much all cases.
+	paths := append(make([]string, 0, 16), currentPath)
 
 	// Keep walking up the directories to find nearest root marker
 	for {

--- a/syntax/import.go
+++ b/syntax/import.go
@@ -18,7 +18,8 @@ import (
 	"github.com/arr-ai/arrai/translate"
 )
 
-const ArraiRootMarker = "go.mod"
+// ModuleRootSentinel is a file which marks the module root of a project.
+const ModuleRootSentinel = "go.mod"
 
 var roots = sync.Map{}
 
@@ -97,7 +98,7 @@ func findRootFromModule(ctx context.Context, modulePath string) (string, error) 
 
 	// Keep walking up the directories to find nearest root marker
 	for {
-		exists, err := tools.FileExists(ctx, filepath.Join(currentPath, ArraiRootMarker))
+		exists, err := tools.FileExists(ctx, filepath.Join(currentPath, ModuleRootSentinel))
 		reachedRoot := currentPath == systemRoot || (err != nil && os.IsPermission(err))
 		switch {
 		case exists:


### PR DESCRIPTION
This commit will allow nested root markers in a project.
Root markers will be found by going up the source directory
of a file. A root marker can be in the same directory or the parent
directories. The root marker locations will also be cached for faster
root marker lookup.

This commit also fixed the root marker lookup as initially it was
done by searching from the provided import path instead of the directory
location of the source scripts.

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
