### PR TITLE
Avoid frozen panic in Reduce by keying bucket values as Value, not any

### DIFF
--- a/rel/ops_rel.go
+++ b/rel/ops_rel.go
@@ -130,17 +130,17 @@ func Reduce(
 	getKey func(value Value) Value,
 	reduce func(key Value, tuples Set) Set,
 ) Set {
-	var buckets frozen.Map[Value, any]
+	var buckets frozen.Map[Value, Value]
 	for e := a.Enumerator(); e.MoveNext(); {
 		value := e.Current()
 		key := getKey(value)
 
-		slot, found := buckets.Get(key)
-		if !found {
-			slot = None
+		var slot Set = None
+		if v, found := buckets.Get(key); found {
+			slot = v.(Set)
 		}
 
-		slot = slot.(Set).With(value)
+		slot = slot.With(value)
 		buckets = buckets.With(key, slot)
 	}
 

--- a/rel/ops_rel.go
+++ b/rel/ops_rel.go
@@ -135,7 +135,7 @@ func Reduce(
 		value := e.Current()
 		key := getKey(value)
 
-		var slot Set = None
+		var slot = None
 		if v, found := buckets.Get(key); found {
 			slot = v.(Set)
 		}

--- a/rel/ops_rel_reduce_test.go
+++ b/rel/ops_rel_reduce_test.go
@@ -2,6 +2,8 @@ package rel
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var testNestData = intPairs("a", "b", []intPair{
@@ -104,4 +106,36 @@ func TestNestBThenA(t *testing.T) {
 			"g",
 		),
 	)
+}
+
+// TestNestManyRowsPerGroup grows each group well past the point where
+// Reduce's internal bucket Set canonicalizes into a Relation (which embeds a
+// slice and a map, so its zero value is not comparable with Go's ==).
+// Reduce accumulates each group in a frozen.Map[Value, Value]; every row
+// added to an existing key replaces that bucket's value, and frozen's
+// Map.With compares old vs. new values to skip no-op writes. Using Value
+// (rather than a bare `any`) as the bucket's value type lets frozen dispatch
+// that comparison to Relation.Equal (Value satisfies frozen.Key[Value]),
+// instead of falling back to `==`, which would panic once a group's
+// accumulated Set became a Relation. See github.com/arr-ai/frozen#97.
+func TestNestManyRowsPerGroup(t *testing.T) {
+	t.Parallel()
+
+	const groups, groupSize = 3, 50
+	pairs := make([]intPair, 0, groups*groupSize)
+	for a := 0; a < groups; a++ {
+		for b := 0; b < groupSize; b++ {
+			pairs = append(pairs, intPair{a, b})
+		}
+	}
+	data := intPairs("a", "b", pairs...)
+
+	nested := Nest(data, NewNames("a", "b"), NewNames("b"), "g")
+	require.Equal(t, groups, nested.Count())
+	for e := nested.Enumerator(); e.MoveNext(); {
+		tuple := e.Current().(Tuple)
+		g, has := tuple.Get("g")
+		require.True(t, has)
+		require.Equal(t, groupSize, g.(Set).Count())
+	}
 }


### PR DESCRIPTION
## Summary
- `Reduce` (used by `Nest`, `SingleAttrNest`, and `Unnest`) accumulates each group in a `frozen.Map[Value, any]`. Every row added to an existing key replaces that bucket's value, and frozen's `Map.With` compares the old and new value to decide whether it can skip a no-op write.
- With `V = any`, frozen has no way to dispatch that comparison to `Relation.Equal` (`Equaler[any]` requires an `Equal(any) bool` method, which `Relation` doesn't have), so it fell back to a bare `==`. That panics with `comparing uncomparable type rel.Relation` once a group's accumulated `Set` canonicalizes into a `Relation` (which embeds a slice and a map, so it isn't comparable with `==`) — i.e. as soon as a nest/group-by key collides more than a couple of times.
- `Value` already satisfies `frozen.Key[Value]` (`Equal(Value) bool`), so switching the bucket map to `frozen.Map[Value, Value]` lets frozen dispatch straight to the real `Equal` method — no reflection, no fallback, and the no-op-write optimization actually works here instead of always taking the write path.
- This pairs with arr-ai/frozen#97, which hardens the same fallback in frozen so it can never panic regardless of a caller's type parameters. This PR removes the only place in this repo that was relying on the now-hardened but still slower fallback path.

## Repro (panics on current master's `Reduce`, given a frozen version with the eqV no-op-write check)
```go
const groups, groupSize = 3, 50
// ... build `groups` distinct keys, each with `groupSize` duplicate rows ...
Nest(data, NewNames("a", "b"), NewNames("b"), "g") // panics once a group's bucket Set becomes a Relation
```

## Test plan
- [x] Added `TestNestManyRowsPerGroup`, which grows groups well past the point where the bucket `Set` becomes a `Relation`
- [x] Verified this new test panics with `comparing uncomparable type rel.Relation` when `Reduce` is reverted to `frozen.Map[Value, any]` and run against a frozen build carrying the bug fixed by arr-ai/frozen#97; passes with this change against both that build and the currently pinned frozen v1.11.0
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)