### PR TITLE
Fix profiler cleanup on interrupt and Fatal error paths

### DIFF
--- a/cmd/arrai/json.go
+++ b/cmd/arrai/json.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
 	"github.com/arr-ai/arrai/pkg/fu"
@@ -32,7 +31,7 @@ func fromJSON(cli *cli.Context) error {
 	}
 	val, err := translate.StrictTranslator().ToArrai(data)
 	if err != nil {
-		logrus.Fatal(err)
+		return err
 	}
 	fmt.Println(fu.Repr(val))
 	return nil

--- a/cmd/arrai/main.go
+++ b/cmd/arrai/main.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"path"
 	"runtime"
 	"runtime/pprof"
 	"strings"
+	"sync/atomic"
+	"syscall"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -39,6 +42,19 @@ var cmds = []*cli.Command{
 func main() {
 	stopProfilers := prepareProfilers()
 	defer stopProfilers()
+
+	// Commands like `serve`/`sync` run until interrupted, and os.Exit (which a
+	// Ctrl-C default disposition or a stray log.Fatal elsewhere triggers) skips
+	// every deferred function in the process, including the one above. Catch
+	// the common interrupt signals so profiling data still gets flushed.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		sig := <-sigCh
+		logrus.Infof("received %s, flushing profilers before exit", sig)
+		stopProfilers()
+		os.Exit(1)
+	}()
 
 	app := cli.NewApp()
 	// logrus.SetLevel(logrus.InfoLevel)
@@ -189,7 +205,11 @@ loop:
 		args = args[1:]
 	}
 	os.Args = append(os.Args[:1], args...)
+	var stopped atomic.Bool
 	return func() {
+		if !stopped.CompareAndSwap(false, true) {
+			return
+		}
 		for i := len(cleanups) - 1; i >= 0; i-- {
 			cleanups[i]()
 		}

--- a/cmd/arrai/serve.go
+++ b/cmd/arrai/serve.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 
@@ -50,7 +51,8 @@ func serve(c *cli.Context) error {
 	go func() {
 		lis, err := net.Listen("tcp", wsListen)
 		if err != nil {
-			log.Fatalf("failed to listen: %v", err)
+			errors <- fmt.Errorf("failed to listen: %w", err)
+			return
 		}
 
 		wsFrontend := newWebsocketFrontend(eng)
@@ -67,10 +69,15 @@ func serve(c *cli.Context) error {
 	go func() {
 		lis, err := net.Listen("tcp", listen)
 		if err != nil {
-			log.Fatalf("failed to listen: %v", err)
+			errors <- fmt.Errorf("failed to listen: %w", err)
+			return
 		}
 
-		grpcServer := newGrpcServer(cert, key, eng)
+		grpcServer, err := newGrpcServer(cert, key, eng)
+		if err != nil {
+			errors <- err
+			return
+		}
 
 		log.Printf("gRPC server listening on %s", listen)
 		errors <- grpcServer.Serve(lis)

--- a/cmd/arrai/serve_grpc.go
+++ b/cmd/arrai/serve_grpc.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 
 	pb "github.com/arr-ai/proto"
@@ -15,22 +17,22 @@ import (
 	"github.com/arr-ai/arrai/syntax"
 )
 
-func newGrpcServer(cert, key string, e *engine.Engine) *grpc.Server {
+func newGrpcServer(cert, key string, e *engine.Engine) (*grpc.Server, error) {
 	var opts []grpc.ServerOption
 	if cert != "" || key != "" {
 		if !(cert != "" && key != "") {
-			logrus.Fatal("TLS cert and key must be supplied together")
+			return nil, errors.New("TLS cert and key must be supplied together")
 		}
 		creds, err := credentials.NewServerTLSFromFile(cert, key)
 		if err != nil {
-			logrus.Fatalf("Failed to generate credentials %v", err)
+			return nil, fmt.Errorf("failed to generate credentials: %w", err)
 		}
 		opts = append(opts, grpc.Creds(creds))
 	}
 	grpcServer := grpc.NewServer(opts...)
 	server := arraiServer{e}
 	pb.RegisterArraiServer(grpcServer, &server)
-	return grpcServer
+	return grpcServer, nil
 }
 
 type arraiServer struct {

--- a/cmd/arrai/sync_other.go
+++ b/cmd/arrai/sync_other.go
@@ -55,7 +55,7 @@ func sync(c *cli.Context) error {
 
 	watch := path.Join(dir, "...")
 	if err := notify.Watch(watch, eich, notify.All); err != nil {
-		log.Fatal(err)
+		return err
 	}
 	defer notify.Stop(eich)
 


### PR DESCRIPTION
## Summary

Follow-up to #731, which fixed `prepareProfilers()`'s cleanup defers firing immediately at setup instead of at program exit. That fix covered the normal `app.Run()` error-return path and the `-help-agent` early exit, but two more exit paths still bypassed it entirely — `os.Exit` (which `Fatal` calls trigger) skips every deferred function in the process, not just the current stack frame's:

1. **No signal handling.** `serve`/`sync` are long-running commands normally stopped with Ctrl-C. With no `SIGINT`/`SIGTERM` handler, that hits the default disposition and kills the process without running any defers — so `-cpuprofile`/`-memprofile` still captured nothing for what's likely the most common real use case (profiling a running server). Verified before/after: sending `SIGINT` to a profiled `serve` process on `master` left a 0-byte, unparseable pprof file (and needed `SIGKILL` to actually terminate); it now exits promptly with a valid profile.
2. **Existing `Fatal` calls in command actions.** `serve`, `serve_grpc`, and `sync` called `log.Fatal`/`logrus.Fatal` directly on error paths reachable during normal execution (bind failures, bad TLS config, watch failures). These are all inside functions with an already-established path back to `app.Run()`'s error return, so converting them to returned errors costs nothing and lets `main()`'s existing (correct) cleanup path handle it.

`stopProfilers()` is now idempotent (atomic-guarded) since the signal handler can race with `main()`'s own deferred/explicit calls to it.

## Test plan
- [x] `go build ./...`, `go test ./...`, `golangci-lint run ./...`
- [x] Manually verified: `SIGINT` during a profiled `serve` run now flushes a valid CPU profile (previously 0 bytes, process didn't even terminate on `SIGINT`)
- [x] Manually verified: a profiled `serve` bind-conflict error and a profiled `json` parse error both now return normally and flush a valid profile