### PR TITLE
{Set,Tuple}.Map return errors

### DIFF
--- a/rel/expr_tuplemap.go
+++ b/rel/expr_tuplemap.go
@@ -25,24 +25,20 @@ func (e *TupleMapExpr) String() string {
 }
 
 // Eval returns the lhs
-func (e *TupleMapExpr) Eval(ctx context.Context, local Scope) (_ Value, err error) {
+func (e *TupleMapExpr) Eval(ctx context.Context, local Scope) (Value, error) {
 	value, err := e.lhs.Eval(ctx, local)
 	if err != nil {
 		return nil, WrapContextErr(err, e, local)
 	}
-	defer func() {
-		if r := recover(); r != nil {
-			if err == nil {
-				panic(r)
-			}
-		}
-	}()
-	return value.(Tuple).Map(func(v Value) Value {
-		scope, _ := e.fn.arg.Bind(ctx, local, v) //nolint: errcheck
-		v, err = e.fn.body.Eval(ctx, local.Update(scope))
+	return value.(Tuple).Map(func(v Value) (Value, error) {
+		scope, err := e.fn.arg.Bind(ctx, local, v) //nolint: errcheck
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
-		return v
-	}), nil
+		ans, err := e.fn.body.Eval(ctx, local.Update(scope))
+		if err != nil {
+			return nil, err
+		}
+		return ans, nil
+	})
 }

--- a/rel/value.go
+++ b/rel/value.go
@@ -88,7 +88,7 @@ type Tuple interface {
 	// Transform
 	With(name string, value Value) Tuple
 	Without(name string) Tuple
-	Map(func(Value) Value) Tuple
+	Map(func(Value) (Value, error)) (Tuple, error)
 	Project(names Names) Tuple
 }
 
@@ -123,7 +123,7 @@ type Set interface {
 	// Transform
 	With(Value) Set
 	Without(Value) Set
-	Map(func(Value) Value) Set
+	Map(func(Value) (Value, error)) (Set, error)
 	Where(func(Value) (bool, error)) (Set, error)
 	CallAll(context.Context, Value) (Set, error)
 

--- a/rel/value_set_array.go
+++ b/rel/value_set_array.go
@@ -322,12 +322,16 @@ func (a Array) Without(value Value) Set {
 }
 
 // Map maps values per f.
-func (a Array) Map(f func(v Value) Value) Set {
+func (a Array) Map(f func(v Value) (Value, error)) (Set, error) {
 	var values []Value
 	for e := a.Enumerator(); e.MoveNext(); {
-		values = append(values, f(e.Current()))
+		v, err := f(e.Current())
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, v)
 	}
-	return NewSet(values...)
+	return NewSet(values...), nil
 }
 
 // Where returns a new Array with all the Values satisfying predicate p.

--- a/rel/value_set_bytes.go
+++ b/rel/value_set_bytes.go
@@ -212,12 +212,16 @@ func (b Bytes) Without(value Value) Set {
 }
 
 // Map maps values per f.
-func (b Bytes) Map(f func(v Value) Value) Set {
+func (b Bytes) Map(f func(v Value) (Value, error)) (Set, error) {
 	result := NewSet()
 	for e := b.Enumerator(); e.MoveNext(); {
-		result = result.With(f(e.Current()))
+		v, err := f(e.Current())
+		if err != nil {
+			return nil, err
+		}
+		result = result.With(v)
 	}
-	return result
+	return result, nil
 }
 
 // Where returns a new Bytes with all the Values satisfying predicate p.

--- a/rel/value_set_closure.go
+++ b/rel/value_set_closure.go
@@ -116,7 +116,7 @@ func (c Closure) Without(v Value) Set {
 	panic("unimplemented")
 }
 
-func (c Closure) Map(f func(Value) Value) Set {
+func (c Closure) Map(f func(v Value) (Value, error)) (Set, error) {
 	panic("unimplemented")
 }
 

--- a/rel/value_set_dict.go
+++ b/rel/value_set_dict.go
@@ -242,12 +242,16 @@ func (d Dict) Without(v Value) Set {
 	return d
 }
 
-func (d Dict) Map(m func(Value) Value) Set {
+func (d Dict) Map(f func(v Value) (Value, error)) (Set, error) {
 	var sb frozen.SetBuilder
 	for e := d.Enumerator(); e.MoveNext(); {
-		sb.Add(m(e.Current()))
+		v, err := f(e.Current())
+		if err != nil {
+			return nil, err
+		}
+		sb.Add(v)
 	}
-	return GenericSet{set: sb.Finish()}
+	return GenericSet{set: sb.Finish()}, nil
 }
 
 func (d Dict) Where(p func(v Value) (bool, error)) (Set, error) {

--- a/rel/value_set_eclosure.go
+++ b/rel/value_set_eclosure.go
@@ -110,7 +110,7 @@ func (ExprClosure) Without(Value) Set {
 	panic("unimplemented")
 }
 
-func (ExprClosure) Map(func(Value) Value) Set {
+func (ExprClosure) Map(func(Value) (Value, error)) (Set, error) {
 	panic("unimplemented")
 }
 

--- a/rel/value_set_generic.go
+++ b/rel/value_set_generic.go
@@ -265,12 +265,16 @@ func (s GenericSet) Without(value Value) Set {
 }
 
 // Map maps values per f.
-func (s GenericSet) Map(f func(v Value) Value) Set {
+func (s GenericSet) Map(f func(v Value) (Value, error)) (Set, error) {
 	result := NewSet()
 	for e := s.Enumerator(); e.MoveNext(); {
-		result = result.With(f(e.Current()))
+		v, err := f(e.Current())
+		if err != nil {
+			return nil, err
+		}
+		result = result.With(v)
 	}
-	return result
+	return result, nil
 }
 
 // Where returns a new genericSet with all the Values satisfying predicate p.

--- a/rel/value_set_native_func.go
+++ b/rel/value_set_native_func.go
@@ -116,7 +116,7 @@ func (*NativeFunction) Without(Value) Set {
 	panic("unimplemented")
 }
 
-func (*NativeFunction) Map(func(Value) Value) Set {
+func (*NativeFunction) Map(func(Value) (Value, error)) (Set, error) {
 	panic("unimplemented")
 }
 

--- a/rel/value_set_str.go
+++ b/rel/value_set_str.go
@@ -224,12 +224,16 @@ func (s String) Without(value Value) Set {
 }
 
 // Map maps values per f.
-func (s String) Map(f func(v Value) Value) Set {
+func (s String) Map(f func(v Value) (Value, error)) (Set, error) {
 	result := NewSet()
 	for e := s.Enumerator(); e.MoveNext(); {
-		result = result.With(f(e.Current()))
+		v, err := f(e.Current())
+		if err != nil {
+			return nil, err
+		}
+		result = result.With(v)
 	}
-	return result
+	return result, nil
 }
 
 // Where returns a new String with all the Values satisfying predicate p.

--- a/rel/value_set_test.go
+++ b/rel/value_set_test.go
@@ -12,7 +12,9 @@ import (
 func TestAsString(t *testing.T) {
 	t.Parallel()
 
-	generic := NewString([]rune("this is a test")).Map(func(v Value) Value { return v })
+	generic, err := NewString([]rune("this is a test")).Map(func(v Value) (Value, error) { return v, nil })
+	require.NoError(t, err)
+
 	stringified, isString := AsString(generic)
 	require.True(t, isString)
 	assert.True(t, stringified.Equal(NewString([]rune("this is a test"))), stringified.String())

--- a/rel/value_tuple.go
+++ b/rel/value_tuple.go
@@ -331,13 +331,17 @@ func (t *GenericTuple) Without(name string) Tuple {
 	return &GenericTuple{tuple: t.tuple.Without(frozen.NewSet(name))}
 }
 
-func (t *GenericTuple) Map(f func(Value) Value) Tuple {
+func (t *GenericTuple) Map(f func(Value) (Value, error)) (Tuple, error) {
 	var b frozen.MapBuilder
 	for e := t.Enumerator(); e.MoveNext(); {
 		key, value := e.Current()
-		b.Put(key, f(value))
+		v, err := f(value)
+		if err != nil {
+			return nil, err
+		}
+		b.Put(key, v)
 	}
-	return &GenericTuple{tuple: b.Finish()}
+	return &GenericTuple{tuple: b.Finish()}, nil
 }
 
 // HasName returns true iff the Tuple has an attribute with the given name.

--- a/rel/value_tuple_array_item.go
+++ b/rel/value_tuple_array_item.go
@@ -157,12 +157,18 @@ func (t ArrayItemTuple) Without(name string) Tuple {
 	return t
 }
 
-func (t ArrayItemTuple) Map(f func(Value) Value) Tuple {
-	at := f(NewNumber(float64(t.at)))
-	item := f(t.item)
+func (t ArrayItemTuple) Map(f func(Value) (Value, error)) (Tuple, error) {
+	at, err := f(NewNumber(float64(t.at)))
+	if err != nil {
+		return nil, err
+	}
+	item, err := f(t.item)
+	if err != nil {
+		return nil, err
+	}
 	if at, ok := at.(Number); ok {
 		if at, is := at.Int(); is {
-			return NewArrayItemTuple(at, item)
+			return NewArrayItemTuple(at, item), nil
 		}
 	}
 	return t.asGenericTuple().Map(f)

--- a/rel/value_tuple_array_item_test.go
+++ b/rel/value_tuple_array_item_test.go
@@ -229,9 +229,11 @@ func TestArrayItemTuple_Without(t *testing.T) {
 
 func TestArrayItemTuple_Map(t *testing.T) {
 	t.Parallel()
-	assert.True(t, NewArrayItemTuple(1, NewNumber(10)).Map(func(v Value) Value {
-		return NewNumber(v.(Number).Float64() + 1)
-	}).Equal(NewArrayItemTuple(2, NewNumber(11))))
+	m, err := NewArrayItemTuple(1, NewNumber(10)).Map(func(v Value) (Value, error) {
+		return NewNumber(v.(Number).Float64() + 1), nil
+	})
+	require.NoError(t, err)
+	assert.True(t, m.Equal(NewArrayItemTuple(2, NewNumber(11))))
 }
 
 func TestArrayItemTuple_HasName(t *testing.T) {

--- a/rel/value_tuple_bytes_byte.go
+++ b/rel/value_tuple_bytes_byte.go
@@ -158,14 +158,20 @@ func (t BytesByteTuple) Without(name string) Tuple {
 	return t
 }
 
-func (t BytesByteTuple) Map(f func(Value) Value) Tuple {
-	at := f(NewNumber(float64(t.at)))
-	byteval := f(NewNumber(float64(t.byteval)))
+func (t BytesByteTuple) Map(f func(Value) (Value, error)) (Tuple, error) { //nolint:dupl
+	at, err := f(NewNumber(float64(t.at)))
+	if err != nil {
+		return nil, err
+	}
+	byteval, err := f(NewNumber(float64(t.byteval)))
+	if err != nil {
+		return nil, err
+	}
 	if at, ok := at.(Number); ok {
 		if at, is := at.Int(); is {
 			if byteval, ok := byteval.(Number); ok {
 				if byteval, is := byteval.Int(); is {
-					return NewBytesByteTuple(at, byte(byteval))
+					return NewBytesByteTuple(at, byte(byteval)), nil
 				}
 			}
 		}

--- a/rel/value_tuple_bytes_byte_test.go
+++ b/rel/value_tuple_bytes_byte_test.go
@@ -234,12 +234,11 @@ func TestBytesByteTuple_Without(t *testing.T) {
 
 func TestBytesByteTuple_Map(t *testing.T) {
 	t.Parallel()
-	AssertEqualValues(t,
-		NewBytesByteTuple(2, 'b'),
-		NewBytesByteTuple(1, 'a').Map(func(v Value) Value {
-			return NewNumber(v.(Number).Float64() + 1)
-		}),
-	)
+	m, err := NewBytesByteTuple(1, 'a').Map(func(v Value) (Value, error) {
+		return NewNumber(v.(Number).Float64() + 1), nil
+	})
+	require.NoError(t, err)
+	AssertEqualValues(t, NewBytesByteTuple(2, 'b'), m)
 }
 
 func TestBytesByteTuple_HasName(t *testing.T) {

--- a/rel/value_tuple_dict_entry.go
+++ b/rel/value_tuple_dict_entry.go
@@ -155,8 +155,17 @@ func (t DictEntryTuple) Without(name string) Tuple {
 	return t
 }
 
-func (t DictEntryTuple) Map(f func(Value) Value) Tuple {
-	return NewDictEntryTuple(f(t.at), f(t.value))
+func (t DictEntryTuple) Map(f func(Value) (Value, error)) (Tuple, error) {
+	at, err := f(t.at)
+	if err != nil {
+		return nil, err
+	}
+	value, err := f(t.value)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewDictEntryTuple(at, value), nil
 }
 
 // HasName returns true iff the Tuple has an attribute with the given name.

--- a/rel/value_tuple_str_char.go
+++ b/rel/value_tuple_str_char.go
@@ -155,14 +155,20 @@ func (t StringCharTuple) Without(name string) Tuple {
 	return t
 }
 
-func (t StringCharTuple) Map(f func(Value) Value) Tuple {
-	at := f(NewNumber(float64(t.at)))
-	char := f(NewNumber(float64(t.char)))
+func (t StringCharTuple) Map(f func(Value) (Value, error)) (Tuple, error) { //nolint:dupl
+	at, err := f(NewNumber(float64(t.at)))
+	if err != nil {
+		return nil, err
+	}
+	char, err := f(NewNumber(float64(t.char)))
+	if err != nil {
+		return nil, err
+	}
 	if at, ok := at.(Number); ok {
 		if at, is := at.Int(); is {
 			if char, ok := char.(Number); ok {
 				if char, is := char.Int(); is {
-					return NewStringCharTuple(at, rune(char))
+					return NewStringCharTuple(at, rune(char)), nil
 				}
 			}
 		}

--- a/rel/value_tuple_str_char_test.go
+++ b/rel/value_tuple_str_char_test.go
@@ -229,11 +229,13 @@ func TestStringCharTuple_Without(t *testing.T) {
 
 func TestStringCharTuple_Map(t *testing.T) {
 	t.Parallel()
+	m, err := NewStringCharTuple(1, 'a').Map(func(v Value) (Value, error) {
+		return NewNumber(v.(Number).Float64() + 1), nil
+	})
+	require.NoError(t, err)
 	AssertEqualValues(t,
 		NewStringCharTuple(2, 'b'),
-		NewStringCharTuple(1, 'a').Map(func(v Value) Value {
-			return NewNumber(v.(Number).Float64() + 1)
-		}),
+		m,
 	)
 }
 

--- a/syntax/expr_import.go
+++ b/syntax/expr_import.go
@@ -15,7 +15,11 @@ type ImportExpr struct {
 }
 
 func NewImportExpr(scanner parser.Scanner, imported rel.Expr, path string) ImportExpr {
-	return ImportExpr{rel.ExprScanner{scanner}, NewPackageExpr(scanner, imported), path}
+	return ImportExpr{
+		ExprScanner: rel.ExprScanner{Src: scanner},
+		packageExpr: NewPackageExpr(scanner, imported),
+		path:        path,
+	}
 }
 
 func (i ImportExpr) Eval(ctx context.Context, _ rel.Scope) (rel.Value, error) {


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- {Set,Tuple}.Map signatures changed to allow for errors to propagate normally.
- 

Checklist:
- [ ] Added related tests
- [ ] Made corresponding changes to the documentation
