### PR TITLE
Harden go.mod pin resolution for module imports

### DIFF
--- a/docs/docs/lang/import.md
+++ b/docs/docs/lang/import.md
@@ -89,7 +89,25 @@ repository. This can be done by the following:
 //{github.com/username/repo_name/path/to/script}
 ```
 
-TODO: versioning
+#### Versioning
+
+By default, `arrai` fetches the latest available version of the repository.
+
+If the importing script's project has a `go.mod` (found the same way as for
+Package Imports above) that already `require`s the module being imported, that
+pinned version is used instead — including following a `replace` directive
+that points it at a fork or a local filepath. This lets you pin or override
+remote imports the same way you would a regular Go dependency:
+
+```go
+require github.com/username/repo_name v1.2.3
+
+replace github.com/username/repo_name => ../local/fork
+```
+
+It is not possible to pin a version inline in the import path itself (e.g.
+`//{github.com/username/repo_name@v1.2.3/path/to/script}`); add or update the
+`require` line in `go.mod` instead.
 
 
 ### HTTP Imports

--- a/syntax/gomod.go
+++ b/syntax/gomod.go
@@ -66,7 +66,12 @@ func loadRequiredModules(moduleRoot string) map[string]requiredModule {
 	}
 
 	mods := map[string]requiredModule{}
-	cmd := exec.Command("go", "list", "-m", "-json", "all") //nolint:gosec
+	// -mod=mod lets this self-heal a go.sum that's missing entries (e.g. a
+	// module required but not needed to build the main module's packages),
+	// matching how `go mod download` behaves. Under the default -mod=readonly,
+	// `go list` would instead fail outright and we'd wrongly treat the module
+	// as unpinned.
+	cmd := exec.Command("go", "list", "-mod=mod", "-m", "-json", "all") //nolint:gosec
 	if moduleRoot != "" {
 		cmd.Dir = moduleRoot
 	}

--- a/syntax/gomod.go
+++ b/syntax/gomod.go
@@ -123,8 +123,9 @@ func seedRequiredModules(moduleRoot string, mods map[string]requiredModule) {
 // retrieveModule resolves importPath to a local module directory.
 // moduleRoot is the importing project's go.mod directory (may be empty to use
 // the process working directory). If that go.mod already requires a matching
-// module, its pinned version and effective Dir (honouring replace) are used.
-// Otherwise importPath prefixes are tried at the given version (or "latest").
+// module, its pinned version and effective Dir (honouring replace) are used,
+// and it is an error if that pinned version can't be resolved. Otherwise
+// importPath prefixes are tried at the given version (or "latest").
 func retrieveModule(importPath, version, moduleRoot string) (*goModule, error) {
 	if version == "" {
 		if pinned, ok := requiredModuleOf(moduleRoot, importPath); ok {
@@ -132,11 +133,16 @@ func retrieveModule(importPath, version, moduleRoot string) (*goModule, error) {
 				return &goModule{Name: pinned.Path, Dir: pinned.Dir}, nil
 			}
 			if pinned.Version != "" {
-				if m, err := downloadModule(pinned.Path, pinned.Version); err == nil {
-					return m, nil
+				m, err := downloadModule(pinned.Path, pinned.Version)
+				if err != nil {
+					// go.mod pins a version for this module: report the failure
+					// rather than silently resolving to a different (latest)
+					// version below, which would defeat the pin.
+					return nil, fmt.Errorf("go.mod requires %s@%s but it could not be downloaded: %w",
+						pinned.Path, pinned.Version, err)
 				}
+				return m, nil
 			}
-			// Fall through to latest-version resolution below.
 		}
 	}
 

--- a/syntax/gomod_test.go
+++ b/syntax/gomod_test.go
@@ -138,3 +138,22 @@ func TestRetrieveModuleWithInvalidPath(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, m)
 }
+
+func TestRetrieveModuleSelfHealsMissingGoSum(t *testing.T) {
+	root := withTempModule(t, `module example.com/pintest
+
+go 1.21
+
+require github.com/pkg/errors v0.8.0
+`)
+
+	// Deliberately skip `go mod download`: go.sum has no entry for the pinned
+	// module. Under plain -mod=readonly, `go list -m -json all` would fail and
+	// the pin would be missed entirely, falling back to @latest.
+	require.NoFileExists(t, filepath.Join(root, "go.sum"))
+
+	m, err := retrieveModule("github.com/pkg/errors", "", root)
+	require.NoError(t, err)
+	require.Equal(t, "github.com/pkg/errors", m.Name)
+	require.Contains(t, filepath.ToSlash(m.Dir), "github.com/pkg/errors@v0.8.0")
+}

--- a/syntax/gomod_test.go
+++ b/syntax/gomod_test.go
@@ -157,3 +157,17 @@ require github.com/pkg/errors v0.8.0
 	require.Equal(t, "github.com/pkg/errors", m.Name)
 	require.Contains(t, filepath.ToSlash(m.Dir), "github.com/pkg/errors@v0.8.0")
 }
+
+func TestRetrieveModuleErrorsWhenPinnedVersionUnavailable(t *testing.T) {
+	root := t.TempDir()
+	resetRequiredModulesCache()
+	t.Cleanup(resetRequiredModulesCache)
+	seedRequiredModules(root, map[string]requiredModule{
+		"github.com/pkg/errors": {Path: "github.com/pkg/errors", Version: "v99.99.99-does-not-exist"},
+	})
+
+	m, err := retrieveModule("github.com/pkg/errors", "", root)
+	require.Error(t, err)
+	require.Nil(t, m)
+	require.Contains(t, err.Error(), "github.com/pkg/errors@v99.99.99-does-not-exist")
+}


### PR DESCRIPTION
## Summary
- `retrieveModule`'s go.mod-pin discovery (`go list -m -json all`) fails outright when `go.sum` lacks an entry for a required module, silently falling back to `@latest` — pass `-mod=mod` so it self-heals `go.sum` the same way `go mod download` does.
- When a pin *is* found but downloading that exact version fails, stop silently degrading to `@latest`; return an error instead, since a pin should mean "use this version or fail."
- Documents the resulting versioning behavior in `docs/docs/lang/import.md`, filling in a long-standing "TODO: versioning" placeholder under Remote Imports.

Follow-up to #732, which restored go.mod-pin resolution for module imports after it regressed during the `anz-bank/pkg` removal.

## Test plan
- [x] `go test ./syntax/...`
- [x] `golangci-lint run ./syntax/...`
- [x] New tests reproduce each bug when its fix is reverted (verified manually), and pass with the fix applied