### PR TITLE
Fix broken doc examples and document missing language syntax

### DIFF
--- a/docs/docs/lang/arithmetic.md
+++ b/docs/docs/lang/arithmetic.md
@@ -51,6 +51,27 @@ expression. `+` always means mathematical addition, never anything else. The
 `++` operator defines concatenation. It will be discussed in more detail in a
 later tutorial.
 
+## Modulo and floor division
+
+Arr.ai has `%` for modulo and `//` for floor division (integer division that
+rounds down). `x // y` is the same as `⌊x / y⌋`.
+
+```arrai
+@> 7 % 3
+@> 7 // 3
+@> -7 // 3
+```
+
+Note that `//` is also used, in a completely unrelated way, to reference
+imports and the standard library (e.g. `//math`, `//{./util.arrai}`) --
+context always disambiguates the two uses.
+
+There's also `-%`, "modulo-truncation", defined as `x -% y = x - x % y`.
+
+```arrai
+@> 7 -% 3
+```
+
 ## Exponentiation
 
 Arr.ai can exponentiate, *x*<sup>*y*</sup>, using the `^` or "power" operator.

--- a/docs/docs/lang/binding.md
+++ b/docs/docs/lang/binding.md
@@ -29,12 +29,12 @@ Try out the following examples to see the first main reason for let-bindings:
 ```arrai
 @> let customer = (name: "Anders", age: 47);
  > let age = customer.age;
- > cond (
+ > cond {
  >     age < 0: "wat?",
  >     0 <= age < 40: "young",
  >     40 <= age < 60: "middle",
- >     *: "old"
- > )
+ >     _: "old"
+ > }
 ```
 
 In the following example, `velocity` illustrates the first main reason, avoiding
@@ -43,10 +43,10 @@ repetition, while `speed` illustrates the second, clarification:
 ```arrai
 @> let v = (x: 0.4, y: 0.7, z: 0.6);
  > let speed = (v.x^2 + v.y^2 + v.z^2)^0.5;
- > cond (
+ > cond {
  >     speed < 1: "too slow",
- >     *: "fast enough"
- > )
+ >     _: "fast enough"
+ > }
 ```
 
 Try a few variations of allowable characters:

--- a/docs/docs/lang/exprs.md
+++ b/docs/docs/lang/exprs.md
@@ -25,6 +25,9 @@ Arr.ai supports operations on numbers.
 2. Binary:
    1. Well known: `+`, `-`, `*`, `/`, `%` (modulo), `^` (power)
    2. Modulo-truncation: `-%` (`x -% y = x - x % y`)
+   3. Floor division: `//` (`x // y = ⌊x / y⌋`). Not to be confused with the `//`
+      used to reference stdlib/imports (e.g. `//math`) -- that's a different,
+      unrelated use of the same token.
 3. Comparison operators, which may be chained: `0 <= i < 10`
    1. Set membership is treated the same: `10 <= n <: validIds`.
 

--- a/docs/docs/lang/exprs.md
+++ b/docs/docs/lang/exprs.md
@@ -9,9 +9,21 @@ Arr.ai supports operations on "true" and "false" values. The values `0`, `()`
 and `{}` are considered "false", while all other values are "true".
 
 1. `expr1 if testexpr else expr2` evaluates to `expr1` if `testexpr` is "true",
-   or `expr2` otherwise.
+   or `expr2` otherwise. **Deprecated:** this form emits a deprecation warning
+   and will be removed in a future release; prefer `cond` (below).
 2. `expr1 && expr2` evaluates to `expr1` if it is "true" or `expr2` otherwise.
 3. `expr1 || expr2` evaluates to `expr1` if it is "false" or `expr2` otherwise.
