### PR TITLE
Honor go.mod-pinned versions (and replace) for module imports

### DIFF
--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -1335,7 +1335,7 @@ func (pc ParseContext) compilePackage(ctx context.Context, b ast.Branch, c ast.C
 			}
 			return NewImportExpr(scanner, expr, importPath), nil
 		}
-		expr, err := importExternalContent(ctx, pkg.Scanner(), decoderTuple, name)
+		expr, err := importExternalContent(ctx, pkg.Scanner(), decoderTuple, name, pc.SourceDir)
 		if err != nil {
 			return nil, err
 		}

--- a/syntax/gomod.go
+++ b/syntax/gomod.go
@@ -1,10 +1,13 @@
 package syntax
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
+	"sync"
 )
 
 // goModule holds the result of `go mod download -json`.
@@ -20,11 +23,74 @@ func extractVersion(path string) (module, version string) {
 	return
 }
 
+var (
+	requiredModuleVersionsOnce sync.Once
+	requiredModuleVersions     map[string]string
+)
+
+// requiredModuleVersionOf returns the version already pinned for importPath (or
+// an ancestor package path of it) in the enclosing project's go.mod/go.sum, as
+// reported by `go list -m -json all`. It returns false if the enclosing
+// project has no go.mod, or no such requirement exists.
+func requiredModuleVersionOf(importPath string) (modPath, version string, ok bool) {
+	requiredModuleVersionsOnce.Do(func() {
+		requiredModuleVersions = loadRequiredModuleVersions()
+	})
+	for path, ver := range requiredModuleVersions {
+		if (path == importPath || strings.HasPrefix(importPath, path+"/")) && len(path) > len(modPath) {
+			modPath, version, ok = path, ver, true
+		}
+	}
+	return
+}
+
+// loadRequiredModuleVersions runs `go list -m -json all` in the working
+// directory and returns the versions already required by its go.mod, keyed
+// by module path. It returns an empty map if there is no enclosing module or
+// the module graph can't be resolved.
+func loadRequiredModuleVersions() map[string]string {
+	versions := map[string]string{}
+	cmd := exec.Command("go", "list", "-m", "-json", "all") //nolint:gosec
+	out, err := cmd.Output()
+	if err != nil {
+		return versions
+	}
+	dec := json.NewDecoder(bytes.NewReader(out))
+	for {
+		var m struct {
+			Path    string
+			Version string
+			Main    bool
+		}
+		if err := dec.Decode(&m); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return versions
+		}
+		if !m.Main && m.Version != "" {
+			versions[m.Path] = m.Version
+		}
+	}
+	return versions
+}
+
 // retrieveModule downloads a Go module and returns its local directory.
