### PR TITLE
go.mod pin resolution: preserve mtime, prefer readonly, auto-add unpinned imports

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,6 +54,7 @@ jobs:
   test:
     name: Test
     strategy:
+      fail-fast: false
       matrix:
         platform: ${{ vars.BUILD_AND_TEST_OS_MATRIX && fromJSON(vars.BUILD_AND_TEST_OS_MATRIX) || fromJSON('[ "ubuntu-latest", "macOS-latest", "windows-latest" ]') }}
     runs-on: ${{ matrix.platform }}

--- a/syntax/gomod.go
+++ b/syntax/gomod.go
@@ -246,6 +246,12 @@ func retrieveModule(importPath, version, moduleRoot string) (*goModule, error) {
 		}
 	}
 
+	// moduleRoot's go.mod doesn't already require this: add it there with
+	// `go get` so this and every later resolution of it -- in this run, and
+	// any future one -- becomes a fast, pinned lookup instead of hitting
+	// this slow, unpinned path again. (This restores v0.321.0's behaviour,
+	// lost when anz-bank/pkg/mod -- whose Get() did the same `go get` call
+	// -- was replaced by an early, unpinned version of this file.)
 	modPath := importPath
 	var lastErr error
 	for {
@@ -253,8 +259,12 @@ func retrieveModule(importPath, version, moduleRoot string) (*goModule, error) {
 		if len(parts) < 3 {
 			break
 		}
-		m, err := downloadModule(modPath, version)
+		m, err := addModule(modPath, version, moduleRoot)
 		if err == nil {
+			// go.mod just changed; forget any memoized graph for moduleRoot
+			// so a later resolution in this same run sees the addition
+			// instead of re-adding it or missing it.
+			requiredModulesByRoot.Delete(moduleRoot)
 			return m, nil
 		}
 		lastErr = err
@@ -262,15 +272,17 @@ func retrieveModule(importPath, version, moduleRoot string) (*goModule, error) {
 	}
 	if lastErr != nil {
 		if ee, ok := lastErr.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("go mod download %s: %s", importPath, ee.Stderr)
+			return nil, fmt.Errorf("go get %s: %s", importPath, ee.Stderr)
 		}
-		return nil, fmt.Errorf("go mod download %s: %w", importPath, lastErr)
+		return nil, fmt.Errorf("go get %s: %w", importPath, lastErr)
 	}
-	return nil, fmt.Errorf("go mod download %s: module not found", importPath)
+	return nil, fmt.Errorf("go get %s: module not found", importPath)
 }
 
 // downloadModule runs `go mod download -json` for modPath at version (or
 // "latest" if version is empty) and returns the resulting module info.
+// Unlike addModule, this never changes go.mod -- it's only used for a module
+// go.mod already pins but whose content isn't in the local module cache yet.
 func downloadModule(modPath, version string) (*goModule, error) {
 	arg := modPath
 	if version != "" {
@@ -291,4 +303,25 @@ func downloadModule(modPath, version string) (*goModule, error) {
 		return nil, fmt.Errorf("go mod download %s: parsing output: %w", arg, err)
 	}
 	return &goModule{Name: result.Path, Dir: result.Dir}, nil
+}
+
+// addModule runs `go get` for modPath at version (or "latest" if version is
+// empty) in moduleRoot, adding a require directive (and go.sum entry) to its
+// go.mod, then looks up the resulting directory the same way an
+// already-pinned module would be.
+func addModule(modPath, version, moduleRoot string) (*goModule, error) {
+	arg := modPath
+	if version != "" {
+		arg += "@" + version
+	} else {
+		arg += "@latest"
+	}
+	cmd := exec.Command("go", "get", arg) //nolint:gosec
+	if moduleRoot != "" {
+		cmd.Dir = moduleRoot
+	}
+	if _, err := cmd.Output(); err != nil {
+		return nil, err
+	}
+	return downloadModule(modPath, version)
 }

--- a/syntax/gomod.go
+++ b/syntax/gomod.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 // goModule holds the result of module resolution (from go list or go mod download).
@@ -125,33 +126,47 @@ func loadRequiredModules(moduleRoot string) map[string]requiredModule {
 	return mods
 }
 
-// fileSnapshot captures whether a file existed and its content, so it can be
-// put back exactly as found.
+// fileSnapshot captures whether a file existed, its content, and its mtime,
+// so it can be put back exactly as found -- including the mtime, since a
+// build tool watching mtimes (like make) shouldn't see a file as touched
+// when a self-heal round-tripped it back to identical content.
 type fileSnapshot struct {
 	path    string
 	existed bool
 	content []byte
+	modTime time.Time
 }
 
 func snapshotFile(path string) (fileSnapshot, error) {
-	content, err := os.ReadFile(path)
+	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fileSnapshot{path: path}, nil
 		}
 		return fileSnapshot{}, err
 	}
