### PR TITLE
Resolve go.mod pins against the top-level project for nested imports

### DIFF
--- a/pkg/arraictx/ctx.go
+++ b/pkg/arraictx/ctx.go
@@ -32,6 +32,7 @@ func InitRunCtx(ctx context.Context) context.Context {
 	ctx = ctxfs.SourceFsOnto(ctx, afero.NewOsFs())
 	ctx = ctxfs.RuntimeFsOnto(ctx, afero.NewOsFs())
 	ctx = ctxrootcache.WithRootCache(ctx)
+	ctx = ctxrootcache.WithPrimaryRootCache(ctx)
 	ctx = buildinfo.WithPackageBuildData(ctx)
 	return ctx
 }

--- a/pkg/ctxrootcache/ctxrootcache.go
+++ b/pkg/ctxrootcache/ctxrootcache.go
@@ -48,3 +48,46 @@ func rootCacheFrom(ctx context.Context) *sync.Map {
 	}
 	return m.(*sync.Map)
 }
+
+type primaryRootKeyType int
+
+const primaryRootKey primaryRootKeyType = iota
+
+// primaryRoot memoizes the module root used to resolve go.mod-pinned module
+// imports for an entire run. Go's module graph has exactly one resolved
+// version per module (via minimal version selection) rooted at the main
+// module's go.mod; consulting a transitive dependency's own go.mod instead
+// (found by walking up from the source file that contains the import,
+// which for a dependency is some read-only directory in the module cache)
+// would both disagree with that resolution and fail outright, since `go
+// list -mod=mod` needs to write go.sum and the module cache is read-only.
+type primaryRoot struct {
+	mu   sync.Mutex
+	root string
+	done bool
+}
+
+// WithPrimaryRootCache adds an empty, not-yet-resolved primary module root
+// to the context.
+func WithPrimaryRootCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, primaryRootKey, &primaryRoot{})
+}
+
+// PrimaryRoot returns the primary module root for ctx, computing it via
+// compute() on the first call and reusing that result (even "not found",
+// i.e. computed == "") for every later call, regardless of what compute
+// would return this time. If ctx has no primary root cache (WithPrimaryRootCache
+// was never called), compute() runs every time.
+func PrimaryRoot(ctx context.Context, compute func() string) string {
+	p, ok := ctx.Value(primaryRootKey).(*primaryRoot)
+	if !ok {
+		return compute()
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.done {
+		p.root = compute()
+		p.done = true
+	}
+	return p.root
+}

--- a/pkg/ctxrootcache/ctxrootcache_test.go
+++ b/pkg/ctxrootcache/ctxrootcache_test.go
@@ -1,0 +1,62 @@
+package ctxrootcache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrimaryRootComputesOnceAndReuses(t *testing.T) {
+	ctx := WithPrimaryRootCache(context.Background())
+
+	calls := 0
+	first := PrimaryRoot(ctx, func() string {
+		calls++
+		return "/outer/project"
+	})
+	require.Equal(t, "/outer/project", first)
+	require.Equal(t, 1, calls)
+
+	// A later call simulating a nested import (whose own compute() would
+	// find a different, wrong root, e.g. a dependency's own go.mod) must
+	// reuse the first result rather than recomputing.
+	second := PrimaryRoot(ctx, func() string {
+		calls++
+		return "/some/nested/dependency/cache/dir"
+	})
+	require.Equal(t, "/outer/project", second)
+	require.Equal(t, 1, calls, "PrimaryRoot must compute the root at most once per context")
+}
+
+func TestPrimaryRootReusesEmptyResult(t *testing.T) {
+	ctx := WithPrimaryRootCache(context.Background())
+
+	calls := 0
+	first := PrimaryRoot(ctx, func() string {
+		calls++
+		return ""
+	})
+	require.Equal(t, "", first)
+
+	second := PrimaryRoot(ctx, func() string {
+		calls++
+		return "/would/be/found/later"
+	})
+	require.Equal(t, "", second,
+		`an initial "not found" result must stick, not be overwritten by a later lucky compute`)
+	require.Equal(t, 1, calls)
+}
+
+func TestPrimaryRootWithoutCacheComputesEveryTime(t *testing.T) {
+	ctx := context.Background()
+
+	calls := 0
+	compute := func() string {
+		calls++
+		return "root"
+	}
+	PrimaryRoot(ctx, compute)
+	PrimaryRoot(ctx, compute)
+	require.Equal(t, 2, calls)
+}

--- a/syntax/gomod.go
+++ b/syntax/gomod.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 )
@@ -66,11 +68,20 @@ func loadRequiredModules(moduleRoot string) map[string]requiredModule {
 	}
 
 	mods := map[string]requiredModule{}