-// Since importPath may include a file path within the module (e.g.
-// "github.com/org/repo/file.arrai"), it tries progressively shorter
-// prefixes until it finds a valid module.
+// If the enclosing project's go.mod already requires a module matching
+// importPath, that pinned version is used. Otherwise, since importPath may
+// include a file path within the module (e.g. "github.com/org/repo/file.arrai"),
+// it tries progressively shorter prefixes at the given version (or "latest"
+// when none is given) until it finds a valid module.
 func retrieveModule(importPath, version string) (*goModule, error) {
+	if version == "" {
+		if modPath, pinned, ok := requiredModuleVersionOf(importPath); ok {
+			if m, err := downloadModule(modPath, pinned); err == nil {
+				return m, nil
+			}
+			// Fall through to latest-version resolution below.
+		}
+	}
+
 	modPath := importPath
 	var lastErr error
 	for {
@@ -32,23 +98,9 @@ func retrieveModule(importPath, version string) (*goModule, error) {
 		if len(parts) < 3 {
 			break
 		}
-		arg := modPath
-		if version != "" {
-			arg += "@" + version
-		} else {
-			arg += "@latest"
-		}
-		cmd := exec.Command("go", "mod", "download", "-json", arg) //nolint:gosec
-		out, err := cmd.Output()
+		m, err := downloadModule(modPath, version)
 		if err == nil {
-			var result struct {
-				Path string `json:"Path"`
-				Dir  string `json:"Dir"`
-			}
-			if err := json.Unmarshal(out, &result); err != nil {
-				return nil, fmt.Errorf("go mod download %s: parsing output: %w", arg, err)
-			}
-			return &goModule{Name: result.Path, Dir: result.Dir}, nil
+			return m, nil
 		}
 		lastErr = err
 		modPath = strings.Join(parts[:len(parts)-1], "/")
@@ -60,4 +112,28 @@ func retrieveModule(importPath, version string) (*goModule, error) {
 		return nil, fmt.Errorf("go mod download %s: %w", importPath, lastErr)
 	}
 	return nil, fmt.Errorf("go mod download %s: module not found", importPath)
+}
+
+// downloadModule runs `go mod download -json` for modPath at version (or
+// "latest" if version is empty) and returns the resulting module info.
+func downloadModule(modPath, version string) (*goModule, error) {
+	arg := modPath
+	if version != "" {
+		arg += "@" + version
+	} else {
+		arg += "@latest"
+	}
+	cmd := exec.Command("go", "mod", "download", "-json", arg) //nolint:gosec
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		Path string `json:"Path"`
+		Dir  string `json:"Dir"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("go mod download %s: parsing output: %w", arg, err)
+	}
+	return &goModule{Name: result.Path, Dir: result.Dir}, nil
 }

--- a/syntax/gomod.go
+++ b/syntax/gomod.go
@@ -10,10 +10,17 @@ import (
 	"sync"
 )
 
-// goModule holds the result of `go mod download -json`.
+// goModule holds the result of module resolution (from go list or go mod download).
 type goModule struct {
 	Name string
 	Dir  string
+}
+
+// requiredModule is one entry from `go list -m -json all` for a non-main module.
+type requiredModule struct {
+	Path    string
+	Version string
+	Dir     string // effective directory (honours replace)
 }
 
 // extractVersion splits "module@version" into ("module", "version").
@@ -23,69 +30,106 @@ func extractVersion(path string) (module, version string) {
 	return
 }
 
-var (
-	requiredModuleVersionsOnce sync.Once
-	requiredModuleVersions     map[string]string
-)
+// requiredModulesByRoot caches `go list -m -json all` results keyed by module root
+// directory (empty string = process working directory).
+var requiredModulesByRoot sync.Map // map[string]map[string]requiredModule
 
-// requiredModuleVersionOf returns the version already pinned for importPath (or
-// an ancestor package path of it) in the enclosing project's go.mod/go.sum, as
-// reported by `go list -m -json all`. It returns false if the enclosing
-// project has no go.mod, or no such requirement exists.
-func requiredModuleVersionOf(importPath string) (modPath, version string, ok bool) {
-	requiredModuleVersionsOnce.Do(func() {
-		requiredModuleVersions = loadRequiredModuleVersions()
-	})
-	for path, ver := range requiredModuleVersions {
-		if (path == importPath || strings.HasPrefix(importPath, path+"/")) && len(path) > len(modPath) {
-			modPath, version, ok = path, ver, true
-		}
-	}
-	return
+// resetRequiredModulesCache clears the memoized go.mod graphs. Tests only.
+func resetRequiredModulesCache() {
+	requiredModulesByRoot = sync.Map{}
 }
 
-// loadRequiredModuleVersions runs `go list -m -json all` in the working
-// directory and returns the versions already required by its go.mod, keyed
-// by module path. It returns an empty map if there is no enclosing module or
-// the module graph can't be resolved.
-func loadRequiredModuleVersions() map[string]string {
-	versions := map[string]string{}
+// requiredModuleOf returns the longest-prefix module matching importPath from
+// the go.mod graph rooted at moduleRoot. Dir is the effective module directory
+// (including replace targets) when go list reported one.
+func requiredModuleOf(moduleRoot, importPath string) (requiredModule, bool) {
+	mods := loadRequiredModules(moduleRoot)
+	var best requiredModule
+	found := false
+	for path, mod := range mods {
+		if path == importPath || strings.HasPrefix(importPath, path+"/") {
+			if !found || len(path) > len(best.Path) {
+				best, found = mod, true
+			}
+		}
+	}
+	return best, found
+}
+
+// loadRequiredModules runs `go list -m -json all` in moduleRoot (or the process
+// cwd when moduleRoot is empty) and returns modules keyed by path. Results are
+// memoized per moduleRoot. Returns an empty map if there is no enclosing module
+// or the module graph can't be resolved.
+func loadRequiredModules(moduleRoot string) map[string]requiredModule {
+	if cached, ok := requiredModulesByRoot.Load(moduleRoot); ok {
+		return cached.(map[string]requiredModule) //nolint:forcetypeassert
+	}
+
+	mods := map[string]requiredModule{}
 	cmd := exec.Command("go", "list", "-m", "-json", "all") //nolint:gosec
+	if moduleRoot != "" {
+		cmd.Dir = moduleRoot
+	}
 	out, err := cmd.Output()
 	if err != nil {
-		return versions
+		requiredModulesByRoot.Store(moduleRoot, mods)
+		return mods
 	}
 	dec := json.NewDecoder(bytes.NewReader(out))
 	for {
 		var m struct {
 			Path    string
 			Version string
+			Dir     string
 			Main    bool
+			Replace *struct {
+				Path string
+				Dir  string
+			}
 		}
 		if err := dec.Decode(&m); err != nil {
 			if err == io.EOF {
 				break
 			}
-			return versions
+			requiredModulesByRoot.Store(moduleRoot, mods)
+			return mods
 		}
-		if !m.Main && m.Version != "" {
-			versions[m.Path] = m.Version
+		if m.Main {
+			continue
+		}
+		dir := m.Dir
+		if m.Replace != nil && m.Replace.Dir != "" {
+			dir = m.Replace.Dir
+		}
+		if m.Path != "" {
+			mods[m.Path] = requiredModule{Path: m.Path, Version: m.Version, Dir: dir}
 		}
 	}
-	return versions
+	requiredModulesByRoot.Store(moduleRoot, mods)
+	return mods
 }
 
-// retrieveModule downloads a Go module and returns its local directory.
-// If the enclosing project's go.mod already requires a module matching
-// importPath, that pinned version is used. Otherwise, since importPath may
-// include a file path within the module (e.g. "github.com/org/repo/file.arrai"),
-// it tries progressively shorter prefixes at the given version (or "latest"
-// when none is given) until it finds a valid module.
-func retrieveModule(importPath, version string) (*goModule, error) {
+// seedRequiredModules marks the memoized go.mod graph for moduleRoot as already
+// loaded. Tests only.
+func seedRequiredModules(moduleRoot string, mods map[string]requiredModule) {
+	requiredModulesByRoot.Store(moduleRoot, mods)
+}
+
+// retrieveModule resolves importPath to a local module directory.
+// moduleRoot is the importing project's go.mod directory (may be empty to use
+// the process working directory). If that go.mod already requires a matching
+// module, its pinned version and effective Dir (honouring replace) are used.
+// Otherwise importPath prefixes are tried at the given version (or "latest").
+func retrieveModule(importPath, version, moduleRoot string) (*goModule, error) {
 	if version == "" {
-		if modPath, pinned, ok := requiredModuleVersionOf(importPath); ok {
-			if m, err := downloadModule(modPath, pinned); err == nil {
-				return m, nil
+		if pinned, ok := requiredModuleOf(moduleRoot, importPath); ok {
+			if pinned.Dir != "" {
+				return &goModule{Name: pinned.Path, Dir: pinned.Dir}, nil
+			}
+			if pinned.Version != "" {
+				if m, err := downloadModule(pinned.Path, pinned.Version); err == nil {
+					return m, nil
+				}
 			}
 			// Fall through to latest-version resolution below.
 		}

--- a/syntax/gomod_test.go
+++ b/syntax/gomod_test.go
@@ -3,106 +3,137 @@ package syntax
 import (
 	"os"
 	"os/exec"
-	"sync"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// withTempModule creates a temporary Go module with the given go.mod content,
-// chdirs into it for the duration of the test, and resets the memoized
-// requiredModuleVersions cache so each test resolves its own go.mod.
-func withTempModule(t *testing.T, goModContent string) {
+// withTempModule creates a temporary Go module with the given go.mod content
+// and returns its absolute path. Clears the memoized module-graph cache so
+// each test resolves its own go.mod.
+func withTempModule(t *testing.T, goModContent string) string {
 	t.Helper()
 
 	dir := t.TempDir()
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { require.NoError(t, os.Chdir(wd)) })
-
-	require.NoError(t, os.WriteFile("go.mod", []byte(goModContent), 0o600))
-
-	requiredModuleVersionsOnce = sync.Once{}
-	t.Cleanup(func() { requiredModuleVersionsOnce = sync.Once{} })
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goModContent), 0o600))
+	resetRequiredModulesCache()
+	t.Cleanup(resetRequiredModulesCache)
+	return dir
 }
 
 func TestRetrieveModuleUsesGoModPinnedVersion(t *testing.T) {
-	// DO NOT t.Parallel(): mutates the process working directory and the
-	// package-level requiredModuleVersions cache.
-
-	withTempModule(t, `module example.com/pintest
+	root := withTempModule(t, `module example.com/pintest
 
 go 1.21
 
 require github.com/pkg/errors v0.8.0
 `)
 
-	out, err := exec.Command("go", "mod", "download", "github.com/pkg/errors").CombinedOutput()
+	cmd := exec.Command("go", "mod", "download", "github.com/pkg/errors")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
-	m, err := retrieveModule("github.com/pkg/errors", "")
+	// Force a fresh go list against this module root (download above may not
+	// populate Dir until list runs in-module).
+	resetRequiredModulesCache()
+
+	m, err := retrieveModule("github.com/pkg/errors", "", root)
 	require.NoError(t, err)
 	require.Equal(t, "github.com/pkg/errors", m.Name)
 	require.Contains(t, m.Dir, "github.com/pkg/errors@v0.8.0")
 }
 
-func TestRetrieveModuleFallsBackWithoutPin(t *testing.T) {
-	// DO NOT t.Parallel(): mutates the process working directory and the
-	// package-level requiredModuleVersions cache.
+func TestRetrieveModuleHonoursReplaceDir(t *testing.T) {
+	root := withTempModule(t, `module example.com/pintest
 
-	withTempModule(t, `module example.com/pintest
+go 1.21
+
+require github.com/pkg/errors v0.8.0
+
+replace github.com/pkg/errors => ./errors-fork
+`)
+
+	fork := filepath.Join(root, "errors-fork")
+	require.NoError(t, os.MkdirAll(fork, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(fork, "go.mod"), []byte("module github.com/pkg/errors\n\ngo 1.21\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(fork, "errors.go"), []byte("package errors\n"), 0o600))
+
+	resetRequiredModulesCache()
+
+	m, err := retrieveModule("github.com/pkg/errors", "", root)
+	require.NoError(t, err)
+	require.Equal(t, "github.com/pkg/errors", m.Name)
+	require.Equal(t, fork, m.Dir)
+}
+
+func TestRetrieveModuleUsesModuleRootNotCwd(t *testing.T) {
+	root := withTempModule(t, `module example.com/pintest
+
+go 1.21
+
+require github.com/pkg/errors v0.8.0
+`)
+
+	cmd := exec.Command("go", "mod", "download", "github.com/pkg/errors")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	resetRequiredModulesCache()
+
+	// Resolve while cwd is elsewhere — must still see the pin under root.
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	elsewhere := t.TempDir()
+	require.NoError(t, os.Chdir(elsewhere))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(wd)) })
+
+	m, err := retrieveModule("github.com/pkg/errors", "", root)
+	require.NoError(t, err)
+	require.Contains(t, m.Dir, "github.com/pkg/errors@v0.8.0")
+}
+
+func TestRetrieveModuleFallsBackWithoutPin(t *testing.T) {
+	root := withTempModule(t, `module example.com/pintest
 
 go 1.21
 `)
 
-	m, err := retrieveModule("github.com/arr-ai/arrai-import-tests", "")
+	m, err := retrieveModule("github.com/arr-ai/arrai-import-tests", "", root)
 	require.NoError(t, err)
 	require.Equal(t, "github.com/arr-ai/arrai-import-tests", m.Name)
 	require.NotEmpty(t, m.Dir)
 }
 
-// seedRequiredModuleVersions marks the memoized go.mod graph as already
-// loaded with the given contents, so requiredModuleVersionOf uses it instead
-// of shelling out to `go list -m -json all`.
-func seedRequiredModuleVersions(t *testing.T, versions map[string]string) {
-	t.Helper()
-
-	requiredModuleVersions = versions
-	requiredModuleVersionsOnce = sync.Once{}
-	requiredModuleVersionsOnce.Do(func() {})
-	t.Cleanup(func() {
-		requiredModuleVersions = nil
-		requiredModuleVersionsOnce = sync.Once{}
-	})
-}
-
-func TestRequiredModuleVersionOfMatchesLongestPrefix(t *testing.T) {
-	seedRequiredModuleVersions(t, map[string]string{
-		"github.com/org/repo":     "v1.0.0",
-		"github.com/org/repo/sub": "v2.0.0",
+func TestRequiredModuleOfMatchesLongestPrefix(t *testing.T) {
+	resetRequiredModulesCache()
+	t.Cleanup(resetRequiredModulesCache)
+	seedRequiredModules("", map[string]requiredModule{
+		"github.com/org/repo":     {Path: "github.com/org/repo", Version: "v1.0.0", Dir: "/mod/repo@v1.0.0"},
+		"github.com/org/repo/sub": {Path: "github.com/org/repo/sub", Version: "v2.0.0", Dir: "/mod/sub@v2.0.0"},
 	})
 
-	modPath, version, ok := requiredModuleVersionOf("github.com/org/repo/sub/file.arrai")
+	mod, ok := requiredModuleOf("", "github.com/org/repo/sub/file.arrai")
 	require.True(t, ok)
-	require.Equal(t, "github.com/org/repo/sub", modPath)
-	require.Equal(t, "v2.0.0", version)
+	require.Equal(t, "github.com/org/repo/sub", mod.Path)
+	require.Equal(t, "v2.0.0", mod.Version)
+	require.Equal(t, "/mod/sub@v2.0.0", mod.Dir)
 
-	modPath, version, ok = requiredModuleVersionOf("github.com/org/repo/file.arrai")
+	mod, ok = requiredModuleOf("", "github.com/org/repo/file.arrai")
 	require.True(t, ok)
-	require.Equal(t, "github.com/org/repo", modPath)
-	require.Equal(t, "v1.0.0", version)
+	require.Equal(t, "github.com/org/repo", mod.Path)
 
-	_, _, ok = requiredModuleVersionOf("github.com/other/repo/file.arrai")
+	_, ok = requiredModuleOf("", "github.com/other/repo/file.arrai")
 	require.False(t, ok)
 }
 
 func TestRetrieveModuleWithInvalidPath(t *testing.T) {
-	// No network access needed: an empty cache means there's nothing pinned,
-	// and the path is too short to ever look like a valid module.
-	seedRequiredModuleVersions(t, map[string]string{})
+	resetRequiredModulesCache()
+	t.Cleanup(resetRequiredModulesCache)
+	seedRequiredModules("", map[string]requiredModule{})
 
-	m, err := retrieveModule("wrong_file_path/deps.arrai", "")
+	m, err := retrieveModule("wrong_file_path/deps.arrai", "", "")
 	require.Error(t, err)
 	require.Nil(t, m)
 }

--- a/syntax/gomod_test.go
+++ b/syntax/gomod_test.go
@@ -1,0 +1,108 @@
+package syntax
+
+import (
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// withTempModule creates a temporary Go module with the given go.mod content,
+// chdirs into it for the duration of the test, and resets the memoized
+// requiredModuleVersions cache so each test resolves its own go.mod.
+func withTempModule(t *testing.T, goModContent string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(wd)) })
+
+	require.NoError(t, os.WriteFile("go.mod", []byte(goModContent), 0o600))
+
+	requiredModuleVersionsOnce = sync.Once{}
+	t.Cleanup(func() { requiredModuleVersionsOnce = sync.Once{} })
+}
+
+func TestRetrieveModuleUsesGoModPinnedVersion(t *testing.T) {
+	// DO NOT t.Parallel(): mutates the process working directory and the
+	// package-level requiredModuleVersions cache.
+
+	withTempModule(t, `module example.com/pintest
+
+go 1.21
+
+require github.com/pkg/errors v0.8.0
+`)
+
+	out, err := exec.Command("go", "mod", "download", "github.com/pkg/errors").CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	m, err := retrieveModule("github.com/pkg/errors", "")
+	require.NoError(t, err)
+	require.Equal(t, "github.com/pkg/errors", m.Name)
+	require.Contains(t, m.Dir, "github.com/pkg/errors@v0.8.0")
+}
+
+func TestRetrieveModuleFallsBackWithoutPin(t *testing.T) {
+	// DO NOT t.Parallel(): mutates the process working directory and the
+	// package-level requiredModuleVersions cache.
+
+	withTempModule(t, `module example.com/pintest
+
+go 1.21
+`)
+
+	m, err := retrieveModule("github.com/arr-ai/arrai-import-tests", "")
+	require.NoError(t, err)
+	require.Equal(t, "github.com/arr-ai/arrai-import-tests", m.Name)
+	require.NotEmpty(t, m.Dir)
+}
+
+// seedRequiredModuleVersions marks the memoized go.mod graph as already
+// loaded with the given contents, so requiredModuleVersionOf uses it instead
+// of shelling out to `go list -m -json all`.
+func seedRequiredModuleVersions(t *testing.T, versions map[string]string) {
+	t.Helper()
+
+	requiredModuleVersions = versions
+	requiredModuleVersionsOnce = sync.Once{}
+	requiredModuleVersionsOnce.Do(func() {})
+	t.Cleanup(func() {
+		requiredModuleVersions = nil
+		requiredModuleVersionsOnce = sync.Once{}
+	})
+}
+
+func TestRequiredModuleVersionOfMatchesLongestPrefix(t *testing.T) {
+	seedRequiredModuleVersions(t, map[string]string{
+		"github.com/org/repo":     "v1.0.0",
+		"github.com/org/repo/sub": "v2.0.0",
+	})
+
+	modPath, version, ok := requiredModuleVersionOf("github.com/org/repo/sub/file.arrai")
+	require.True(t, ok)
+	require.Equal(t, "github.com/org/repo/sub", modPath)
+	require.Equal(t, "v2.0.0", version)
+
+	modPath, version, ok = requiredModuleVersionOf("github.com/org/repo/file.arrai")
+	require.True(t, ok)
+	require.Equal(t, "github.com/org/repo", modPath)
+	require.Equal(t, "v1.0.0", version)
+
+	_, _, ok = requiredModuleVersionOf("github.com/other/repo/file.arrai")
+	require.False(t, ok)
+}
+
+func TestRetrieveModuleWithInvalidPath(t *testing.T) {
+	// No network access needed: an empty cache means there's nothing pinned,
+	// and the path is too short to ever look like a valid module.
+	seedRequiredModuleVersions(t, map[string]string{})
+
+	m, err := retrieveModule("wrong_file_path/deps.arrai", "")
+	require.Error(t, err)
+	require.Nil(t, m)
+}

--- a/syntax/gomod_test.go
+++ b/syntax/gomod_test.go
@@ -42,7 +42,7 @@ require github.com/pkg/errors v0.8.0
 	m, err := retrieveModule("github.com/pkg/errors", "", root)
 	require.NoError(t, err)
 	require.Equal(t, "github.com/pkg/errors", m.Name)
-	require.Contains(t, m.Dir, "github.com/pkg/errors@v0.8.0")
+	require.Contains(t, filepath.ToSlash(m.Dir), "github.com/pkg/errors@v0.8.0")
 }
 
 func TestRetrieveModuleHonoursReplaceDir(t *testing.T) {
@@ -57,7 +57,8 @@ replace github.com/pkg/errors => ./errors-fork
 
 	fork := filepath.Join(root, "errors-fork")
 	require.NoError(t, os.MkdirAll(fork, 0o700))
-	require.NoError(t, os.WriteFile(filepath.Join(fork, "go.mod"), []byte("module github.com/pkg/errors\n\ngo 1.21\n"), 0o600))
+	gomod := []byte("module github.com/pkg/errors\n\ngo 1.21\n")
+	require.NoError(t, os.WriteFile(filepath.Join(fork, "go.mod"), gomod, 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(fork, "errors.go"), []byte("package errors\n"), 0o600))
 
 	resetRequiredModulesCache()
@@ -91,7 +92,7 @@ require github.com/pkg/errors v0.8.0
 
 	m, err := retrieveModule("github.com/pkg/errors", "", root)
 	require.NoError(t, err)
-	require.Contains(t, m.Dir, "github.com/pkg/errors@v0.8.0")
+	require.Contains(t, filepath.ToSlash(m.Dir), "github.com/pkg/errors@v0.8.0")
 }
 
 func TestRetrieveModuleFallsBackWithoutPin(t *testing.T) {

--- a/syntax/import.go
+++ b/syntax/import.go
@@ -121,11 +121,11 @@ func importExternalContent(
 	ctx context.Context,
 	scanner parser.Scanner,
 	decoder rel.Tuple,
-	importPath string,
+	importPath, sourceDir string,
 ) (rel.Expr, error) {
 	var moduleErr error
 	if !strings.HasPrefix(importPath, "http://") && !strings.HasPrefix(importPath, "https://") {
-		v, err := importModuleFile(ctx, decoder, importPath)
+		v, err := importModuleFile(ctx, decoder, importPath, sourceDir)
 		if err == nil {
 			return v, nil
 		}
@@ -154,7 +154,7 @@ func importExternalContent(
 	return v, nil
 }
 
-func importModuleFile(ctx context.Context, decoder rel.Tuple, importPath string) (rel.Expr, error) {
+func importModuleFile(ctx context.Context, decoder rel.Tuple, importPath, sourceDir string) (rel.Expr, error) {
 	if isRunningBundle(ctx) {
 		return fileValue(ctx, decoder, path.Join(ModuleDir, importPath))
 	}
@@ -164,7 +164,14 @@ func importModuleFile(ctx context.Context, decoder rel.Tuple, importPath string)
 		return nil, errors.New("per-importing versioning is not allowed")
 	}
 
-	m, err := retrieveModule(modPath, ver)
+	moduleRoot := ""
+	if sourceDir != "" {
+		if root, err := findRootFromModule(ctx, sourceDir); err == nil {
+			moduleRoot = root
+		}
+	}
+
+	m, err := retrieveModule(modPath, ver, moduleRoot)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Restores go.mod version pinning for `//{github.com/...}` module imports, which regressed when `anz-bank/pkg/mod` was replaced with always-`@latest` download during the frozen generics migration.
- Prefer the effective `Dir` from `go list -m -json all` so **`replace` directives** are honoured (matches old pkg/mod behaviour more closely than re-downloading `path@version`).
- Resolve the graph relative to the **importing script's module root**, not process cwd.
- Tests cover pinned version, `replace => ./local`, module-root≠cwd, longest-prefix match, fallback to `@latest`, and invalid paths.

## Test plan
- [x] `go test ./syntax/ -run 'RetrieveModule|RequiredModule'`
- [ ] Manual: project with `replace github.com/foo => ./local` importing `//{github.com/foo/...}` resolves to local
- [ ] Manual: `arrai run` from outside the module still sees that module's pins


Made with [Cursor](https://cursor.com)