### PR TITLE
Fix stale dependency names in NOTICES

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -10,7 +10,7 @@ upstream repository.
 - github.com/arr-ai/frozen
 - github.com/arr-ai/hash
 - github.com/arr-ai/wbnf
-- github.com/anz-bank/afero (replacing github.com/spf13/afero)
+- github.com/spf13/afero
 - github.com/richardlehane/mscfb
 - github.com/richardlehane/msoleps
 - github.com/sethvargo/go-retry
@@ -54,7 +54,7 @@ upstream repository.
 - github.com/go-errors/errors
 - github.com/iancoleman/strcase
 - github.com/mattn/go-isatty
-- github.com/mohae/deepcopy
+- github.com/tiendc/go-deepcopy
 - github.com/rjeczalik/notify
 - github.com/sirupsen/logrus
 - github.com/stretchr/testify


### PR DESCRIPTION
## Summary
- `NOTICES` still listed `github.com/anz-bank/afero (replacing github.com/spf13/afero)`, but the anz-bank fork was dropped in #744 — `go.mod` now requires plain `github.com/spf13/afero` directly.
- `NOTICES` also still listed `github.com/mohae/deepcopy`, which is no longer a dependency; it was replaced by `github.com/tiendc/go-deepcopy` (indirect), which was missing from the file.
- Verified both replacements' licenses from the module cache: `spf13/afero` is Apache-2.0 and `tiendc/go-deepcopy` is MIT — same categories as before, only the module names changed.
- Cross-checked every other entry in `NOTICES` against `go.mod`'s full dependency list (direct + indirect); everything else matches.

## Test plan
- [x] Diffed `NOTICES` entries against `go.mod`'s direct and indirect requires
- [x] Confirmed license type for `github.com/spf13/afero` (Apache-2.0) and `github.com/tiendc/go-deepcopy` (MIT) from the downloaded module cache