### PR TITLE
Set v0.336.0 audit log commit hash

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -5,7 +5,7 @@ maintenance activities. Append-only — newest entries at the bottom.
 
 ## 2026-04-11 — /release v0.336.0
 
-- **Commit**: `pending`
+- **Commit**: `d42bbc8`
 - **Outcome**: Released v0.336.0 (darwin-arm64, linux-amd64, linux-arm64). Ships the lodash code-injection CVE fix (GHSA-r5fr-rjxr-66jc) for the docs site dependency tree.
 - **Deferred**:
   - 🎯T5 docs/ npm audit is clean — 22 transitive advisories remain in Docusaurus 3.9.2's dep tree (serialize-javascript, picomatch, brace-expansion, path-to-regexp). Tracked as a target; addressed separately via surgical overrides.


### PR DESCRIPTION
## Summary

Rewrites the `Commit: pending` placeholder in the v0.336.0 audit log entry to the real squash-merge hash `d42bbc8` from #708.

Docs-only follow-up; standard second-PR pattern for the audit-log chicken-and-egg.

## Test plan

- [ ] CI passes (docs-only change, should be trivial)
- [ ] Merge, then tag `v0.336.0` for goreleaser

🤖 Generated with [Claude Code](https://claude.com/claude-code)