### PR TITLE
Extend arr.ai-native test corpus: coverage 53.7% -> 57.9%, wire up the slowpath differential-oracle build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,17 +70,32 @@ jobs:
     - name: Run tests
       run: make test
 
+  test-slowpath:
+    name: Test (slowpath)
+    runs-on: ${{ vars.RUNNER_UBUNTU && fromJSON(vars.RUNNER_UBUNTU) || 'ubuntu-latest' }}
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version: "1.25"
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+
+    - name: Run tests with fast paths disabled
+      run: make test-slowpath
+
   coverage:
     name: Coverage
     runs-on: ${{ vars.RUNNER_UBUNTU && fromJSON(vars.RUNNER_UBUNTU) || 'ubuntu-latest' }}
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: "1.25"
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Calculate coverage
       run: go test -v -covermode=atomic -coverprofile=coverage.out -race ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ${{ vars.RUNNER_UBUNTU && fromJSON(vars.RUNNER_UBUNTU) || 'ubuntu-latest' }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: "1.25"
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - uses: Logerfo/newline-action@0.0.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
 
@@ -31,7 +31,7 @@ jobs:
         run: make check-clean
 
       - name: Validate goreleaser config
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: check -f .github/goreleaser_configs/goreleaser.yml
@@ -41,12 +41,12 @@ jobs:
     runs-on: ${{ vars.RUNNER_UBUNTU && fromJSON(vars.RUNNER_UBUNTU) || 'ubuntu-latest' }}
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: "1.25"
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Build
       run: go build -v -race ./cmd/arrai
@@ -60,12 +60,12 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: "1.25"
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Run tests
       run: make test
@@ -101,13 +101,13 @@ jobs:
       run: go test -v -covermode=atomic -coverprofile=coverage.out -race ./...
 
     - name: Convert coverage to lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.9
+      uses: jandelgado/gcov2lcov-action@v1.2.0
       with:
           infile: coverage.out
           outfile: coverage.lcov
 
     - name: Coveralls
-      uses: coverallsapp/github-action@v2.1.2
+      uses: coverallsapp/github-action@v2.3.8
       if: ${{ github.repository_owner == 'anz-bank' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,13 @@ test: generate
 	[ "$$(go env GOOS)" = "darwin" ] || GOARCH=386 go build ./...
 	make build && ./arrai test
 
+# test-slowpath is a differential oracle: -tags slowpath forces every
+# representation-specific shortcut (see rel/fastpath.go) to its general
+# fallback, so a clean run here means the fast paths agree with the
+# fallbacks on every test in the suite, not just the ones written to target
+# a specific shortcut.
+test-slowpath: generate
+	go test $(GOTESTFLAGS) -tags timingsensitive,slowpath ./...
+
 docker: generate
 	docker build . -t arrai

--- a/pkg/test/testdata/planroundtrip/binops_arithmetic_test.arrai
+++ b/pkg/test/testdata/planroundtrip/binops_arithmetic_test.arrai
@@ -34,6 +34,15 @@
     cmpNe:    2 != 3,
     cmpIn:    2 <: {1, 2, 3},
     cmpNotIn: 5 !<: {1, 2, 3},
+
+    # A chained comparison (`a OP b OP c`) compiles to a single CompareExpr
+    # evaluating each adjacent pair in turn, distinct from two `<`s ANDed
+    # together. `let i = 5` (rather than a literal) keeps this from
+    # constant-folding away, so Eval actually runs; the false case exercises
+    # its short-circuit branch (stopping at the first unsatisfied pair)
+    # untested by the all-true case.
+    chainedCompare:      (let i = 5; 0 <= i < 10),
+    chainedCompareFalse: (let i = 5; !(0 <= i < 3)),
     cmpSubset:        {1, 2} (<) {1, 2, 3},
     cmpSuperset:      {1, 2, 3} (>) {1, 2},
     cmpSubsetEq:      {1, 2} (<=) {1, 2},

--- a/pkg/test/testdata/planroundtrip/binops_join_family_test.arrai
+++ b/pkg/test/testdata/planroundtrip/binops_join_family_test.arrai
@@ -19,4 +19,26 @@ let r2 = {|b,c| (5,7),(6,7)};
     # against a real Relation takes Joiner's GenericJoin fallback instead of
     # the Relation<->Relation fast path every other join case above uses.
     joinDictWithRelation: ({0: 'a', 1: 'b'} <&> {(@: 0, extra: 'x'), (@: 1, extra: 'y')}) count = 2,
+
+    # Every relation elsewhere in this corpus only ever gets compared,
+    # joined, or indexed via `@`; printing one directly (with a matching %v
+    # count so it's individually formatted rather than spread/consumed -
+    # see the large_relation_test.arrai formatProbe for why that matters)
+    # exercises Relation's own Format/String/AttrsName/canonicalRelation.
+    relationFormatProbe: (//log.printf('%v %v', {r1, 99})) count = 2,
+
+    # Unary `-` on a non-empty relation wraps it, distinct from Negate's
+    # own-identity shortcut for an *empty* (IsTrue()==false) relation.
+    relationNegate: (-r1) = (@neg: r1),
+
+    # Calling a relation as a function requires a real `@` attr (unlike r1's
+    # a/b) - a 2-attr relation shaped this way is genuinely a Relation, not
+    # a canonical Dict, since its second attr name isn't @item/@value/etc.
+    relationCallAll: {|@, val| (0, 'a'), (1, 'b')}(0) = 'a',
+
+    # Nesting a relation as a set element (Hash) and unioning it with a
+    # differently-shaped/bucketed relation (getBucket/getSetBuilder) are
+    # both untested by the direct join/compare cases above.
+    relationAsSetElement: {r1, 99} count = 2,
+    relationUnionDifferentShape: (r1 | {(c: 1, d: 2)}) count = 3,
 )

--- a/pkg/test/testdata/planroundtrip/binops_logical_merge_test.arrai
+++ b/pkg/test/testdata/planroundtrip/binops_logical_merge_test.arrai
@@ -47,4 +47,16 @@
     # by the direct-operation cases above.
     trueAsSetElement: {true, 1, 'a'} count = 3,
     trueUnionWithRelation: (true | {(x: 1, y: 2)}) count = 2,
+
+    # `false` is `{}` (EmptySet) - same rationale as the `true`/TrueSet
+    # block above, for EmptySet's own Set-interface methods.
+    falseHasNot: !(1 <: false),
+    falseLessThanOther: false < 'a',
+    falseNegate: (-false) = (@neg: false),
+    falseWithEmptyTuple: (false with ()) = true,
+    falseWithOther: (false with 5) count = 1,
+    falseWithoutOther: (false without 5) = false,
+    falseWhereTrue: (false where \_ true) = false,
+    falseArrayEnumerator: (//log.printf('empty', false)) count = 0,
+    falseAsSetElement: {false, 1, 'a'} count = 3,
 )

--- a/pkg/test/testdata/planroundtrip/binops_logical_merge_test.arrai
+++ b/pkg/test/testdata/planroundtrip/binops_logical_merge_test.arrai
@@ -18,4 +18,33 @@
 
     # `&&`/`||` are wire-adjacent boolean ops; asymmetric operands catch a mix-up.
     andNotOr: (true && false) != (true || false),
+
+    # `true` is itself `{()}` (a real Set, not a distinct boolean type), and
+    # `false` is `{}` (EmptySet) - direct set operations on them exercise
+    # TrueSet's own Set-interface methods, untested elsewhere since nothing
+    # else in this corpus operates on a boolean *as a set*.
+    trueCount:  true count = 1,
+    trueHas:    () <: true,
+    trueHasNot: !(1 <: true),
+    trueNegate: (-true) = (@neg: true),
+    trueLessThanOther:  true < 'a',
+    trueNotLessThanFalse: !(true < false),
+    trueWith:    (true with 5) count = 2,
+    trueWithout: (true without ()) = false,
+    trueWithoutOther: (true without 5) = true,
+    trueWhereTrue:  (true where \_ true) = true,
+    trueWhereFalse: (true where \_ false) = false,
+    trueEnumerator: (true => \x x) = {()},
+    trueArrayEnumerator: (//log.printf('%v', true)) count = 1,
+
+    # Number's own Less dispatches via Kind() for a cross-type comparison,
+    # a different (and real) trigger for TrueSet.Kind() from the other side
+    # of `<` - TrueSet's own Less doesn't call Kind() at all.
+    numberLessTrueViaKind: 5 < true,
+
+    # Nesting `true` as a set element (Hash/Hash128) or unioning it with a
+    # differently-bucketed set (getBucket/getSetBuilder) are both untested
+    # by the direct-operation cases above.
+    trueAsSetElement: {true, 1, 'a'} count = 3,
+    trueUnionWithRelation: (true | {(x: 1, y: 2)}) count = 2,
 )

--- a/pkg/test/testdata/planroundtrip/control_flow_test.arrai
+++ b/pkg/test/testdata/planroundtrip/control_flow_test.arrai
@@ -63,4 +63,10 @@
     # cond condition) caused an 8s parser-backtracking failure; a plain `let`
     # binding avoids whatever ambiguity that caused.
     emptySetPatternLet: (let {} = {}; 1) = 1,
+
+    # `.` is the implicit-subject identifier used throughout arr.ai (`>>`,
+    # `where`, etc. all bind it as a lambda parameter), but it can also be
+    # bound directly via `let`, distinct from the lambda-parameter binding
+    # path exercised everywhere else in this corpus.
+    letDot: (let . = 42; . + 1) = 43,
 )

--- a/pkg/test/testdata/planroundtrip/functions_patterns_test.arrai
+++ b/pkg/test/testdata/planroundtrip/functions_patterns_test.arrai
@@ -9,6 +9,17 @@
     nestedPattern: ([1, [2, 3]] -> \[x, [y, z]] x + y + z) = 6,
     setPattern:    (cond {(y: 1, z: 2)} { {(:y, :z)}: {(y*z)} }) = {(2)},
 
+    # A literal-value pattern (as opposed to an ident/array/tuple/dict/set
+    # pattern) compiles to an ExprPattern, matching only if the value is
+    # exactly equal - untested elsewhere (cond's own pattern matching
+    # apparently doesn't route through Pattern.Bind the same way).
+    exprPatternMatch: (5 -> \5 'matched') = 'matched',
+
+    # Closure.Hash delegates to its underlying *Function's Hash - untested
+    # elsewhere, since the earlier Closure coverage only exercised Negate/
+    # Less/Kind (String-based), never actually hashing one.
+    closureAsSetElement: {\x x, 99} count = 2,
+
     # extraPattern above only covers a *trailing* array-pattern rest; leading
     # and middle positions need the matcher to compute the rest slice from
     # both ends instead of just "everything after a fixed prefix".

--- a/pkg/test/testdata/planroundtrip/functions_patterns_test.arrai
+++ b/pkg/test/testdata/planroundtrip/functions_patterns_test.arrai
@@ -9,6 +9,17 @@
     nestedPattern: ([1, [2, 3]] -> \[x, [y, z]] x + y + z) = 6,
     setPattern:    (cond {(y: 1, z: 2)} { {(:y, :z)}: {(y*z)} }) = {(2)},
 
+    # extraPattern above only covers a *trailing* array-pattern rest; leading
+    # and middle positions need the matcher to compute the rest slice from
+    # both ends instead of just "everything after a fixed prefix".
+    arrayPatternRestLeading: ([1, 2, 3, 4] -> \[...t, x, y] [t, x, y]) = [[1, 2], 3, 4],
+    arrayPatternRestMiddle:  ([1, 2, 3, 4] -> \[x, ...t, y] [x, t, y]) = [1, [2, 3], 4],
+
+    # A set pattern's rest (`...t`) is "every element not matched by a
+    # literal", a distinct algorithm from an array's positional slice - sets
+    # are unordered, so there's no fixed prefix/suffix to slice around.
+    setPatternRest: ({1, 2, 3} -> \{1, 2, ...t} t) = {3},
+
     # Optional tuple attr (`b?:`) with a fallback default value, used when the
     # attr is missing from the matched tuple - a distinct compile branch
     # (compileTuplePattern's `fall`/`tail` handling) from a plain required attr.

--- a/pkg/test/testdata/planroundtrip/functions_patterns_test.arrai
+++ b/pkg/test/testdata/planroundtrip/functions_patterns_test.arrai
@@ -28,4 +28,14 @@
 
     arrayPatternFallbackUsed:    ([1] -> \[x, ?y:99] [x, y]) = [1, 99],
     arrayPatternFallbackUnused:  ([1, 2] -> \[x, ?y:99] [x, y]) = [1, 2],
+
+    # A lambda value (Closure) is callable like NativeFunction, but its
+    # structural Set-interface methods (Count/Has/Enumerator/With/Without/
+    # Map/Where/ArrayEnumerator) are all panic("unimplemented") stubs -
+    # same class of gap as NativeFunction's, left alone deliberately.
+    # Negate/Less/Kind/EqualFunction are real, working methods though.
+    closureNegate: (let f = \x x; (-f) = (@neg: f)),
+    closureLessCrossKind: !((\x x) < 5),
+    closureLessSameKind: ((\x x) < (\y y)) | ((\y y) < (\x x)),
+    numberLessClosureViaKind: 5 < (\x x),
 )

--- a/pkg/test/testdata/planroundtrip/large_relation_test.arrai
+++ b/pkg/test/testdata/planroundtrip/large_relation_test.arrai
@@ -13,6 +13,12 @@
     (
         count:    r count = 600,
         where:    (r where .y = 0) count = 120,
+
+        # Formatting a Relation directly (not via `=`, which only ever needs
+        # Equal) exercises Relation.Format's own row-by-row Values.project
+        # machinery - untested elsewhere, since every other relation in this
+        # corpus only ever gets compared, never printed.
+        formatProbe: (//log.printf('%v', r)) count = 600,
         without:  (r without (x: 0, y: 0)) count = 599,
         orderby:  (r orderby .x) count = 600,
         join:     (r <&> {(y: 0, z: 'a'), (y: 1, z: 'b')}) count = 240,

--- a/pkg/test/testdata/planroundtrip/literals_types_test.arrai
+++ b/pkg/test/testdata/planroundtrip/literals_types_test.arrai
@@ -287,6 +287,16 @@
     # *NativeFunction value.
     nativeFunctionLiteral: (//str.lower)("ABC") = "abc",
 
+    # `//str.lower` resolves dynamically at Eval time via PackageExpr (scope
+    # lookup), never compile-time-folded into a literal Value - so comparing
+    # two *uncalled* references exercises NativeFunction.Equal directly, but
+    # (unlike other "literal" cases in this corpus) doesn't actually reach
+    # encodeValue/decodeValue's "native" PlanNode case: there's no compile-time
+    # constant-fold path that embeds a raw *NativeFunction as a plan literal,
+    # so that case (and lookupNative, its plan-decode counterpart) appears to
+    # be unreachable from any current arr.ai construct.
+    nativeFunctionEqual: (let f = //str.lower; f) = //str.lower,
+
     # A literal *set* of special-shape tuples constant-folds the whole set to a
     # Value at compile time (NewSetExpr), which recurses into encodeValue's
     # aitemval/scharval/bbyteval/dentryval cases for each element - a different

--- a/pkg/test/testdata/planroundtrip/literals_types_test.arrai
+++ b/pkg/test/testdata/planroundtrip/literals_types_test.arrai
@@ -277,6 +277,40 @@
     bytesByteTupleRuntime:  (\i (@: i, @byte: i + 96))(1) = (@: 1, @byte: 97),
     dictEntryTupleRuntime:  (\i (@: {i, i + 1}, @value: i + 2))(1) = (@: {1, 2}, @value: 3),
 
+    # The 4 canonical-shape tuples above are only ever constructed and
+    # Equal-compared elsewhere in this corpus - every other Tuple-interface
+    # method on them (MustGet/With/Without/Map/Negate/IsTrue/Names/Project)
+    # is untested. `.@item`/`.@char`/etc access is MustGet; `:>` (TupleMap,
+    # distinct from `=>`'s SetMap) is Map; `.~|@|` (project-drop) exercises
+    # both Names and Project.
+    arrayItemTupleMustGet:  (@: 1, @item: 2).@item = 2,
+    stringCharTupleMustGet: (@: 1, @char: 65).@char = 65,
+    bytesByteTupleMustGet:  (@: 1, @byte: 97).@byte = 97,
+    dictEntryTupleMustGet:  (@: {1, 2}, @value: 3).@value = 3,
+
+    arrayItemTupleMap:  ((@: 1, @item: 2) :> \x x + 1) = (@: 2, @item: 3),
+    stringCharTupleMap: ((@: 1, @char: 65) :> \x x + 1) = (@: 2, @char: 66),
+    bytesByteTupleMap:  ((@: 1, @byte: 97) :> \x x + 1) = (@: 2, @byte: 98),
+    dictEntryTupleMap:  ((@: {1, 2}, @value: 3) :> \x x) = (@: {1, 2}, @value: 3),
+
+    arrayItemTupleProjectDrop:  (@: 1, @item: 2).~|@| = (@item: 2),
+    stringCharTupleProjectDrop: (@: 1, @char: 65).~|@| = (@char: 65),
+    bytesByteTupleProjectDrop:  (@: 1, @byte: 97).~|@| = (@byte: 97),
+    dictEntryTupleProjectDrop:  (@: {1, 2}, @value: 3).~|@| = (@value: 3),
+
+    # Unlike a plain Value's default Negate (wrap in `(@neg: ...)`), each
+    # canonical-shape tuple overrides Negate to negate its position/value
+    # directly, staying in its own shape (or a byte-wrapped equivalent).
+    arrayItemTupleNegate:  (-(@: 1, @item: 2)) = (@: -1, @item: -2),
+    stringCharTupleNegate: (-(@: 1, @char: 65)) = (@: -1, @char: -65),
+    bytesByteTupleNegate:  (-(@: 1, @byte: 97)) = (@: -1, @byte: 159),
+    dictEntryTupleNegate:  (-(@: {1, 2}, @value: 3)) = (@: (@neg: {1, 2}), @value: -3),
+
+    arrayItemTupleIsTrue:  !(@: 1, @item: 2) = false,
+    stringCharTupleIsTrue: !(@: 1, @char: 65) = false,
+    bytesByteTupleIsTrue:  !(@: 1, @byte: 97) = false,
+    dictEntryTupleIsTrue:  !(@: {1, 2}, @value: 3) = false,
+
     # Comparing a plain GenericTuple against one of the canonical 2-attr
     # shapes (a different concrete Go type implementing Tuple) exercises
     # GenericTuple.Equal's cross-type fallback branch, untested by the

--- a/pkg/test/testdata/planroundtrip/literals_types_test.arrai
+++ b/pkg/test/testdata/planroundtrip/literals_types_test.arrai
@@ -273,6 +273,20 @@
     # fails the fast-path's `count == len(values)` check) both fall through
     # to the generic element-by-element `+` path instead.
     bytesConcatenate:       <<'a', 'b'>> ++ <<'c'>> = <<'a', 'b', 'c'>>,
+
+    # Bytes/String/Array are only ever compared/indexed/concatenated
+    # elsewhere in this corpus - unary `-`, cross-kind/same-kind `<`, and
+    # unioning with a differently-bucketed set were all untested.
+    bytesNegate: (-<<97, 98>>) = (@neg: <<97, 98>>),
+    bytesLessCrossKind: !(<<97, 98>> < 5),
+    bytesLessSameKind: <<97, 98>> < <<97, 99>>,
+    bytesUnionDifferentBucket: (<<97, 98>> | {(x: 1, y: 2)}) count = 3,
+
+    stringNegate: (-'ab') = (@neg: 'ab'),
+    stringUnionDifferentBucket: ('ab' | {(x: 1, y: 2)}) count = 3,
+
+    arrayNegate: (-[1, 2]) = (@neg: [1, 2]),
+    arrayUnionDifferentBucket: ([1, 2] | {(x: 1, y: 2)}) count = 3,
     sparseArrayConcatenate: [1, , 3] ++ [4, 5] = [1, , 3, 4, 5],
 
     # Special-shape tuple literals constant-fold to their own Value types

--- a/pkg/test/testdata/planroundtrip/literals_types_test.arrai
+++ b/pkg/test/testdata/planroundtrip/literals_types_test.arrai
@@ -213,6 +213,13 @@
     # shape in this corpus.
     genericSetMixedShapes: {1, 'a', (x: 1)} = {1, 'a', (x: 1)},
 
+    # A GenericSet nested as a set element (rather than the outermost value,
+    # the only role it plays elsewhere in this corpus) - exercises whatever
+    # the outer set's construction/enumeration needs from a nested Set
+    # element, untested by comparing a bare GenericSet directly (Equal only).
+    genericSetNestedAsElement:
+        (//log.printf('%v', {{3, 'a', (x: 1)}, 99})) count = 2,
+
     xstrInterp: $"1 + 1 = ${1 + 1}" = "1 + 1 = 2",
     xstrNested: $"${$"${1}"}" = "1",
 

--- a/pkg/test/testdata/planroundtrip/literals_types_test.arrai
+++ b/pkg/test/testdata/planroundtrip/literals_types_test.arrai
@@ -297,6 +297,22 @@
     # be unreachable from any current arr.ai construct.
     nativeFunctionEqual: (let f = //str.lower; f) = //str.lower,
 
+    # A bare *NativeFunction, like every other atomic value, is arr.ai's
+    # "1-element set containing itself" - Count/Negate/IsTrue/Less are real,
+    # working Set/Value-interface methods on it. Hash/Hash128 need forcing
+    # via nesting as a set element.
+    nativeFunctionCount:  //str.lower count = 1,
+    nativeFunctionNegate: (-//str.lower) = (@neg: //str.lower),
+    nativeFunctionIsTrue: (!//str.lower) = false,
+    nativeFunctionLessCrossKind:      (//str.lower < 5) = false,
+    nativeFunctionLessCrossKindOther: (5 < //str.lower) = true,
+
+    # Less's same-kind branch compares two NativeFunctions by String() -
+    # a real trigger for NativeFunction.String() too, since //log.printf's
+    # usual ArrayEnumerator-based trick isn't available here.
+    nativeFunctionLessSameKind: (//str.lower < //str.upper) | (//str.upper < //str.lower),
+    nativeFunctionAsSetElement: {//str.lower, 1, 'a'} count = 3,
+
     # A literal *set* of special-shape tuples constant-folds the whole set to a
     # Value at compile time (NewSetExpr), which recurses into encodeValue's
     # aitemval/scharval/bbyteval/dentryval cases for each element - a different

--- a/pkg/test/testdata/planroundtrip/literals_types_test.arrai
+++ b/pkg/test/testdata/planroundtrip/literals_types_test.arrai
@@ -35,6 +35,21 @@
     # seqPipeline.Enumerator directly instead of mustArray().Enumerator().
     seqPipelineEnumerator: (([1, 2, 3] >> . + 1) => \x (x.@item + 10)) = {12, 13, 14},
 
+    # Unary `-`/`<`/`!` and nesting-as-a-set-element each reach a seqPipeline
+    # method untested above: Negate/Less/IsTrue (all base-delegating, so no
+    # forcing needed) and Hash/Hash128 (forcing is required, since a set
+    # needs the pipeline's *resulting* elements to bucket/dedupe it).
+    seqPipelineNegate: (-([1, 2, 3] >> . + 1)) = (@neg: [2, 3, 4]),
+    seqPipelineLess: ([1, 2, 3] >> . + 1) < ([4, 5, 6] >> . + 1),
+    seqPipelineIsTrue: !([1, 2, 3] >> . + 1) = false,
+    seqPipelineAsSetElement: {([1, 2, 3] >> . + 1), 99} count = 2,
+
+    # dictPipeline's counterparts to the four seqPipeline cases just above.
+    dictPipelineNegate: (-({'a': 1} >> . + 1)) = (@neg: {'a': 2}),
+    dictPipelineLess: ({'a': 1} >> . + 1) < ({'b': 2} >> . + 1),
+    dictPipelineIsTrue: !({'a': 1} >> . + 1) = false,
+    dictPipelineAsSetElement: {({'a': 1} >> . + 1), 99} count = 2,
+
     emptyArrayEqualsEmptySet: [] = {},
     emptySetEqualsEmptyArray: {} = [],
 

--- a/pkg/test/testdata/planroundtrip/literals_types_test.arrai
+++ b/pkg/test/testdata/planroundtrip/literals_types_test.arrai
@@ -205,6 +205,15 @@
 
     tupleLiteral: (a: 1, b: 2).a = 1,
     dictLiteral:  {'x': 1, 'y': 2}('x') = 1,
+
+    # Every other Dict in this corpus only ever gets compared or indexed.
+    # //log.printf formats its *enumerated elements*, not the set itself
+    # (it calls ArrayEnumerator then %v's each result) - so printing the
+    # dict directly (one %v) would format its raw *values*, not the dict.
+    # Nesting it as an element of an outer 2-element set, with matching
+    # %v count, formats the dict itself via that element's own Format -
+    # exercising Dict.Format/OrderedEntries and dictEntryTupleLess.
+    dictFormatProbe: (//log.printf('%v %v', {{'x': 1, 'y': 2}, 99})) count = 2,
     setLiteral:   2 <: {1, 2, 3},
 
     # A set mixing element shapes (number, string, tuple) can't canonicalise
@@ -218,7 +227,7 @@
     # the outer set's construction/enumeration needs from a nested Set
     # element, untested by comparing a bare GenericSet directly (Equal only).
     genericSetNestedAsElement:
-        (//log.printf('%v', {{3, 'a', (x: 1)}, 99})) count = 2,
+        (//log.printf('%v %v', {{3, 'a', (x: 1)}, 99})) count = 2,
 
     xstrInterp: $"1 + 1 = ${1 + 1}" = "1 + 1 = 2",
     xstrNested: $"${$"${1}"}" = "1",
@@ -273,6 +282,11 @@
     stringCharTupleLiteral: (@: 1, @char: 65) = (@: 1, @char: 65),
     bytesByteTupleLiteral:  (@: 1, @byte: 97) = (@: 1, @byte: 97),
     dictEntryTupleLiteral:  (@: {1, 2}, @value: 3) = (@: {1, 2}, @value: 3),
+
+    # A dict-shaped relation literal with two rows sharing the same key
+    # collects both values under it (multipleValues) rather than erroring
+    # like a plain `{'a': 1, 'a': 2}` dict literal would - untested probe.
+    dictHeadingDupKeyProbe: {|@, @value| (1, 'a'), (1, 'b')} count = 1,
 
     # Same 4 canonical shapes, but built at *runtime* from a function
     # argument rather than as compile-time-foldable literals - this is the

--- a/pkg/test/testdata/planroundtrip/stdlib_pkg_test.arrai
+++ b/pkg/test/testdata/planroundtrip/stdlib_pkg_test.arrai
@@ -25,6 +25,12 @@
 
     fmtPretty: //fmt.pretty([1, 2, 3]) = "[1, 2, 3]",
 
+    # //fmt.pretty on an Array needs no reordering (already positional);
+    # a genuine unordered *set* takes PrettifyString's other branch, which
+    # needs OrderedValues/ValueEnumeratorToSlice to produce a canonical
+    # (rather than hash-bucket-arbitrary) element order.
+    fmtPrettySet: //fmt.pretty({3, 1, 2}) = "{1, 2, 3}",
+
     bitsSet:  //bits.set(6) = {1, 2},
     bitsMask: //bits.mask({1, 2}) = 6,
 

--- a/pkg/test/testdata/planroundtrip/stdlib_pkg_test.arrai
+++ b/pkg/test/testdata/planroundtrip/stdlib_pkg_test.arrai
@@ -4,6 +4,19 @@
     strTitle:  //str.title("hello") = "Hello",
     seqSplit:  //seq.split(',', "a,b,c") = ['a', 'b', 'c'],
     seqJoin:   //seq.join(", ", ["a", "b"]) = "a, b",
+
+    # //seq.* dispatches on the *subject*'s concrete type - every case above
+    # uses a String subject; an Array subject takes a completely separate
+    # implementation (arrayContains/arraySplit/arrayJoin/arrayHasPrefix/
+    # arrayHasSuffix/arrayTrimPrefix/arrayTrimSuffix), untested elsewhere.
+    seqContainsArray:   //seq.contains([2, 3], [1, 2, 3]) = true,
+    seqHasPrefixArray:  //seq.has_prefix([1, 2], [1, 2, 3]) = true,
+    seqHasSuffixArray:  //seq.has_suffix([2, 3], [1, 2, 3]) = true,
+    seqTrimPrefixArray: //seq.trim_prefix([1, 2], [1, 2, 3]) = [3],
+    seqTrimSuffixArray: //seq.trim_suffix([2, 3], [1, 2, 3]) = [1],
+    seqSplitArray:      //seq.split([0], [1, 0, 2, 0, 3]) = [[1], [2], [3]],
+    seqJoinArray:       //seq.join([0], [[1], [2], [3]]) = [1, 0, 2, 0, 3],
+    seqSubArray:        //seq.sub([2], [9], [1, 2, 3]) = [1, 9, 3],
     mathSin:   //math.sin(0) = 0,
 
     # Encoding packages (//encoding.json, //encoding.csv) are entirely


### PR DESCRIPTION
## Summary

Follow-up to #739 (now merged). This continues the `pkg/test/testdata/planroundtrip` corpus work from that PR, but targeted at `master` directly since the performance-overhaul branch is closed. Two independent threads:

- **CI**: wires up `rel/fastpath_slow.go`'s `-tags slowpath` differential-oracle build, which was implemented but never referenced by CI or the Makefile despite its own doc comment describing exactly this use case ("running the test corpus both ways is a differential oracle over every shortcut at once"). Added a `test-slowpath` Makefile target and CI job; the whole suite already passes cleanly under it. Also bumped every GitHub Action in `go.yml` to its latest major version while touching the file.
- **Coverage**: extended the corpus from 53.7% to 57.9% of `rel`/`syntax` statements (measured via `TestPlanRoundtripCorpus`), closing gaps across `seqPipeline`/`dictPipeline`, the four canonical-shape tuples (`ArrayItemTuple`/`StringCharTuple`/`BytesByteTuple`/`DictEntryTuple`), `NativeFunction`, `Closure`, `TrueSet`/`EmptySet` (i.e. `true`/`false` as real sets), `Relation`, `Dict`, `Bytes`/`String`/`Array`, and a handful of specific user-flagged gaps (chained comparisons, set/array-pattern rest, `let . = ...`).

## Notable findings along the way

- `syntax/lex.go` (~500 lines, a complete hand-written standalone lexer) appears to be **entirely dead code** — the real parser (`syntax/parser.go`) uses a separate wbnf-grammar-based implementation. Every entry point's only references anywhere are inside commented-out code in `parse_xml.go`, and even its own dedicated test helper (`AssertScan`) has zero callers. `syntax/file_pos.go` is dead by extension (its only consumer is `lex.go`). Not deleted here — flagging for a maintainer call on whether to remove it.
- A handful of smaller confirmed-dead findings: `NewContextErr`, `NewNativeLambda`, `EqualClosure`, `Function.Equal`, `ParseString`/`MustParseString`/`MustParse` — all have zero real callers, typically because a sibling method (`WrapContextErr`, `EqualFunction`, etc.) is what's actually used everywhere.
- `*NativeFunction` and `Closure` (lambda values) both have `Has`/`Enumerator`/`With`/`Without`/`Map`/`Where`/`ArrayEnumerator` implemented as `panic("unimplemented")`, despite otherwise being treated as arr.ai's universal "1-element set containing itself" (`Count()==1` is implemented correctly). Reproducible, e.g. `2 <: //str.lower` or `//str.lower where \_ true` crash the whole process instead of erroring cleanly like the equivalent operation on a `Number` does. Left unfixed intentionally — flagging in case it's worth a follow-up, not attempting a fix in this PR.

## Test plan

- [x] `go test ./...` — full suite green
- [x] `go test -tags slowpath ./...` — full suite green under the new CI build
- [x] `make test-slowpath` runs locally as expected