+	restore, err := snapshotGoModFiles(moduleRoot)
+	if err != nil {
+		requiredModulesByRoot.Store(moduleRoot, mods)
+		return mods
+	}
+	defer restore()
+
 	// -mod=mod lets this self-heal a go.sum that's missing entries (e.g. a
 	// module required but not needed to build the main module's packages),
 	// matching how `go mod download` behaves. Under the default -mod=readonly,
 	// `go list` would instead fail outright and we'd wrongly treat the module
-	// as unpinned.
+	// as unpinned. snapshotGoModFiles/restore above undo any such edits once
+	// we're done, so resolving an import never leaves go.mod/go.sum changed
+	// in the caller's project.
 	cmd := exec.Command("go", "list", "-mod=mod", "-m", "-json", "all") //nolint:gosec
 	if moduleRoot != "" {
 		cmd.Dir = moduleRoot
@@ -112,6 +123,61 @@ func loadRequiredModules(moduleRoot string) map[string]requiredModule {
 	}
 	requiredModulesByRoot.Store(moduleRoot, mods)
 	return mods
+}
+
+// fileSnapshot captures whether a file existed and its content, so it can be
+// put back exactly as found.
+type fileSnapshot struct {
+	path    string
+	existed bool
+	content []byte
+}
+
+func snapshotFile(path string) (fileSnapshot, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fileSnapshot{path: path}, nil
+		}
+		return fileSnapshot{}, err
+	}
+	return fileSnapshot{path: path, existed: true, content: content}, nil
+}
+
+// restore is called via defer with nothing to propagate a failure to; it's a
+// best-effort revert of a self-heal `go list` may have made.
+func (s fileSnapshot) restore() {
+	if s.existed {
+		_ = os.WriteFile(s.path, s.content, 0o600) //nolint:errcheck
+		return
+	}
+	_ = os.Remove(s.path) //nolint:errcheck
+}
+
+// snapshotGoModFiles saves the current go.mod/go.sum in dir (the process cwd
+// if dir is "") and returns a func that restores them exactly as found. `go
+// list -mod=mod` can rewrite either file to self-heal missing entries; the
+// caller's own project files shouldn't come out of an import resolution
+// changed, so loadRequiredModules reverts them once it has what it needs.
+func snapshotGoModFiles(dir string) (restore func(), err error) {
+	if dir == "" {
+		dir, err = os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+	}
+	goMod, err := snapshotFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return nil, err
+	}
+	goSum, err := snapshotFile(filepath.Join(dir, "go.sum"))
+	if err != nil {
+		return nil, err
+	}
+	return func() {
+		goMod.restore()
+		goSum.restore()
+	}, nil
 }
 
 // seedRequiredModules marks the memoized go.mod graph for moduleRoot as already

--- a/syntax/gomod_test.go
+++ b/syntax/gomod_test.go
@@ -1,12 +1,15 @@
 package syntax
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/arr-ai/arrai/pkg/ctxrootcache"
 )
 
 // withTempModule creates a temporary Go module with the given go.mod content
@@ -156,6 +159,110 @@ require github.com/pkg/errors v0.8.0
 	require.NoError(t, err)
 	require.Equal(t, "github.com/pkg/errors", m.Name)
 	require.Contains(t, filepath.ToSlash(m.Dir), "github.com/pkg/errors@v0.8.0")