+4. `cond { cond1: expr1, cond2: expr2, ..., _: exprDefault }` evaluates
+   `cond1`, `cond2`, etc. in turn and evaluates to the `exprN` belonging to the
+   first one that is "true". The `_` arm, if present, matches unconditionally
+   and acts as a default, e.g. `cond {2 > 1: 1, 2 > 3: 2, _: 3}` evaluates to
+   `1`.
+
+   `cond` also accepts a control expression, in which case each arm's key is a
+   [pattern](./binding#pattern-matching) matched against the control
+   expression's value rather than a boolean condition:
+   `cond controlExpr { pattern1: expr1, ..., _: exprDefault }`, e.g.
+   `cond 2 { (1, 2, 3): "small", _: "other" }` evaluates to `"small"`.
 
 All above expressions exhibit short-circuit behaviours, which means that that
 `expr2` will be evaluated if its value is needed. While the arr.ai language has
@@ -125,14 +137,14 @@ following syntax:
 
 1. For regular recursive functions:
 ```arrai
-let rec factorial = \n 1 if n < 2 else n * factorial(n - 1); factorial(5)
+let rec factorial = \n cond {n < 2: 1, _: n * factorial(n - 1)}; factorial(5)
 ```
 
 2. For mutual recursion:
 ```arrai
 let rec oe = (
-   even = \n n == 0 || oe.odd (n - 1),
-   odd  = \n n != 0 && oe.even(n - 1),
+   even: \n n = 0 || oe.odd (n - 1),
+   odd:  \n n != 0 && oe.even(n - 1),
 );
 oe.even(6)
 ```
@@ -141,10 +153,10 @@ It is also possible to use the same syntax in a tuple.
 
 ```arrai
 let t = (
-   rec fact: \n cond n ((0, 1): 1, n: n * fact(n - 1)),
+   rec fact: \n cond n {(0, 1): 1, n: n * fact(n - 1)},
    n       : 5
 );
-t.rec(t.n)
+t.fact(t.n)
 ```
 
 This syntactic sugar only works with expression that evaluates to either a

--- a/docs/docs/lang/relops.md
+++ b/docs/docs/lang/relops.md
@@ -108,6 +108,47 @@ combination of these states.
 The definition of `<&>` given earlier holds true regardless of what `x`, `y`
 and `z` represent.
 
+## Nest and unnest
+
+`nest` and `unnest` convert between a relation and a nested representation
+where one attribute holds a relation of the remaining attributes, grouped by
+whatever's left.
+
+The simplest form, `relation nest attr`, groups tuples by every attribute
+except `attr` and collects the values of `attr` into a set under that same
+name:
+
+```arrai
+@> {|x,y| (1, 2), (1, 3), (2, 4)} nest y
+```
+
+`relation nest |names|attr` is more explicit: the attributes listed in
+`|names|` are the ones nested *away* into `attr`, and the relation is grouped
+by whatever's left:
+
+```arrai
+@> {|x,y,z| (1, 1, 2), (1, 1, 3), (1, 2, 4)} nest |x, y|a
+```
+
+The inverse form, `relation nest ~|names|attr`, nests away every attribute
+*except* the ones listed in `|names|`, grouping by those named attributes:
+
+```arrai
+@> {|x,y,z| (1, 1, 2), (1, 1, 3), (1, 2, 4), (1, 3, 5)} nest ~|z|a
+```
+
+`unnest` reverses `nest`: `relation unnest attr` expects `attr` to hold a
+relation in each tuple, and merges it back into the outer tuple, one output
+tuple per element of the nested relation:
+
+```arrai
+@> {
+    (a: {(x: 1, y: 1)}, z: 2),
+    (a: {(x: 1, y: 1)}, z: 3),
+    (a: {(x: 1, y: 2)}, z: 4),
+} unnest a
+```
+
 ## Rank
 
 The `rank` operator computes the position of each tuple in a relation by a

--- a/docs/docs/lang/setops.md
+++ b/docs/docs/lang/setops.md
@@ -7,6 +7,43 @@ title: Set operators
 @> {'you', 'them', 'and', 'me'} with 'or' without 'you'
 ```
 
+## `with` and `without`
+
+`set with elem` returns a new set containing all the elements of `set` plus
+`elem`. `set without elem` returns a new set containing all the elements of
+`set` except `elem` (a no-op if `elem` isn't a member).
+
+```arrai
+@> {1, 2, 3} with 4
+@> {1, 2, 3} without 2
+@> {1, 2, 3} without 5   # elem not present: returns set unchanged
+```
+
+Because arrays, strings, byte arrays and dictionaries are just sets of tuples
+under the hood, `with`/`without` work on their underlying `(@:, @item:)`,
+`(@:, @char:)`, `(@:, @byte:)` and `(@:, @value:)` tuples too:
+
+```arrai
+@> [1, 2, 3] without (@: 0, @item: 1)
+```
+
+## `count` and `single`
+
+The postfix `count` operator returns the number of elements in a set:
+
+```arrai
+@> {1, 2, 3} count
+```
+
+The postfix `single` operator returns the sole element of a one-element set,
+and fails if the set is empty or has more than one element:
+
+```arrai
+@> {42} single
+@> {} single       # FAIL: empty set
+@> {1, 2} single   # FAIL: too many elements
+```
+
 ## Boolean set operators
 
 Arr.ai supports the conventional set operators.

--- a/docs/docs/lang/transforms.md
+++ b/docs/docs/lang/transforms.md
@@ -162,6 +162,67 @@ operators to be chained together to transform deeper structures:
 @> {(r:0.7, g:0, b:0), (r:0.4, g:0.6, b:0), (r:0.5, g:0.5, b:1)} => :> . ^ 2
 ```
 
+## `where`
+
+The `where` operator filters a set (or relation), keeping only the elements
+for which the given expression is "true":
+
+```arrai
+@> {1, 2, 3, 4, 5} where . > 2
+@> {|a,b| (3, 41), (2, 42), (1, 43)} where .a = 3
+```
+
+## `filter`
+
+`filter` combines pattern matching with filtering: each element of a set is
+matched against a `cond`-style set of patterns, and elements that don't match
+any pattern are dropped from the result.
+
+```arrai
+@> {1, [2, 3], 4, [5, 6]} filter . {[a, b]: a + b}
+```
+
+Here, only the array elements match the `[a, b]` pattern, so `1` and `4` are
+silently excluded from the result. Add a `_` arm to provide a default for
+non-matching elements instead of dropping them:
+
+```arrai
+@> {1, [2, 3], 4, [5, 6]} filter . {[a, b]: a + b, _: 0}
+```
+
+## Reductions: `sum`, `max`, `min`, `mean`, `median`
+
+These operators reduce a set to a single number by first transforming each
+element (like `=>`), then combining the results:
+
+```arrai
+@> {1, 2, 3} sum .
+@> {1, 5, 3} max .
+@> {1, 5, 3} min .
+@> {2, 4, 6} mean .
+@> {1, 2, 3, 4, 5} median .
+```
+
+## Merging tuples and dictionaries: `+>`
+
+The `+>` operator merges two tuples, or two dictionaries, into one. Where both
+sides define the same attribute or key, the right-hand side wins:
+
+```arrai
+@> (a: 1, b: 2) +> (b: 3, c: 4)
+@> {"a": 1, "b": 2} +> {"b": 3, "c": 4}
+```
+
+Within a tuple or dictionary literal, suffixing an attribute/key with `+>` (or
+`|` for sets) instead of `:` recursively merges its value into the
+corresponding value already being merged in, rather than overwriting it
+wholesale:
+
+```arrai
+@> (a: (b: (c: {1}))) +> (a: (b: (c: {2})))          # plain merge: c is overwritten
+@> (a: (b: (c: {1}))) +> (a+>: (b+>: (c|: {2})))     # recursive merge: c is unioned
+```
+
 ## Interaction with order and orderby
 
 (The following discussion applies equally to `order` and `orderby`, so we'll


### PR DESCRIPTION
## Summary
- Documents floor division (`//`), which was previously only shown incidentally in an example with no explanation.
- Fixes `cond` examples in `binding.md` and `exprs.md` that used stale `cond (...)`/`*` syntax — the real grammar is `cond {...}`/`_`, so these examples didn't actually parse.
- Fixes the recursion examples in `exprs.md`: the mutual-recursion tuple used `=` for tuple keys and `==` for equality (neither valid arr.ai), and the tuple-embedded `rec` example referenced a nonexistent `t.rec` instead of `t.fact`.
- Notes that `if...else` is deprecated at runtime (emits a warning pushing users to `cond`), which wasn't previously documented, and adds `cond` itself as a properly documented operator.
- Adds documentation for syntax that is exercised by the `pkg/test/testdata/planroundtrip` corpus but had zero prose documentation: `nest`/`unnest`, `with`/`without`, `count`/`single`, `where`, `filter`, the `sum`/`max`/`min`/`mean`/`median` reductions, and the `+>` tuple/dictionary merge operator.

Every code snippet touched or added was manually verified against `arrai eval` on master (`b32b470`).

## Test plan
- [x] Manually ran every new/modified `@>` example through `go run ./cmd/arrai eval` to confirm it parses and produces the stated result
- [x] Checked code-fence balance across all edited files