### PR TITLE
Broaden Hash128/Equal regression coverage for #738's fixes

### DIFF
--- a/rel/testdata/fuzz/FuzzArrayHash128RepeatedValue/cd6bfdb1fe13f4b0
+++ b/rel/testdata/fuzz/FuzzArrayHash128RepeatedValue/cd6bfdb1fe13f4b0
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("\x89")
+string("\xb8")
+byte('R')

--- a/rel/value_set_array_test.go
+++ b/rel/value_set_array_test.go
@@ -20,18 +20,90 @@ import (
 // completely independent of the repeated value -- so, for example,
 // ["AppA", "AppA"] and ["AppB", "AppB"] hashed identically despite being
 // unequal, silently corrupting any hash-based Set/Map containing such
-// arrays as elements or as part of a composite key (this is how it was
-// found: architecture-specs' fully-qualified app name paths often repeat
-// a segment, e.g. `MVISION :: MVISION`).
+// arrays as elements or as part of a composite key (found via a real
+// fully-qualified name convention that repeats a path segment).
+//
+// Covers repeats at adjacent (0,1) and non-adjacent (0,2) indices, an
+// all-elements-equal array with an even element count (an odd count doesn't
+// fully cancel — xor-ing the same value-dependent term in three times
+// leaves one copy, so a 3-element all-equal array would pass even against
+// the old, buggy formula), and a repeat one level down inside a nested
+// array.
 func TestArrayHash128DistinguishesRepeatedElementValue(t *testing.T) {
 	t.Parallel()
 
-	a := NewArray(NewString([]rune("AppA")), NewString([]rune("AppA")))
-	b := NewArray(NewString([]rune("AppB")), NewString([]rune("AppB")))
+	str := func(s string) Value { return NewString([]rune(s)) }
 
-	assert.False(t, a.Equal(b), "arrays with different repeated values must not be equal")
-	assert.NotEqual(t, a.(Array).Hash128(), b.(Array).Hash128(),
-		"arrays with different repeated values must not hash the same")
+	cases := []struct {
+		name string
+		a, b Set
+	}{
+		{
+			name: "adjacent repeat",
+			a:    NewArray(str("x"), str("x")),
+			b:    NewArray(str("y"), str("y")),
+		},
+		{
+			name: "non-adjacent repeat",
+			a:    NewArray(str("x"), str("mid"), str("x")),
+			b:    NewArray(str("y"), str("mid"), str("y")),
+		},
+		{
+			name: "all elements equal, even count",
+			a:    NewArray(str("x"), str("x"), str("x"), str("x")),
+			b:    NewArray(str("y"), str("y"), str("y"), str("y")),
+		},
+		{
+			name: "repeat nested one level down",
+			a:    NewArray(NewArray(str("x"), str("x")), str("tail")),
+			b:    NewArray(NewArray(str("y"), str("y")), str("tail")),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.False(t, c.a.Equal(c.b), "arrays with different repeated values must not be equal")
+			assert.NotEqual(t, c.a.(Array).Hash128(), c.b.(Array).Hash128(),
+				"arrays with different repeated values must not hash the same")
+		})
+	}
+}
+
+// FuzzArrayHash128RepeatedValue generalizes
+// TestArrayHash128DistinguishesRepeatedElementValue's fixed cases across
+// arbitrary element values and repeat counts, so it can catch a
+// reintroduction of the xor-cancellation bug (or a similar one) for
+// combinations the hand-written cases don't happen to cover. Run with
+// `go test -fuzz=FuzzArrayHash128RepeatedValue ./rel/`.
+func FuzzArrayHash128RepeatedValue(f *testing.F) {
+	f.Add("x", "y", uint8(2))
+	f.Add("AppA", "AppB", uint8(2))
+	f.Add("x", "y", uint8(3))
+	f.Add("x", "y", uint8(4))
+	f.Fuzz(func(t *testing.T, x, y string, rawCount uint8) {
+		// Invalid UTF-8 bytes collapse to the same replacement rune, so
+		// compare post-[]rune-round-trip -- that's what NewString actually
+		// sees -- rather than the raw fuzzer-provided strings.
+		xr, yr := string([]rune(x)), string([]rune(y))
+		if xr == yr {
+			return
+		}
+		count := int(rawCount%6) + 2 // 2..7 repeats of the same value.
+		xs := make([]Value, count)
+		ys := make([]Value, count)
+		for i := range xs {
+			xs[i] = NewString([]rune(xr))
+			ys[i] = NewString([]rune(yr))
+		}
+		a, b := NewArray(xs...).(Array), NewArray(ys...).(Array)
+
+		if a.Equal(b) {
+			t.Fatalf("arrays of %d copies of %q and %q must not be equal", count, xr, yr)
+		}
+		if a.Hash128() == b.Hash128() {
+			t.Fatalf("arrays of %d copies of %q and %q hashed the same", count, xr, yr)
+		}
+	})
 }
 
 func TestAsArray(t *testing.T) {

--- a/rel/value_tuple_test.go
+++ b/rel/value_tuple_test.go
@@ -3,8 +3,44 @@ package rel
 import (
 	"testing"
 
+	"github.com/arr-ai/hash/hash128"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestSpecializedTupleHash128AgreesWithGenericTuple guards against a
+// regression like the one fixed in Relation/Dict.Hash128: GenericTuple.Equal
+// is permissive across kinds (it compares against any Tuple, including
+// these specialized ones), even though each specialized kind's own Equal is
+// narrower (it only matches its own kind). So a specialized tuple and its
+// generic equivalent must still hash the same in the direction that IS
+// claimed equal — generic.Equal(specialized) — or a hash-based Set/Map can
+// fail to recognize them as duplicates depending on which representation
+// it happens to hold.
+func TestSpecializedTupleHash128AgreesWithGenericTuple(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		t    Tuple
+	}{
+		{"StringCharTuple", NewStringCharTuple(2, 'x')},
+		{"BytesByteTuple", NewBytesByteTuple(2, 7)},
+		{"ArrayItemTuple", NewArrayItemTuple(2, NewNumber(7))},
+		{"DictEntryTuple", NewDictEntryTuple(NewString([]rune("k")), NewNumber(7))},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			generic := c.t.(interface{ asGenericTuple() Tuple }).asGenericTuple()
+
+			assert.False(t, c.t.Equal(generic),
+				"specialized tuple's own Equal is narrower and doesn't match a generic tuple (by design)")
+			assert.True(t, generic.Equal(c.t), "generic tuple must equal its specialized equivalent")
+			assert.Equal(t, generic.(*GenericTuple).Hash128(), c.t.(interface{ Hash128() hash128.H128 }).Hash128(),
+				"specialized tuple and its generic equivalent must hash the same, since generic.Equal considers them equal")
+		})
+	}
+}
 
 func TestTupleBuilder(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Follow-up to #738 (merged). Three additions closing test-coverage gaps the original fix didn't cover, no production code changes:

- **`Array.Hash128`'s cancellation test only covered a two-element array with an adjacent repeat.** Extended to non-adjacent repeats, an all-equal array (with an *even* element count — an odd count doesn't fully cancel under the old `xor` formula, since xor-ing the same term three times leaves one copy uncancelled, so a 3-element all-equal case would misleadingly pass even against the buggy code), and a repeat nested one level down.
- **Added a test asserting each specialized tuple kind (`StringCharTuple`, `BytesByteTuple`, `ArrayItemTuple`, `DictEntryTuple`) hashes the same as its `GenericTuple` equivalent.** `GenericTuple.Equal` is permissive across kinds (unlike each specialized kind's own, narrower `Equal`), so this is exactly the same class of bug as `Relation`/`Dict.Hash128` from #738, and wasn't covered by any existing test.
- **Added `FuzzArrayHash128RepeatedValue`**, generalizing the repeated-value cancellation case across arbitrary values and repeat counts (2–7) instead of a handful of hand-picked cases. In the process this surfaced a bug in the *test harness itself* (not production code): invalid UTF-8 byte sequences collapse to the same replacement rune through `[]rune` conversion, so two distinct fuzzer-provided byte strings can be genuinely equal once round-tripped through `NewString` — the fuzz target now compares post-round-trip. Seeded with the input that surfaced this as a regression case. 6M+ generated executions found no further issues.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite passes)
- [x] `golangci-lint run ./...` (0 issues)
- [x] Reverting `Array.Hash128`'s fix locally confirms both the table test and the fuzz corpus catch the original bug again
- [x] `go test -fuzz=FuzzArrayHash128RepeatedValue -fuzztime=30s` — 6M+ executions, no failures against the current fix