+}
+
+func TestPrimaryRootMakesNestedImportsUseTheTopLevelPin(t *testing.T) {
+	outer := withTempModule(t, `module example.com/outer
+
+go 1.21
+
+require github.com/pkg/errors v0.8.0
+`)
+	cmd := exec.Command("go", "mod", "download", "github.com/pkg/errors")
+	cmd.Dir = outer
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	// Stands in for a dependency's own copy of go.mod (e.g. inside the
+	// read-only module cache) pinning a different, stale version -- this
+	// must lose to the top-level project's pin once it's part of a larger
+	// build graph, not win just because it's nearer the importing file.
+	nested := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(nested, "go.mod"), []byte(`module example.com/nested
+
+go 1.21
+
+require github.com/pkg/errors v0.9.1
+`), 0o600))
+	cmd = exec.Command("go", "mod", "download", "github.com/pkg/errors")
+	cmd.Dir = nested
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	resetRequiredModulesCache()
+
+	ctx := ctxrootcache.WithPrimaryRootCache(context.Background())
+
+	// First resolution, from the top-level project itself: establishes the
+	// primary root.
+	root := ctxrootcache.PrimaryRoot(ctx, func() string { return outer })
+	require.Equal(t, outer, root)
+
+	m, err := retrieveModule("github.com/pkg/errors", "", root)
+	require.NoError(t, err)
+	require.Contains(t, filepath.ToSlash(m.Dir), "github.com/pkg/errors@v0.8.0")
+
+	// Second resolution simulates a nested import made from a file under
+	// `nested`. PrimaryRoot must still return the outer root -- not
+	// `nested`, even though a compute() naively rooted at the importing
+	// file would find `nested`'s go.mod instead.
+	nestedRoot := ctxrootcache.PrimaryRoot(ctx, func() string { return nested })
+	require.Equal(t, outer, nestedRoot, "nested imports must resolve against the primary (top-level) module root")
+
+	m, err = retrieveModule("github.com/pkg/errors", "", nestedRoot)
+	require.NoError(t, err)
+	require.Contains(t, filepath.ToSlash(m.Dir), "github.com/pkg/errors@v0.8.0",
+		"the outer project's pin must win, not the nested directory's own (different) pin")
+}
+
+func TestLoadRequiredModulesDoesNotLeaveGoSumChanged(t *testing.T) {
+	root := withTempModule(t, `module example.com/pintest
+
+go 1.21
+
+require github.com/pkg/errors v0.8.0
+`)
+	// No go.sum at all: resolving requires `go list -mod=mod` to self-heal
+	// it from scratch, the most extreme case of the self-heal touching the
+	// file. It must still come out exactly as it went in afterwards.
+	require.NoFileExists(t, filepath.Join(root, "go.sum"))
+
+	m, err := retrieveModule("github.com/pkg/errors", "", root)
+	require.NoError(t, err)
+	require.Contains(t, filepath.ToSlash(m.Dir), "github.com/pkg/errors@v0.8.0")
+
+	require.NoFileExists(t, filepath.Join(root, "go.sum"),
+		"resolving an import must not leave go.sum changed in the caller's project")
+}
+
+func TestLoadRequiredModulesPreservesExistingGoModAndGoSum(t *testing.T) {
+	root := withTempModule(t, `module example.com/pintest
+
+go 1.21
+
+require github.com/pkg/errors v0.8.0
+`)
+	cmd := exec.Command("go", "mod", "download", "github.com/pkg/errors")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	resetRequiredModulesCache()
+
+	goModBefore, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	require.NoError(t, err)
+	goSumBefore, err := os.ReadFile(filepath.Join(root, "go.sum"))
+	require.NoError(t, err)
+
+	m, err := retrieveModule("github.com/pkg/errors", "", root)
+	require.NoError(t, err)
+	require.Contains(t, filepath.ToSlash(m.Dir), "github.com/pkg/errors@v0.8.0")
+
+	goModAfter, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	require.NoError(t, err)
+	goSumAfter, err := os.ReadFile(filepath.Join(root, "go.sum"))
+	require.NoError(t, err)
+	require.Equal(t, goModBefore, goModAfter, "resolving an import must not change an existing go.mod")
+	require.Equal(t, goSumBefore, goSumAfter, "resolving an import must not change an existing go.sum")
 }
 
 func TestRetrieveModuleErrorsWhenPinnedVersionUnavailable(t *testing.T) {

--- a/syntax/import.go
+++ b/syntax/import.go
@@ -164,12 +164,26 @@ func importModuleFile(ctx context.Context, decoder rel.Tuple, importPath, source
 		return nil, errors.New("per-importing versioning is not allowed")
 	}
 
-	moduleRoot := ""
-	if sourceDir != "" {
-		if root, err := findRootFromModule(ctx, sourceDir); err == nil {
-			moduleRoot = root
+	// Resolve go.mod pins against the primary (top-level) project's module
+	// graph for every import, not each file's own nearest go.mod. Go's
+	// module graph has exactly one resolved version per module (minimal
+	// version selection) computed from the main module's go.mod; a
+	// transitive dependency's own go.mod may pin something older (or
+	// nothing at all) and, since it's found by walking up from a file
+	// inside a read-only module cache directory, running `go list -mod=mod`
+	// there fails outright trying to write go.sum -- silently discarding
+	// every pin found this way and falling back to slow @latest resolution
+	// for every nested import.
+	moduleRoot := ctxrootcache.PrimaryRoot(ctx, func() string {
+		if sourceDir == "" {
+			return ""
 		}
-	}
+		root, err := findRootFromModule(ctx, sourceDir)
+		if err != nil {
+			return ""
+		}
+		return root
+	})
 
 	m, err := retrieveModule(modPath, ver, moduleRoot)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `importModuleFile` resolved a go.mod pin by walking up from the *importing file's own* directory (`findRootFromModule`). For a top-level script that's the user's project, but for a nested import (a file pulled in as a dependency, itself doing a `//{github.com/...}` import) that directory is inside the read-only Go module cache. `go list -mod=mod -m -json all` there fails outright trying to self-heal `go.sum` (`permission denied`), so the pin lookup silently comes back empty and resolution falls back to slow `@latest` git resolution — every time, for every nested import.
- Real-world impact: `arrai bundle`/`arrai r` on a script with a couple of nested imports went from ~0.7s (pre-pin-resolution `v0.321.0`) to 45-66s.
- Fix: resolve every import in a run against a single "primary" module root, computed once from the top-level project and reused for nested imports regardless of which file actually contains the `import` statement. This matches Go's actual module resolution — one resolved version per module via minimal version selection over the *main* module's go.mod — rather than treating each dependency's own go.mod as authoritative.
- While tracing this, also found that `go list -mod=mod`'s go.sum self-heal (intentional, for a go.sum missing entries not needed to build the main module) was left mutating the caller's real `go.sum`/`go.mod` in place — a real behavior difference from `v0.321.0`, which never touched either file. Fixed by snapshotting both files before resolving and restoring them afterward, so import resolution never leaves a project's checked-in files changed.

## Test plan

- [x] New unit tests for the primary-root memoization contract (`pkg/ctxrootcache/ctxrootcache_test.go`)
- [x] New integration-style test proving the exact regression: a "nested" directory's own (different) go.mod pin no longer wins over the top-level project's pin (`TestPrimaryRootMakesNestedImportsUseTheTopLevelPin`)
- [x] New tests proving `go.mod`/`go.sum` come out byte-identical after resolution, including the self-heal-from-nothing case (`TestLoadRequiredModulesDoesNotLeaveGoSumChanged`, `TestLoadRequiredModulesPreservesExistingGoModAndGoSum`)
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run` all clean
- [x] Verified against a real production workload (nested imports through multiple modules): 45-66s → ~0.7-1.4s, byte-identical output to both the pre-regression baseline and `v0.321.0`, and zero `go.sum`/`go.mod` diff left behind (previously 65 lines of unrelated churn)