-	return fileSnapshot{path: path, existed: true, content: content}, nil
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fileSnapshot{}, err
+	}
+	return fileSnapshot{path: path, existed: true, content: content, modTime: info.ModTime()}, nil
 }
 
 // restore is called via defer with nothing to propagate a failure to; it's a
-// best-effort revert of a self-heal `go list` may have made.
+// best-effort revert of a self-heal `go list` may have made. If the content
+// coming back out matches what went in, it doesn't touch the file at all --
+// not even to rewrite identical bytes -- so an untouched go.mod/go.sum keeps
+// its original mtime rather than jumping to "now" on every single resolve.
 func (s fileSnapshot) restore() {
-	if s.existed {
-		_ = os.WriteFile(s.path, s.content, 0o600) //nolint:errcheck
+	if !s.existed {
+		_ = os.Remove(s.path) //nolint:errcheck
 		return
 	}
-	_ = os.Remove(s.path) //nolint:errcheck
+	if current, err := os.ReadFile(s.path); err == nil && bytes.Equal(current, s.content) {
+		return
+	}
+	_ = os.WriteFile(s.path, s.content, 0o600)   //nolint:errcheck
+	_ = os.Chtimes(s.path, s.modTime, s.modTime) //nolint:errcheck
 }
 
 // snapshotGoModFiles saves the current go.mod/go.sum in dir (the process cwd

--- a/syntax/gomod.go
+++ b/syntax/gomod.go
@@ -253,6 +253,20 @@ func retrieveModule(importPath, version, moduleRoot string) (*goModule, error) {
 	// this slow, unpinned path again. (This restores v0.321.0's behaviour,
 	// lost when anz-bank/pkg/mod -- whose Get() did the same `go get` call
 	// -- was replaced by an early, unpinned version of this file.)
+	//
+	// Without a known moduleRoot, `go get` (unset working directory) falls
+	// back to whatever go.mod the process's own cwd happens to sit under.
+	// That's still a real project worth pinning into if one's there -- but
+	// if cwd isn't inside any module at all, skip straight to a plain,
+	// unpinned download instead of letting `go get` fail confusingly.
+	pinning := moduleRoot != "" || hasAmbientGoMod()
+	resolve := downloadModule
+	if pinning {
+		resolve = func(modPath, version string) (*goModule, error) {
+			return addModule(modPath, version, moduleRoot)
+		}
+	}
+
 	modPath := importPath
 	var lastErr error
 	for {
@@ -260,24 +274,67 @@ func retrieveModule(importPath, version, moduleRoot string) (*goModule, error) {
 		if len(parts) < 3 {
 			break
 		}
-		m, err := addModule(modPath, version, moduleRoot)
+		m, err := resolve(modPath, version)
 		if err == nil {
-			// go.mod just changed; forget any memoized graph for moduleRoot
-			// so a later resolution in this same run sees the addition
-			// instead of re-adding it or missing it.
-			requiredModulesByRoot.Delete(moduleRoot)
+			if pinning {
+				// go.mod just changed; forget any memoized graph for
+				// moduleRoot so a later resolution in this same run sees
+				// the addition instead of re-adding it or missing it.
+				requiredModulesByRoot.Delete(moduleRoot)
+			}
 			return m, nil
+		}
+		if isTransientModuleErr(err) {
+			// A failure that doesn't mean modPath isn't a real module --
+			// shortening to a guessed shorter prefix here risks landing on
+			// a different, wrong (but real, e.g. a monorepo root) module
+			// that happens to succeed, permanently pinning it in place of
+			// surfacing the real, transient error.
+			return nil, wrapGoGetErr(importPath, err)
 		}
 		lastErr = err
 		modPath = strings.Join(parts[:len(parts)-1], "/")
 	}
 	if lastErr != nil {
-		if ee, ok := lastErr.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("go get %s: %s", importPath, ee.Stderr)
-		}
-		return nil, fmt.Errorf("go get %s: %w", importPath, lastErr)
+		return nil, wrapGoGetErr(importPath, lastErr)
 	}
 	return nil, fmt.Errorf("go get %s: module not found", importPath)
+}
+
+// hasAmbientGoMod reports whether the process's own working directory sits
+// inside a Go module -- the same directory `go get`/`go mod download` fall
+// back to when moduleRoot is unknown (unset cmd.Dir walks up from cwd).
+func hasAmbientGoMod() bool {
+	out, err := exec.Command("go", "env", "GOMOD").Output() //nolint:gosec
+	if err != nil {
+		return false
+	}
+	gomod := strings.TrimSpace(string(out))
+	return gomod != "" && gomod != os.DevNull
+}
+
+func wrapGoGetErr(importPath string, err error) error {
+	if ee, ok := err.(*exec.ExitError); ok {
+		return fmt.Errorf("go get %s: %s", importPath, ee.Stderr)
+	}
+	return fmt.Errorf("go get %s: %w", importPath, err)
+}
+
+// transientModuleErr matches classes of `go get` failure that don't mean
+// modPath isn't a valid module -- network, proxy, and checksum-verification
+// failures can hit what's still the correct, longest path. retrieveModule's
+// loop must not treat these the same as a genuine "no such module" and
+// shorten to a guessed prefix.
+var transientModuleErr = regexp.MustCompile(
+	`(?i)dial tcp|no such host|i/o timeout|connection (refused|reset)|` +
+		`tls:? handshake|checksum mismatch|SECURITY ERROR|context deadline exceeded`)
+
+func isTransientModuleErr(err error) bool {
+	ee, ok := err.(*exec.ExitError)
+	if !ok {
+		return false
+	}
+	return transientModuleErr.Match(ee.Stderr)
 }
 
 // downloadModule runs `go mod download -json` for modPath at version (or
@@ -320,6 +377,10 @@ var moduleFoundButMissingPackage = regexp.MustCompile(`module (\S+)@\S+ found \(
 // go.mod, then looks up the resulting directory the same way an
 // already-pinned module would be.
 func addModule(modPath, version, moduleRoot string) (*goModule, error) {
+	restore, err := snapshotGoModFiles(moduleRoot)
+	if err != nil {
+		return nil, err
+	}
 	arg := modPath
 	if version != "" {
 		arg += "@" + version
@@ -331,6 +392,7 @@ func addModule(modPath, version, moduleRoot string) (*goModule, error) {
 		cmd.Dir = moduleRoot
 	}
 	if _, err := cmd.Output(); err != nil {
+		restore()
 		if ee, ok := err.(*exec.ExitError); ok {
 			if m := moduleFoundButMissingPackage.FindSubmatch(ee.Stderr); m != nil {
 				return addModule(string(m[1]), version, moduleRoot)
@@ -338,5 +400,15 @@ func addModule(modPath, version, moduleRoot string) (*goModule, error) {
 		}
 		return nil, err
 	}
-	return downloadModule(modPath, version)
+	m, err := downloadModule(modPath, version)
+	if err != nil {
+		// `go get` above already committed modPath to go.mod/go.sum, but its
+		// content can't actually be confirmed available -- leaving that
+		// require in place would permanently pin an unconfirmed module,
+		// including if retrieveModule's caller goes on to succeed at a
+		// different, shorter prefix instead.
+		restore()
+		return nil, err
+	}
+	return m, nil
 }

--- a/syntax/gomod.go
+++ b/syntax/gomod.go
@@ -68,30 +68,51 @@ func loadRequiredModules(moduleRoot string) map[string]requiredModule {
 		return cached.(map[string]requiredModule) //nolint:forcetypeassert
 	}
 
-	mods := map[string]requiredModule{}
+	// The overwhelmingly common case is a go.sum that's already complete
+	// enough to answer this under the default -mod=readonly -- which touches
+	// nothing on disk. Only fall back to self-healing (-mod=mod) when that
+	// actually fails, e.g. a go.sum missing an entry for a module that isn't
+	// needed to build the main module's own packages (so plain `go build`
+	// never needed to add it) but is needed to enumerate the full graph here.
+	mods, err := runGoListAllModules(moduleRoot, "-mod=readonly")
+	if err != nil {
+		mods, err = loadRequiredModulesWithSelfHeal(moduleRoot)
+	}
+	if err != nil {
+		mods = map[string]requiredModule{}
+	}
+	requiredModulesByRoot.Store(moduleRoot, mods)
+	return mods
+}
+
+// loadRequiredModulesWithSelfHeal retries the module-graph query with
+// -mod=mod, which lets `go list` self-heal a go.sum that's missing entries,
+// matching how `go mod download` behaves. Whatever edits that makes are
+// reverted once we're done (snapshotGoModFiles/restore), so resolving an
+// import never leaves go.mod/go.sum changed in the caller's project even on
+// this fallback path.
+func loadRequiredModulesWithSelfHeal(moduleRoot string) (map[string]requiredModule, error) {
 	restore, err := snapshotGoModFiles(moduleRoot)
 	if err != nil {
-		requiredModulesByRoot.Store(moduleRoot, mods)
-		return mods
+		return nil, err
 	}
 	defer restore()
+	return runGoListAllModules(moduleRoot, "-mod=mod")
+}
 
-	// -mod=mod lets this self-heal a go.sum that's missing entries (e.g. a
-	// module required but not needed to build the main module's packages),
-	// matching how `go mod download` behaves. Under the default -mod=readonly,
-	// `go list` would instead fail outright and we'd wrongly treat the module
-	// as unpinned. snapshotGoModFiles/restore above undo any such edits once
-	// we're done, so resolving an import never leaves go.mod/go.sum changed
-	// in the caller's project.
-	cmd := exec.Command("go", "list", "-mod=mod", "-m", "-json", "all") //nolint:gosec
+// runGoListAllModules runs `go list <modFlag> -m -json all` in moduleRoot
+// (or the process cwd when moduleRoot is empty) and parses the result into
+// a map keyed by module path, honouring replace directives.
+func runGoListAllModules(moduleRoot, modFlag string) (map[string]requiredModule, error) {
+	cmd := exec.Command("go", "list", modFlag, "-m", "-json", "all") //nolint:gosec
 	if moduleRoot != "" {
 		cmd.Dir = moduleRoot
 	}
 	out, err := cmd.Output()
 	if err != nil {
-		requiredModulesByRoot.Store(moduleRoot, mods)
-		return mods
+		return nil, err
 	}
+	mods := map[string]requiredModule{}
 	dec := json.NewDecoder(bytes.NewReader(out))
 	for {
 		var m struct {
@@ -108,8 +129,7 @@ func loadRequiredModules(moduleRoot string) map[string]requiredModule {
 			if err == io.EOF {
 				break
 			}
-			requiredModulesByRoot.Store(moduleRoot, mods)
-			return mods
+			return mods, err
 		}
 		if m.Main {
 			continue
@@ -122,8 +142,7 @@ func loadRequiredModules(moduleRoot string) map[string]requiredModule {
 			mods[m.Path] = requiredModule{Path: m.Path, Version: m.Version, Dir: dir}
 		}
 	}
-	requiredModulesByRoot.Store(moduleRoot, mods)
-	return mods
+	return mods, nil
 }
 
 // fileSnapshot captures whether a file existed, its content, and its mtime,

--- a/syntax/gomod.go
+++ b/syntax/gomod.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -305,6 +306,15 @@ func downloadModule(modPath, version string) (*goModule, error) {
 	return &goModule{Name: result.Path, Dir: result.Dir}, nil
 }
 
+// moduleFoundButMissingPackage matches `go get`'s error when it correctly
+// identifies a module boundary but the specific package/file within it isn't
+// present in the resolved version -- e.g. a stale proxy cache serving an
+// older pseudo-version than whatever was originally pinned. When this
+// happens the module path is authoritative: `go` already confirmed it, so
+// retrying at a shorter prefix would abandon a real boundary and risk
+// landing on a different, wrong (too-shallow) module instead.
+var moduleFoundButMissingPackage = regexp.MustCompile(`module (\S+)@\S+ found \([^)]*\), but does not contain package`)
+
 // addModule runs `go get` for modPath at version (or "latest" if version is
 // empty) in moduleRoot, adding a require directive (and go.sum entry) to its
 // go.mod, then looks up the resulting directory the same way an
@@ -321,6 +331,11 @@ func addModule(modPath, version, moduleRoot string) (*goModule, error) {
 		cmd.Dir = moduleRoot
 	}
 	if _, err := cmd.Output(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			if m := moduleFoundButMissingPackage.FindSubmatch(ee.Stderr); m != nil {
+				return addModule(string(m[1]), version, moduleRoot)
+			}
+		}
 		return nil, err
 	}
 	return downloadModule(modPath, version)

--- a/syntax/gomod_test.go
+++ b/syntax/gomod_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -263,6 +264,44 @@ require github.com/pkg/errors v0.8.0
 	require.NoError(t, err)
 	require.Equal(t, goModBefore, goModAfter, "resolving an import must not change an existing go.mod")
 	require.Equal(t, goSumBefore, goSumAfter, "resolving an import must not change an existing go.sum")
+}
+
+// TestLoadRequiredModulesPreservesGoSumMtime guards against a regression
+// where restore() wrote go.sum's original content back with os.WriteFile,
+// which updates the mtime even when the bytes are unchanged. A build tool
+// comparing mtimes (e.g. make, deciding whether a .arraiz needs rebuilding
+// because it depends on go.mod) would see an untouched go.sum as "just
+// modified" on every single resolve.
+func TestLoadRequiredModulesPreservesGoSumMtime(t *testing.T) {
+	root := withTempModule(t, `module example.com/pintest
+
+go 1.21
+
+require github.com/pkg/errors v0.8.0
+`)
+	cmd := exec.Command("go", "mod", "download", "github.com/pkg/errors")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	resetRequiredModulesCache()
+
+	goSumPath := filepath.Join(root, "go.sum")
+	before, err := os.Stat(goSumPath)
+	require.NoError(t, err)
+
+	// mtimes can have coarser resolution than the time between statting and
+	// resolving; back-date the file so a real (bugged) rewrite is detectable
+	// regardless of clock granularity.
+	backdated := before.ModTime().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(goSumPath, backdated, backdated))
+
+	_, err = retrieveModule("github.com/pkg/errors", "", root)
+	require.NoError(t, err)
+
+	after, err := os.Stat(goSumPath)
+	require.NoError(t, err)
+	require.True(t, after.ModTime().Equal(backdated),
+		"resolving an import must not touch go.sum's mtime when its content is unchanged")
 }
 
 func TestRetrieveModuleErrorsWhenPinnedVersionUnavailable(t *testing.T) {

--- a/syntax/gomod_test.go
+++ b/syntax/gomod_test.go
@@ -147,6 +147,29 @@ go 1.21
 	require.NotEmpty(t, pinned.Dir)
 }
 
+// TestRetrieveModuleStopsAtModuleBoundaryOnMissingPackage guards against
+// retrieveModule's fallback loop shortening past a module `go` already
+// confirmed exists, just because the specific package within it wasn't
+// found (e.g. a stale proxy serving an older version than intended, or --
+// as here -- a package path that plain doesn't exist in any version).
+// Continuing to shorten past a confirmed module risks landing on a
+// different, wrong (too-shallow) module instead of reporting the real one.
+func TestRetrieveModuleStopsAtModuleBoundaryOnMissingPackage(t *testing.T) {
+	root := withTempModule(t, `module example.com/pintest
+
+go 1.21
+`)
+
+	// cloud.google.com/go is a real, public multi-module monorepo: the repo
+	// root and cloud.google.com/go/pubsub are each their own Go module. Using
+	// a public module here (resolved via the Go module proxy) keeps this
+	// test independent of any private-repo network access.
+	m, err := retrieveModule(
+		"cloud.google.com/go/pubsub/does/not/exist", "", root)
+	require.NoError(t, err)
+	require.Equal(t, "cloud.google.com/go/pubsub", m.Name)
+}
+
 func TestRequiredModuleOfMatchesLongestPrefix(t *testing.T) {
 	resetRequiredModulesCache()
 	t.Cleanup(resetRequiredModulesCache)

--- a/syntax/gomod_test.go
+++ b/syntax/gomod_test.go
@@ -2,9 +2,11 @@ package syntax
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -375,4 +377,107 @@ func TestRetrieveModuleErrorsWhenPinnedVersionUnavailable(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, m)
 	require.Contains(t, err.Error(), "github.com/pkg/errors@v99.99.99-does-not-exist")
+}
+
+// TestIsTransientModuleErr locks down which `go get` failures are recognized
+// as transient (network/proxy/checksum issues that say nothing about whether
+// modPath is a real module) versus genuine "no such module" failures that
+// should drive retrieveModule's path-shortening loop.
+func TestIsTransientModuleErr(t *testing.T) {
+	transient := []string{
+		"dial tcp 1.2.3.4:443: connect: connection refused",
+		"lookup proxy.golang.org: no such host",
+		"read tcp 1.2.3.4:443: i/o timeout",
+		"read tcp 1.2.3.4:443: connect: connection reset by peer",
+		// Go's actual wording has a colon between "tls" and "handshake"
+		// (e.g. "remote error: tls: handshake failure"), not a bare space --
+		// the regex must match both forms.
+		"remote error: tls: handshake failure",
+		"net/http: TLS handshake timeout",
+		"SECURITY ERROR\nThis download does NOT match the one reported by the checksum server.",
+		"verifying go.sum: checksum mismatch",
+		"context deadline exceeded",
+	}
+	for _, msg := range transient {
+		require.True(t, isTransientModuleErr(&exec.ExitError{Stderr: []byte(msg)}), msg)
+	}
+
+	notTransient := []string{
+		"no matching versions for query \"latest\"",
+		"unknown revision v99.99.99-does-not-exist",
+		"module lookup disabled by GOPROXY=off",
+		"module github.com/foo found (v1.0.0), but does not contain package github.com/foo/bar",
+	}
+	for _, msg := range notTransient {
+		require.False(t, isTransientModuleErr(&exec.ExitError{Stderr: []byte(msg)}), msg)
+	}
+
+	require.False(t, isTransientModuleErr(errors.New("not an ExitError")),
+		"only *exec.ExitError carries the Stderr this classifies on")
+}
+
+// TestRetrieveModuleWithoutAmbientModuleFallsBackToDownload covers
+// resolving with an unknown moduleRoot ("", e.g. the arrai shell/REPL,
+// which has no source file to walk up from) from a working directory that
+// isn't inside any Go module at all. `go get` (which addModule's pinning
+// path uses) hard-fails outside a module ("'go get' is no longer supported
+// outside a module"), so this must use the plain, unpinned download path
+// instead -- confirmed separately that `go mod download` (unlike `go get`)
+// works fine with no go.mod present.
+func TestRetrieveModuleWithoutAmbientModuleFallsBackToDownload(t *testing.T) {
+	resetRequiredModulesCache()
+	t.Cleanup(resetRequiredModulesCache)
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	outside := t.TempDir()
+	require.NoError(t, os.Chdir(outside))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(wd)) })
+
+	out, err := exec.Command("go", "env", "GOMOD").Output()
+	require.NoError(t, err)
+	require.Equal(t, string(os.DevNull), strings.TrimSpace(string(out)),
+		"test dir must not sit inside any Go module for this to be meaningful")
+
+	m, err := retrieveModule("github.com/arr-ai/arrai-import-tests", "", "")
+	require.NoError(t, err)
+	require.Equal(t, "github.com/arr-ai/arrai-import-tests", m.Name)
+	require.NotEmpty(t, m.Dir)
+}
+
+// TestRetrieveModuleStopsImmediatelyOnTransientError guards the other side
+// of the module-boundary fix: a transient `go get` failure (here, a
+// poisoned GOPROXY forcing "connection refused") says nothing about
+// whether the full import path is a real module, so retrieveModule must
+// not shorten and retry -- doing so risks masking the real error, or
+// worse, succeeding at a different, wrong (too-shallow) module.
+//
+// Discriminates old vs. new behaviour via the returned error's content:
+// wrapGoGetErr always labels the error with the *original* (longest)
+// importPath, so that alone can't tell old and new code apart. But the
+// *stderr* it wraps names whichever modPath was actually attempted -- the
+// full path (repeated across `go get`'s own message, its module line, and
+// its proxy URL) if stopped immediately (new), or only the shortened
+// 3-segment prefix if the loop kept going after each transient failure
+// (old). So "/sub/sub2" (only ever present in the full path) appears
+// multiple times in the new behaviour's error but exactly once (from the
+// outer label alone) in the old behaviour's -- confirmed empirically:
+// 4 vs. 1.
+func TestRetrieveModuleStopsImmediatelyOnTransientError(t *testing.T) {
+	root := withTempModule(t, `module example.com/pintest
+
+go 1.21
+`)
+	t.Setenv("GOPROXY", "http://127.0.0.1:1")
+
+	m, err := retrieveModule("github.com/arr-ai/arrai-import-tests/sub/sub2", "", root)
+	require.Error(t, err)
+	require.Nil(t, m)
+	require.Contains(t, strings.ToLower(err.Error()), "connection refused")
+	require.Greater(t, strings.Count(err.Error(), "/sub/sub2"), 1, err.Error())
+
+	goMod, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	require.NoError(t, err)
+	require.NotContains(t, string(goMod), "arrai-import-tests",
+		"a failed resolution must not leave a partial require behind")
 }

--- a/syntax/gomod_test.go
+++ b/syntax/gomod_test.go
@@ -109,6 +109,42 @@ go 1.21
 	require.NoError(t, err)
 	require.Equal(t, "github.com/arr-ai/arrai-import-tests", m.Name)
 	require.NotEmpty(t, m.Dir)
+
+	// Resolving an otherwise-unpinned import adds it to go.mod (restoring
+	// v0.321.0's behaviour, lost when anz-bank/pkg/mod was replaced by an
+	// early, unpinned version of this file) so this and every later
+	// resolution -- in this run, and any future one -- is a fast, pinned
+	// lookup instead of hitting this slow path again.
+	goMod, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	require.NoError(t, err)
+	require.Contains(t, string(goMod), "github.com/arr-ai/arrai-import-tests",
+		"resolving an unpinned import must add it as a require in go.mod")
+
+	pinned, ok := requiredModuleOf(root, "github.com/arr-ai/arrai-import-tests")
+	require.True(t, ok, "the newly-added module must be visible to a later lookup in the same run")
+	require.Equal(t, m.Dir, pinned.Dir)
+}
+
+// TestRetrieveModulePersistsAcrossRuns simulates a later, separate run (fresh
+// process, so a fresh memoized-graph cache) finding a module that an earlier
+// run's fallback resolution added to go.mod: it must resolve via the fast
+// pinned path, not fall back to `go get` again.
+func TestRetrieveModulePersistsAcrossRuns(t *testing.T) {
+	root := withTempModule(t, `module example.com/pintest
+
+go 1.21
+`)
+
+	_, err := retrieveModule("github.com/arr-ai/arrai-import-tests", "", root)
+	require.NoError(t, err)
+
+	// Simulate a fresh process: forget the in-memory graph, but go.mod/go.sum
+	// on disk are exactly as the earlier "run" left them.
+	resetRequiredModulesCache()
+
+	pinned, ok := requiredModuleOf(root, "github.com/arr-ai/arrai-import-tests")
+	require.True(t, ok, "a later run must find the module via go.mod, not need to re-add it")
+	require.NotEmpty(t, pinned.Dir)
 }
 
 func TestRequiredModuleOfMatchesLongestPrefix(t *testing.T) {

--- a/syntax/gomod_test.go
+++ b/syntax/gomod_test.go
@@ -386,6 +386,10 @@ func TestRetrieveModuleErrorsWhenPinnedVersionUnavailable(t *testing.T) {
 func TestIsTransientModuleErr(t *testing.T) {
 	transient := []string{
 		"dial tcp 1.2.3.4:443: connect: connection refused",
+		// Windows phrases a refused connection quite differently -- no
+		// literal "connection refused" -- but still says "dial tcp", which
+		// is itself one of this regex's own match branches.
+		"dial tcp 1.2.3.4:443: connectex: No connection could be made because the target machine actively refused it.",
 		"lookup proxy.golang.org: no such host",
 		"read tcp 1.2.3.4:443: i/o timeout",
 		"read tcp 1.2.3.4:443: connect: connection reset by peer",
@@ -473,7 +477,11 @@ go 1.21
 	m, err := retrieveModule("github.com/arr-ai/arrai-import-tests/sub/sub2", "", root)
 	require.Error(t, err)
 	require.Nil(t, m)
-	require.Contains(t, strings.ToLower(err.Error()), "connection refused")
+	// "dial tcp" (unlike the OS-specific wording after it -- Unix says
+	// "connection refused", Windows says "connectex: ... actively refused
+	// it") is present on every platform's dial-failure message and is
+	// itself one of transientModuleErr's match branches.
+	require.Contains(t, strings.ToLower(err.Error()), "dial tcp")
 	require.Greater(t, strings.Count(err.Error(), "/sub/sub2"), 1, err.Error())
 
 	goMod, err := os.ReadFile(filepath.Join(root, "go.mod"))


### PR DESCRIPTION
## Summary

Six related fixes/improvements to the go.mod-pin-resolution path (`syntax/gomod.go`, from #732/#736), found while root-causing a real `.arraiz` rebuild-flakiness issue in a consuming project's CI, then digging into the feature's actual history.

**1. Preserve go.mod/go.sum mtime when restoring after self-heal.** #742's `restore()` writes the original content back with `os.WriteFile`, which bumps the mtime to "now" even when the bytes are byte-identical to what was there before — so every resolution touching go.mod aged it forward, cascading into spurious `.arraiz` rebuilds downstream (confirmed via `make --debug=v`: `Prerequisite 'scripts/go.mod' is newer than target '...'`, despite content never changing). Fixed by skipping the rewrite when content already matches, and restoring the original mtime via `os.Chtimes` when a real rewrite is needed.

**2. Try `-mod=readonly` before falling back to the self-heal path.** Traced the actual history: `v0.321.0` (via `anz-bank/pkg/mod`, removed in `deb7e85`) resolved imports using `go mod download` (bare) + `go list -m` (no `all`) — lighter queries that never needed self-healing. `deb7e85` replaced that with a naive `@latest`-only resolver, and #732/#736 later re-added pin-awareness using `go list -m -json all`, which needs the *full* unpruned graph and routinely needs `-mod=mod`'s self-heal to get it, even when go.sum is otherwise complete. Verified against a real project: `-mod=readonly` succeeds outright (zero errors, same ~0.02s) whenever go.sum is already sufficient — the common case. Only retry with `-mod=mod` (still snapshot/restore-protected) when readonly actually fails. This means the self-heal/restore path — and the TOCTOU race a concurrent `arrai bundle` could hit racing another process over go.mod/go.sum — no longer executes at all for the common case.

**3. Add unpinned imports to go.mod instead of just downloading them.** Also restores `v0.321.0` behaviour: `anz-bank/pkg@v0.0.48`'s `Get()` ran `go get <path>` for an import that wasn't already resolvable, persisting a require directive (and go.sum entry) — confirmed by reading its actual source. The `deb7e85` replacement (carried through #732/#736) only ever ran `go mod download`, which populates the module cache but never touches go.mod — so a never-declared import stayed on the slow, unpinned path forever, on every run, with no way to become fast short of a human manually running `go get`. `retrieveModule`'s fallback now calls a new `addModule` (`go get`, run in `moduleRoot`) instead of `downloadModule` when go.mod doesn't already require the import; a successful add evicts the memoized module graph so a later resolution in the same run sees it immediately. `downloadModule` itself is unchanged, still used for the already-pinned-but-not-cached case, which must never touch go.mod.

**4. Stop shortening past a confirmed module boundary.** `addModule`'s fallback loop chops the last path segment and retries on any `go get` failure — but when `go get` reports `module X found (version), but does not contain package Y`, `X` *is* the correct, confirmed module (the failure is that the specific file isn't in the resolved version, e.g. a stale proxy cache). Continuing to shorten past a confirmed boundary risks landing on a different, wrong (too-shallow) module that happens to independently exist — reproduced for real against a multi-module monorepo. Fixed by recognizing this specific error and retrying once with the confirmed path directly, cutting a 5-segment path down to at most 2 attempts (82s → 40s in the reproduction).

**5. Skip pinning with no module context at all.** `moduleRoot` can legitimately be `""` — the shell/REPL has no source file to derive one from, or `findRootFromModule` walks to the filesystem root without finding a `go.mod`. Previously this meant `addModule` always tried `go get` with `cmd.Dir` unset: if the process's cwd happens to be inside some unrelated project, that silently pollutes its go.mod; if cwd isn't inside any module at all, `go get` hard-fails (`'go get' is no longer supported outside a module`). Fixed by checking `go env GOMOD` first and falling back to the plain, unpinned `downloadModule` path (which works fine module-less) when there's no ambient module to pin into.

**6. Stop the shortening loop on transient `go get` errors.** Generalizes fix 4: a network/proxy/checksum failure (`dial tcp`, `no such host`, timeouts, connection refused/reset, checksum mismatch, `SECURITY ERROR`) says nothing about whether the attempted path is a real module, so treating it the same as "no such module" and shortening can mask the real error or land on a different, wrong-but-real shorter module. `addModule` also now snapshots/restores go.mod around the entire attempt (not just the `go get` failure case), so a `go get` that succeeds but whose immediately-following `downloadModule` call fails doesn't leave an unconfirmed `require` behind.

## Test plan

- [x] `TestLoadRequiredModulesPreservesGoSumMtime`, `TestRetrieveModuleFallsBackWithoutPin` (extended), `TestRetrieveModulePersistsAcrossRuns`: each fails against its respective pre-fix code and passes with it (verified via `git stash` for each).
- [x] Fix 2: verified against a real project's `go.mod`: `-mod=readonly` succeeds with zero errors, identical timing to `-mod=mod`; full existing suite (pin resolution, replace-dir, self-heal fallback) unchanged.
- [x] Fix 3: verified end-to-end: resolving a brand new import added correct `go.mod`/`go.sum` entries (matching real `go get` output), and a second run resolved the same import in 0.14s via the fast pinned path with zero further file changes.
- [x] Fix 4: `TestRetrieveModuleStopsAtModuleBoundaryOnMissingPackage` (uses `cloud.google.com/go`/`cloud.google.com/go/pubsub`, a real public multi-module monorepo resolved via the public Go proxy — no private-repo network access needed, so it also runs cleanly in this repo's own public CI).
- [x] Fix 5: `TestRetrieveModuleWithoutAmbientModuleFallsBackToDownload` (chdir into a module-less temp dir, assert success); confirmed via `git stash` to fail with the exact `'go get' is no longer supported outside a module` error pre-fix.
- [x] Fix 6: `TestIsTransientModuleErr` (table-driven classifier test) and `TestRetrieveModuleStopsImmediatelyOnTransientError` (poisons `GOPROXY`, asserts the loop attempts the full path exactly once instead of shortening through every prefix); both confirmed via `git stash` to fail against pre-fix code.
- [x] End-to-end against a real consuming project's data throughout: nested-import resolution via a script needing a private, nested Go dependency (itself requiring `arr-ai/arrai`) still correct and fast (0.68-1.1s, 80-85MB peak RSS) with zero unwanted go.mod/go.sum changes when nothing needs adding.
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run` all clean.

Happy to split fix 3 into its own PR if that's easier to review separately — it's a larger behavioural change than # 1/# 2 (go.mod now gets a real, persistent write for a genuinely new dependency, by design) — let me know.

Note: this PR's own `Lint` (`make check-clean`) check is currently failing, but it's pre-existing and unrelated — `master`'s tip is missing a "regenerate embedded stdlib bundles" commit after its last dependency bump, and the same failure reproduces on other unrelated open PRs.

Also includes an unrelated small CI fix: `TestRetrieveModuleStopsImmediatelyOnTransientError` asserted on Unix-specific "connection refused" wording and failed on `windows-latest` (Windows phrases a refused dial as `connectex: ... actively refused it` instead — a test bug, not a product one, since `isTransientModuleErr` already matched via the OS-independent `dial tcp` branch either way). Fixed the assertion, and added `fail-fast: false` to the Test job's OS matrix so one platform failing doesn't cancel the others mid-run.


