### PR TITLE
Fix CI: remove deprecated lint config, bump Node and Go versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Uses Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Install yarn
         run: npm install -g yarn

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,13 +13,13 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
+        go-version: "1.24"
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
 
     - name: Get dependencies
-      run: go get -v -t -d ./...
+      run: go mod download
 
     - name: Build
       run: GOOS=js GOARCH=wasm go build -o arrai.wasm ./cmd/arrai
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 20.x
 
     - name: Run tests
       run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -38,7 +38,7 @@ jobs:
         echo '**** env'
         env
         echo '**** node'
-        node $(go env GOROOT)/misc/wasm/wasm_exec_node.js arrai.wasm eval '1 + 5'
+        node $(go env GOROOT)/lib/wasm/wasm_exec_node.js arrai.wasm eval '1 + 5'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_AUTH_TOKEN: "SOME-RANDOM-KEY"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,10 +4,6 @@ run:
 linters-settings:
   errcheck:
     check-blank: true
-  govet:
-    check-shadowing: false
-  revive:
-    min-confidence: 0
   dupl:
     threshold: 100
   lll:


### PR DESCRIPTION
- Remove govet.check-shadowing and revive.min-confidence (removed in
  golangci-lint v1.64)
- Bump docs workflow Node from 18.x to 20.x (Docusaurus 3.9 requires it)
- Bump wasm workflow Go from 1.21 to 1.24 and Node to 20.x, replace
  deprecated go get with go mod download

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
