### PR TITLE
Document and surface -cpuprofile/-memprofile flags

### DIFF
--- a/cmd/arrai/main.go
+++ b/cmd/arrai/main.go
@@ -23,6 +23,20 @@ import (
 //go:embed agents-guide.md
 var agentsGuide string
 
+// profilerFlags document -cpuprofile/-memprofile for `--help`. They're never
+// actually parsed by cli: prepareProfilers() strips them out of os.Args
+// before the app is built, since profiling must start before app.Run().
+var profilerFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "cpuprofile",
+		Usage: "Write a CPU profile to `FILE` for the duration of the run. Must precede the command name.",
+	},
+	&cli.StringFlag{
+		Name:  "memprofile",
+		Usage: "Write a heap profile to `FILE` at the end of the run. Must precede the command name.",
+	},
+}
+
 var cmds = []*cli.Command{
 	shellCommand,
 	runCommand,
@@ -69,15 +83,17 @@ func main() {
 		app.Name = "ai"
 		app.Usage = "arr.ai interactive shell"
 		app.Action = iShell
+		app.Flags = profilerFlags
 	case "ax":
 		app.Name = "ax"
 		app.Usage = "the ultimate data transformer"
 		app.Action = transform
+		app.Flags = profilerFlags
 	default:
 		app.Name = "arrai"
 		app.Usage = "the ultimate data engine"
 		app.Commands = cmds
-		app.Flags = []cli.Flag{
+		app.Flags = append([]cli.Flag{
 			&cli.BoolFlag{
 				Name:        "debug",
 				Aliases:     []string{"d"},
@@ -90,7 +106,7 @@ func main() {
 				Usage:       "Print help text and agent guide for AI coding assistants",
 				Destination: &helpAgent,
 			},
-		}
+		}, profilerFlags...)
 		app.Before = func(c *cli.Context) error {
 			if helpAgent {
 				fmt.Print(agentsGuide)

--- a/docs/docs/cli/profiling.md
+++ b/docs/docs/cli/profiling.md
@@ -1,0 +1,32 @@
+---
+id: profiling
+title: Profiling
+---
+
+`arrai` can write Go [pprof](https://pkg.go.dev/runtime/pprof) CPU and heap
+profiles for any invocation, via two global flags:
+
+| flag | description |
+|-|-|
+| `-cpuprofile=<path>` | Write a CPU profile covering the whole run to `<path>`. |
+| `-memprofile=<path>` | Write a heap profile (taken after a GC, at the end of the run) to `<path>`. |
+
+These flags are consumed by `arrai` itself, before the command line is
+otherwise parsed, so they must come **before** the command name and must use
+the `=` form (`-cpuprofile <path>`, with a space, is not supported):
+
+```bash
+$ arrai -cpuprofile=cpu.prof run script.arrai
+$ arrai -memprofile=mem.prof eval '2 + 2'
+```
+
+They work with any binary personality (`arrai`, `ai`, `ax`) and with
+long-running commands like `serve`: stopping the command normally, letting it
+error out, or interrupting it with Ctrl-C (`SIGINT`)/`SIGTERM` all flush the
+profile correctly.
+
+View the resulting profile with:
+
+```bash
+$ go tool pprof cpu.prof
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -35,6 +35,7 @@ module.exports = {
         "Command Line": [
             'cli/eval',
             'cli/run',
+            'cli/profiling',
         ],
         "Examples": [
             'examples/all',


### PR DESCRIPTION
## Summary
- `-cpuprofile`/`-memprofile` were entirely undiscoverable: `prepareProfilers()` strips them from `os.Args` by hand before `cli.App` is built, so they were never registered as `cli.Flag`s and never showed up in `--help` for any of the three binary personalities (`arrai`, `ai`, `ax`).
- Adds them to `app.Flags` purely for `--help`/usage display — actual parsing is unchanged, still handled by `prepareProfilers()` since profiling has to start before `app.Run()`.
- Adds a Command Line docs page (`docs/docs/cli/profiling.md`) covering usage, the leading-flag/`=`-syntax requirement, and how they interact with long-running commands (see #737).

## Test plan
- [x] `go build ./...`, `go test ./cmd/...`, `golangci-lint run ./cmd/...`
- [x] Manually verified `--help` output lists both flags for `arrai` and `ai`
- [x] Manually verified `-cpuprofile=<path>` still works end-to-end after the flag declarations were added