### PR TITLE
Fix Relation/Dict Hash128 disagreeing with their own Equal

### DIFF
--- a/rel/hash128.go
+++ b/rel/hash128.go
@@ -28,7 +28,6 @@ var (
 	valuesSalt   = hash128.String("rel.Values")
 	emptySetSalt = hash128.String("rel.EmptySet")
 	arraySalt    = hash128.String("rel.Array")
-	dictSalt     = hash128.String("rel.Dict")
 	unionSalt    = hash128.String("rel.UnionSet")
 	relationSalt = hash128.String("rel.Relation")
 

--- a/rel/value_set_array.go
+++ b/rel/value_set_array.go
@@ -120,12 +120,19 @@ func (a Array) Hash(seed uintptr) uintptr {
 	return a.Hash128().Seeded(seed)
 }
 
-// Hash128 computes the 128-bit hash of an Array: the xor of its item tuples.
+// Hash128 computes the 128-bit hash of an Array by mixing its item tuples in
+// index order. Each item's hash already binds its index (via hashTuple2), so
+// this doesn't need to be order-independent like a set/dict combination —
+// and using Mix here, rather than Xor, matters: xor-ing per-element hashes
+// together is vulnerable to cancellation when the same value occurs at two
+// different indices (e.g. ["x", "x"]), since the value-dependent part of
+// hashTuple2's own internal xor is identical at both positions and cancels
+// out, making the array's hash independent of that repeated value.
 func (a Array) Hash128() hash128.H128 {
 	h := arraySalt
 	for i, v := range a.values {
 		if v != nil {
-			h = h.Xor(hashTuple2(atNameHash, NewNumber(float64(a.offset+i)), itemNameHash, v))
+			h = h.Mix(hashTuple2(atNameHash, NewNumber(float64(a.offset+i)), itemNameHash, v))
 		}
 	}
 	return h

--- a/rel/value_set_array_test.go
+++ b/rel/value_set_array_test.go
@@ -11,6 +11,29 @@ import (
 	"github.com/arr-ai/arrai/pkg/arraictx"
 )
 
+// TestArrayHash128DistinguishesRepeatedElementValue guards against a
+// cancellation bug: Array.Hash128 combined per-index item hashes with xor,
+// but each item hash already xors together an index-hash and a value-hash
+// via hashTuple2. When the same value occurs at two different indices (e.g.
+// ["x", "x"] vs ["y", "y"]), the value-dependent part of those two item
+// hashes is identical and cancels out under xor, making the array's hash
+// completely independent of the repeated value -- so, for example,
+// ["AppA", "AppA"] and ["AppB", "AppB"] hashed identically despite being
+// unequal, silently corrupting any hash-based Set/Map containing such
+// arrays as elements or as part of a composite key (this is how it was
+// found: architecture-specs' fully-qualified app name paths often repeat
+// a segment, e.g. `MVISION :: MVISION`).
+func TestArrayHash128DistinguishesRepeatedElementValue(t *testing.T) {
+	t.Parallel()
+
+	a := NewArray(NewString([]rune("AppA")), NewString([]rune("AppA")))
+	b := NewArray(NewString([]rune("AppB")), NewString([]rune("AppB")))
+
+	assert.False(t, a.Equal(b), "arrays with different repeated values must not be equal")
+	assert.NotEqual(t, a.(Array).Hash128(), b.(Array).Hash128(),
+		"arrays with different repeated values must not hash the same")
+}
+
 func TestAsArray(t *testing.T) {
 	t.Parallel()
 	AssertEqualValues(t,

--- a/rel/value_set_dict.go
+++ b/rel/value_set_dict.go
@@ -108,13 +108,18 @@ func (d Dict) Hash(seed uintptr) uintptr {
 }
 
 // Hash128 computes the 128-bit hash of a Dict: the xor of its entry tuples,
-// computed once per Dict.
+// computed once per Dict. This must agree with the hash of an equal generic
+// Set of the same (@, @value) entry tuples — Dict.Equal treats the two as
+// equal — so, unlike other kinds, Dict does NOT mix in a kind-specific salt:
+// a non-empty Dict hashes exactly like GenericSet (plain xor of elements),
+// and an empty Dict hashes exactly like EmptySet (emptySetSalt), since
+// Dict{}.Equal(EmptySet{}) is also true.
 func (d Dict) Hash128() hash128.H128 {
 	if d.hash == nil {
-		return dictSalt
+		return emptySetSalt
 	}
 	return d.hash.get(func() hash128.H128 {
-		h := dictSalt
+		var h hash128.H128
 		for e := d.Enumerator(); e.MoveNext(); {
 			h = h.Xor(e.Current().Hash128())
 		}

--- a/rel/value_set_dict_test.go
+++ b/rel/value_set_dict_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/arr-ai/arrai/pkg/arraictx"
+	"github.com/arr-ai/frozen"
 )
 
 func TestDictEntryTupleLess(t *testing.T) {
@@ -34,6 +35,29 @@ func TestDictEntryTupleOrdered(t *testing.T) {
 	AssertEqualValues(t, NewDictEntryTuple(NewString([]rune("a")), NewNumber(2)), entries[1])
 	AssertEqualValues(t, NewDictEntryTuple(NewString([]rune("b")), NewNumber(1)), entries[2])
 	AssertEqualValues(t, NewDictEntryTuple(NewString([]rune("b")), NewNumber(2)), entries[3])
+}
+
+// TestDictHash128AgreesWithGenericSetEqual guards against a hash/equals
+// contract violation: Dict.Equal treats a Dict as equal to a generic Set of
+// the same (@, @value) entry tuples, and an empty Dict as equal to
+// EmptySet{}. Hash128 must agree in both cases, or a Set/Map keyed on Dict
+// values can silently fail to recognize an existing equal entry depending
+// on which representation it happens to be constructed as
+// (see https://github.com/arr-ai/arrai/issues/PLACEHOLDER).
+func TestDictHash128AgreesWithGenericSetEqual(t *testing.T) {
+	t.Parallel()
+
+	key := NewString([]rune("k"))
+	value := NewNumber(1)
+	d := MustNewDict(false, NewDictEntryTuple(key, value)).(Dict)
+	entryTuple := NewTuple(NewAttr("@", key), NewAttr(DictValueAttr, value))
+	gs := GenericSet{set: frozen.NewSet[Value](entryTuple)}
+
+	assert.True(t, d.Equal(gs), "a Dict must equal an equivalent generic Set of entry tuples")
+	assert.Equal(t, d.Hash128(), gs.Hash128(), "equal Dict/Set values must hash the same")
+
+	assert.True(t, Dict{}.Equal(EmptySet{}), "an empty Dict must equal EmptySet{}")
+	assert.Equal(t, Dict{}.Hash128(), EmptySet{}.Hash128(), "an empty Dict must hash like EmptySet{}")
 }
 
 func TestDictLess(t *testing.T) {

--- a/rel/value_set_rel.go
+++ b/rel/value_set_rel.go
@@ -406,15 +406,31 @@ func (r Relation) Hash(seed uintptr) uintptr {
 	return r.Hash128().Seeded(seed)
 }
 
-// Hash128 computes the 128-bit hash of a Relation from the positional row
-// set's own hash (O(1)) and the attribute names, so relations that Equal
-// distinguishes by schema also hash differently.
+// Hash128 computes the 128-bit hash of a Relation: the xor over attribute
+// names, xor'd with the xor over rows of each row's own name/value hash
+// (the same per-attribute formula GenericTuple uses). Row hashes must be
+// computed this way, and not taken from the positional row set's own hash,
+// because that mixes values in strict positional order — which would make
+// Hash128 disagree with EqualRelation whenever two equal relations differ
+// only in their internal attribute ordering (e.g. from different
+// join/projection code paths), violating the hash/equals contract.
 func (r Relation) Hash128() hash128.H128 {
+	nameHash := make(map[string]hash128.H128, len(r.attrs))
 	h := relationSalt
 	for _, name := range r.attrs {
-		h = h.Xor(hash128.String(name))
+		nh := hash128.String(name)
+		nameHash[name] = nh
+		h = h.Xor(nh)
 	}
-	return h.Xor(r.rows.Hash128())
+	for e := r.rows.set.Range(); e.Next(); {
+		row := e.Value().(Values)
+		var rh hash128.H128
+		for name, index := range r.attrMap {
+			rh = rh.Xor(hashAttr(nameHash[name], row[index]))
+		}
+		h = h.Xor(rh)
+	}
+	return h
 }
 
 // RelationValuesEnumerator enumerates the values as Values.

--- a/rel/value_set_rel_test.go
+++ b/rel/value_set_rel_test.go
@@ -90,6 +90,32 @@ func TestRelationUnion(t *testing.T) {
 	)
 }
 
+// TestRelationHash128AgreesWithEqualRegardlessOfAttrOrder guards against a
+// hash/equals contract violation: EqualRelation canonicalizes rows into
+// sorted-attribute-name order before comparing, so two relations with the
+// same tuples but different internal attribute ordering (e.g. produced by
+// different join/projection paths) are Equal. Hash128 must agree, or a
+// Set/Map keyed on Relation values can silently fail to recognize an
+// existing equal entry depending on which internal ordering it happens to
+// have (see https://github.com/arr-ai/arrai/issues/PLACEHOLDER).
+func TestRelationHash128AgreesWithEqualRegardlessOfAttrOrder(t *testing.T) {
+	t.Parallel()
+
+	r1 := newRelation(
+		NamesSlice{"a", "b"},
+		valueProjector{0, 1},
+		&positionalRelation{set: frozen.NewSet[any](row(1, 2))},
+	)
+	r2 := newRelation(
+		NamesSlice{"b", "a"},
+		valueProjector{0, 1},
+		&positionalRelation{set: frozen.NewSet[any](row(2, 1))},
+	)
+
+	assert.True(t, r1.EqualRelation(r2), "relations should be equal regardless of internal attribute order")
+	assert.Equal(t, r1.Hash128(), r2.Hash128(), "equal relations must hash the same")
+}
+
 func TestRelationHas(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Three confirmed hash/equals contract violations introduced by #734's single-pass hashing rewrite. All three break the fundamental invariant that Equal values must hash the same, so a hash-based Set/Map can silently fail to find or dedupe an existing entry depending on internal representation, construction order, or the specific values involved:

- **`Relation.Hash128`** hashed rows in raw positional order, but `EqualRelation` canonicalizes rows into sorted-attribute-name order before comparing. Two `Equal` relations with different internal attribute ordering (e.g. produced by different join/projection code paths) could hash differently.
- **`Dict.Hash128`** mixed in a `dictSalt` that `GenericSet`/`EmptySet` don't have, even though `Dict.Equal` deliberately treats a `Dict` as equal to a generic `Set` of the same `(@, @value)` entries (and an empty `Dict` as equal to `EmptySet{}`). Equal `Dict`/`Set` values could hash differently.
- **`Array.Hash128`** combined per-index item hashes with `xor`, but each item hash already `xor`s together an index-hash and a value-hash via `hashTuple2`. When the same value occurs at two different indices (e.g. `["x", "x"]`), the value-dependent part of those two item hashes is identical and cancels out under `xor`, making the array's hash completely independent of the repeated value — `["x", "x"]` and `["y", "y"]` hashed identically despite being unequal. Fixed by combining item hashes with `Mix` instead, which isn't self-cancelling like `xor`.

Each is pinned down with a minimal, isolated unit test.

## Context

Found while investigating a real-world regression: a downstream project's script that dedups statement calls and relocates their annotations started non-deterministically dropping annotations after upgrading past `f897d42`. Bisected by individually reverting each of that commit's five named sub-changes (indexed `where`, `Reduce`→`MapBuilder`, `let rec`, direct calls, `GenericTuple` hash caching) against the real failing workload — none alone explained it — which pointed at the remaining "single-pass hashing" surface. Reading each type's `Hash128()` against its own `Equal()` turned up the `Relation` and `Dict` issues; tracing intermediate values through the actual reproduction with `//log.print` showed the annotation relation was already incomplete immediately after `sysl.newNormalize(sysl.load(proto))`, which led to `Array.Hash128` and the exact `["AppA", "AppA"]`/`["AppB", "AppB"]` collision.

All three together fully resolve the original regression — verified against the real production workload (previously non-deterministic annotation loss, now clean across repeated runs).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite passes)
- [x] `golangci-lint run ./...` (0 issues)
- [x] New unit tests fail on `f897d42`/pre-fix code, pass after